### PR TITLE
fix(setup): profile auto-detect, RED verify.conf placeholder, honest --dry-run

### DIFF
--- a/setup.ps1
+++ b/setup.ps1
@@ -430,14 +430,16 @@ function Build-VerifyConf ([string]$dest) {
   $lines += "# .harness/verify.conf — generated for profile(s): $($o.Profiles)"
   $lines += '# One phase per line:  Label :: shell command. Runs in order; first failure stops the run.'
   $lines += '# This is YOUR definition of "shippable". Uncomment + edit the phases that fit this project,'
-  $lines += '# then DELETE the sanity line below once at least one real phase is active.'
+  $lines += '# then DELETE the placeholder line below once at least one real phase is active.'
   $lines += ''
   foreach ($p in $ProfileArr) {
     $preset = Join-Path $HarnessDir "config/verify-presets/$p.conf"
     if (Test-Path $preset) { $lines += (Get-Content $preset); $lines += '' }
   }
-  $lines += '# Universal placeholder so verify.sh runs green until you wire real phases — REPLACE THIS:'
-  $lines += "sanity :: echo `"verify.sh wired for: $($o.Profiles) — replace this phase with real checks`""
+  $lines += '# Placeholder that FAILS ON PURPOSE, so verify.sh stays RED until you wire real phases.'
+  $lines += '# A green verify that checks nothing is worse than none — it lies. Make the presets above'
+  $lines += '# real (uncomment + edit), then DELETE this line:'
+  $lines += "unwired :: echo `"verify.conf ($($o.Profiles)) has only this placeholder — wire real build/test/lint phases in .harness/verify.conf, then delete this line`" >&2; exit 1"
   Set-Content -Path $dest -Value ($lines -join "`n") -Encoding utf8
 }
 

--- a/setup.ps1
+++ b/setup.ps1
@@ -1139,7 +1139,25 @@ Resolve-OperatorIdentity (Join-Path $o.Target 'CLAUDE.md')
 Assemble-To (Join-Path $o.Target 'CLAUDE.md') $includeCore
 if ($o.AlsoAgents -and (-not $o.DryRun)) { Assemble-To (Join-Path $o.Target 'AGENTS.md') $includeCore }
 if ($o.AlsoGemini -and (-not $o.DryRun)) { Assemble-To (Join-Path $o.Target 'GEMINI.md') $includeCore }
-if ($o.DryRun) { exit 0 }
+if ($o.DryRun) {
+  Write-Host ''
+  Say "DRY RUN — nothing was written. A real run would ALSO scaffold into $($o.Target):"
+  Write-Host '    + scripts/        verify.sh, handoff.sh, new-research.sh, new-feedback.sh, secret-scan.sh, install-git-hooks.sh, lint-leanness.sh'
+  Write-Host '    + hooks/git/      managed git hooks (secret-scan, protect-main, conventional-commits)'
+  Write-Host '    + .harness/       verify.conf (+ .example), templates/, handoffs/'
+  Write-Host '    + .planning/      progress-log.md'
+  if ($o.AssembleOnly) { Write-Host '    + .claude/        settings.local.json.example' }
+  else { Write-Host '    + .claude/        settings.local.json.example, skills/ pack (/handoff, /verify, /harness-help + 3 more)' }
+  Write-Host '    + docs/           feedback/README.md, research/ (+ _archive dirs)'
+  Write-Host '    + FIRST-STEPS.md'
+  if ($o.AlsoAgents) { Write-Host '    + AGENTS.md       (--also-agents-md)' }
+  if ($o.AlsoGemini) { Write-Host '    + GEMINI.md       (--also-gemini-md)' }
+  if ($o.WithMcp) { Write-Host "    + .mcp.json       (--with-mcp: $($o.WithMcp))" }
+  if ($o.WithHooks) { Write-Host '    ~ git hooks installed via scripts/install-git-hooks.sh (--with-hooks)' }
+  Write-Host ''
+  Say 'Re-run without --dry-run to write these.'
+  exit 0
+}
 
 Say "Scaffolding project structure in $($o.Target)"
 foreach ($d in @('docs/research/_archive','docs/feedback/_archive','.planning','.harness/handoffs','scripts','.claude','hooks/git','.harness/templates')) {

--- a/setup.ps1
+++ b/setup.ps1
@@ -144,6 +144,9 @@ function Detect-Profile ([string]$dir) {  # best-guess profile name from the fil
   if ((Test-Has $dir @('Dockerfile','docker-compose.y*ml','*.tf','ansible.cfg','Vagrantfile')) -or (Test-Path (Join-Path $dir 'ansible') -PathType Container) -or (Test-Path (Join-Path $dir 'terraform') -PathType Container) -or (Test-Path (Join-Path $dir 'k8s') -PathType Container)) { return 'devops-setup' }
   if ((Test-Has $dir @('*.ipynb','*.csv','*.parquet')) -or (Test-Path (Join-Path $dir 'notebooks') -PathType Container)) { return 'data-crunching' }
   if ((Test-Has $dir @('mkdocs.yml','docusaurus.config.*','_config.yml','*.tex')) -or ((Test-Path (Join-Path $dir 'docs') -PathType Container) -and (Test-Has (Join-Path $dir 'docs') @('*.md')))) { return 'document-creation' }
+  # Weak signal, checked LAST: loose source files with no manifest still make this a code project.
+  # Deliberately below data/doc so a manifest-less notebook or docs tree still wins over a stray script.
+  if (Test-Has $dir @('*.py','*.js','*.mjs','*.ts','*.tsx','*.jsx','*.go','*.rs','*.rb','*.java','*.kt','*.php','*.c','*.cc','*.cpp','*.cs','*.swift','*.scala')) { return 'software-dev' }
   return 'general-admin'
 }
 function Uninstall-From ([string]$path) {  # back up, strip the managed block; delete file if nothing else remains

--- a/setup.ps1
+++ b/setup.ps1
@@ -147,6 +147,12 @@ function Detect-Profile ([string]$dir) {  # best-guess profile name from the fil
   # Weak signal, checked LAST: loose source files with no manifest still make this a code project.
   # Deliberately below data/doc so a manifest-less notebook or docs tree still wins over a stray script.
   if (Test-Has $dir @('*.py','*.js','*.mjs','*.ts','*.tsx','*.jsx','*.go','*.rs','*.rb','*.java','*.kt','*.php','*.c','*.cc','*.cpp','*.cs','*.swift','*.scala')) { return 'software-dev' }
+  # One level deep: a monorepo often keeps its manifest in a subdir (e.g. backend/requirements.txt).
+  # Lowest priority — only rescues what would otherwise be general-admin; never overrides a root
+  # data/doc/devops signal. Immediate subdirs only (bounded); -Force omitted so dotdirs are skipped.
+  foreach ($sub in Get-ChildItem -Path $dir -Directory -ErrorAction SilentlyContinue) {
+    if (Test-Has $sub.FullName @('go.mod','package.json','tsconfig.json','Cargo.toml','pyproject.toml','requirements.txt','pom.xml','build.gradle*','*.csproj','Gemfile','composer.json')) { return 'software-dev' }
+  }
   return 'general-admin'
 }
 function Uninstall-From ([string]$path) {  # back up, strip the managed block; delete file if nothing else remains

--- a/setup.sh
+++ b/setup.sh
@@ -155,6 +155,16 @@ detect_profile() {  # <dir> -> best-guess profile name from the files present (f
   # Weak signal, checked LAST: loose source files with no manifest still make this a code project.
   # Deliberately below data/doc so a manifest-less notebook or docs tree still wins over a stray script.
   _has "$d" '*.py' '*.js' '*.mjs' '*.ts' '*.tsx' '*.jsx' '*.go' '*.rs' '*.rb' '*.java' '*.kt' '*.php' '*.c' '*.cc' '*.cpp' '*.cs' '*.swift' '*.scala' && { echo software-dev; return; }
+  # One level deep: a monorepo often keeps its manifest in a subdir (e.g. backend/requirements.txt).
+  # Lowest priority — only rescues what would otherwise be general-admin; never overrides a root
+  # data/doc/devops signal. Immediate subdirs only (bounded); the glob skips dotdirs like .git/.venv.
+  local _sub
+  for _sub in "$d"/*/; do
+    [ -d "$_sub" ] || continue
+    if _has "$_sub" go.mod package.json tsconfig.json Cargo.toml pyproject.toml requirements.txt pom.xml 'build.gradle*' '*.csproj' Gemfile composer.json; then
+      echo software-dev; return
+    fi
+  done
   echo general-admin
 }
 uninstall_from() {  # <file> -> back it up, strip the managed block; delete the file if nothing else remains

--- a/setup.sh
+++ b/setup.sh
@@ -1184,7 +1184,28 @@ resolve_operator_identity "$TARGET/CLAUDE.md"
 assemble_to "$TARGET/CLAUDE.md" "$INCLUDE_CORE"
 $ALSO_AGENTS_MD && ! $DRY_RUN && assemble_to "$TARGET/AGENTS.md" "$INCLUDE_CORE"
 $ALSO_GEMINI_MD && ! $DRY_RUN && assemble_to "$TARGET/GEMINI.md" "$INCLUDE_CORE"
-$DRY_RUN && exit 0
+if $DRY_RUN; then
+  echo
+  say "DRY RUN — nothing was written. A real run would ALSO scaffold into $TARGET:"
+  echo "    + scripts/        verify.sh, handoff.sh, new-research.sh, new-feedback.sh, secret-scan.sh, install-git-hooks.sh, lint-leanness.sh"
+  echo "    + hooks/git/      managed git hooks (secret-scan, protect-main, conventional-commits)"
+  echo "    + .harness/       verify.conf (+ .example), templates/, handoffs/"
+  echo "    + .planning/      progress-log.md"
+  if $ASSEMBLE_ONLY; then
+    echo "    + .claude/        settings.local.json.example"
+  else
+    echo "    + .claude/        settings.local.json.example, skills/ pack (/handoff, /verify, /harness-help + 3 more)"
+  fi
+  echo "    + docs/           feedback/README.md, research/ (+ _archive dirs)"
+  echo "    + FIRST-STEPS.md"
+  if $ALSO_AGENTS_MD; then echo "    + AGENTS.md       (--also-agents-md)"; fi
+  if $ALSO_GEMINI_MD; then echo "    + GEMINI.md       (--also-gemini-md)"; fi
+  if [ -n "$WITH_MCP" ]; then echo "    + .mcp.json       (--with-mcp: $WITH_MCP)"; fi
+  if $WITH_HOOKS; then echo "    ~ git hooks installed via scripts/install-git-hooks.sh (--with-hooks)"; fi
+  echo
+  say "Re-run without --dry-run to write these."
+  exit 0
+fi
 
 say "Scaffolding project structure in $TARGET"
 mkdir -p "$TARGET/docs/research/_archive" "$TARGET/docs/feedback/_archive" "$TARGET/.planning" "$TARGET/.harness/handoffs" "$TARGET/scripts" "$TARGET/.claude"

--- a/setup.sh
+++ b/setup.sh
@@ -796,15 +796,17 @@ build_verify_conf() {  # <dest> — generate .harness/verify.conf from the chose
     echo "# .harness/verify.conf — generated for profile(s): $PROFILES"
     echo "# One phase per line:  Label :: shell command. Runs in order; first failure stops the run."
     echo "# This is YOUR definition of \"shippable\". Uncomment + edit the phases that fit this project,"
-    echo "# then DELETE the sanity line below once at least one real phase is active."
+    echo "# then DELETE the placeholder line below once at least one real phase is active."
     echo
     local p preset
     for p in "${PROFILE_ARR[@]}"; do
       preset="$HARNESS_DIR/config/verify-presets/$p.conf"
       [ -f "$preset" ] && { cat "$preset"; echo; }
     done
-    echo "# Universal placeholder so verify.sh runs green until you wire real phases — REPLACE THIS:"
-    echo "sanity :: echo \"verify.sh wired for: $PROFILES — replace this phase with real checks\""
+    echo "# Placeholder that FAILS ON PURPOSE, so verify.sh stays RED until you wire real phases."
+    echo "# A green verify that checks nothing is worse than none — it lies. Make the presets above"
+    echo "# real (uncomment + edit), then DELETE this line:"
+    echo "unwired :: echo \"verify.conf ($PROFILES) has only this placeholder — wire real build/test/lint phases in .harness/verify.conf, then delete this line\" >&2; exit 1"
   } > "$dest"
 }
 

--- a/setup.sh
+++ b/setup.sh
@@ -152,6 +152,9 @@ detect_profile() {  # <dir> -> best-guess profile name from the files present (f
   { _has "$d" Dockerfile 'docker-compose.y*ml' '*.tf' ansible.cfg Vagrantfile || [ -d "$d/ansible" ] || [ -d "$d/terraform" ] || [ -d "$d/k8s" ]; } && { echo devops-setup; return; }
   { _has "$d" '*.ipynb' '*.csv' '*.parquet' || [ -d "$d/notebooks" ]; } && { echo data-crunching; return; }
   { _has "$d" mkdocs.yml 'docusaurus.config.*' _config.yml '*.tex' || { [ -d "$d/docs" ] && _has "$d/docs" '*.md'; }; } && { echo document-creation; return; }
+  # Weak signal, checked LAST: loose source files with no manifest still make this a code project.
+  # Deliberately below data/doc so a manifest-less notebook or docs tree still wins over a stray script.
+  _has "$d" '*.py' '*.js' '*.mjs' '*.ts' '*.tsx' '*.jsx' '*.go' '*.rs' '*.rb' '*.java' '*.kt' '*.php' '*.c' '*.cc' '*.cpp' '*.cs' '*.swift' '*.scala' && { echo software-dev; return; }
   echo general-admin
 }
 uninstall_from() {  # <file> -> back it up, strip the managed block; delete the file if nothing else remains


### PR DESCRIPTION
Three correctness fixes to the installer, found while running agentsmith on a real project. Each is verified end-to-end in **both** `setup.sh` and `setup.ps1`, and agentsmith's own `scripts/verify.sh` suite stays green.

## Fixes

**1. Profile auto-detect missed real code projects** (`detect_profile`)
A folder of loose source (`.py`/`.js`/`.go`…) with no manifest, or a monorepo whose manifest sits one level down (`backend/requirements.txt`), fell through to `general-admin` — the wrong operating profile. Adds a loose-source signal and a depth-1 manifest scan, both at the **lowest** priority so they only rescue what would otherwise be `general-admin`: a root `notebooks/` or `docs/` tree still wins. Verified that data/doc monorepos are never mis-stolen.

**2. Generated `verify.conf` was green-by-default** (`build_verify_conf`)
The `sanity :: echo …` placeholder always exits 0, so a fresh install's `verify.sh` reported "all phase(s) passed" having checked nothing — a verify that lies (the exact failure the harness's own R2/R5 warn against). Replaced with an `unwired` phase that fails (exit 1) with a pointer, so verify stays RED until real build/test/lint phases are wired.

**3. `--dry-run` under-reported the blast radius**
Project-mode `--dry-run` previewed only `CLAUDE.md` then exited, hiding the ~20 other files a real run scaffolds (`scripts/`, `hooks/git/`, `.harness/`, `.planning/`, `.claude/`, `FIRST-STEPS.md`). Now lists the full scaffold (honouring `--also-*`/`--with-*` flags) and still writes nothing.

## Verification

- **detect_profile** — reproduced every case in bash and PowerShell: loose source → `software-dev`, nested manifest → `software-dev`, depth-2 nested → `general-admin` (unchanged), a `notebooks/`/`docs/` monorepo with a nested manifest → still `data-crunching`/`document-creation` (guards), bare README → `general-admin`.
- **verify.conf** — a freshly scaffolded project's `verify.sh` now exits 1 with the pointer message.
- **dry-run** — prints the scaffold list; the target dir and `~/.claude` stay untouched.
- **Regression** — `scripts/verify.sh` self-test: syntax / secret-scan / leak-gate / identity / assemble / consent all pass, including the `setup.sh`↔`setup.ps1` parity checks.

Split into three atomic commits (plus the monorepo depth-1 scan as a fourth) so each fix is reviewable and revertable on its own.
