### PR TITLE
feat(setup): auto-install rtk (CLI-output compressor) for code profiles

### DIFF
--- a/config/plugins.md
+++ b/config/plugins.md
@@ -67,6 +67,27 @@ interactive prompt:
 own languages** (a Python LSP, a Rust plugin, etc.). Marketplaces are registered only when you
 actually select the pack, so unused ones never touch your config.
 
+## Command-output compression (rtk) — a binary, not a plugin
+
+[`rtk`](https://github.com/rtk-ai/rtk) (Rust Token Killer, Apache-2.0) is a CLI proxy that
+compresses noisy command output — `git`, tests, package managers, `kubectl`/`terraform` — by
+60–90% *before* it reaches the context window. It's the token-economics rule (keep context lean,
+fight context rot) applied to **tool output** instead of the rules file.
+
+Unlike everything else here it's **not a Claude Code plugin** — it's a small native binary plus a
+`PreToolUse` hook that transparently rewrites Bash commands (`git status` → `rtk git status`). So
+`setup.sh`/`setup.ps1` install it on its own track:
+
+- **Default-ON for the code profiles** (`software-dev`, `devops-setup`); off everywhere else.
+  Force it with `--with-rtk`, skip it with `--no-rtk`.
+- Install is per-OS (Homebrew / the official installer / a native Windows binary), then rtk's own
+  `rtk init -g --auto-patch` wires the hook, an `RTK.md`, and the `settings.json` entry — the
+  harness doesn't hand-maintain any of that. **Restart Claude Code** after install to load the hook.
+- Windows needs **ripgrep** (`rg`) on PATH for some filters (`winget install BurntSushi.ripgrep.MSVC`).
+- **Nothing is silently hidden:** the hook only touches Bash calls (Read/Grep/Glob bypass it), full
+  output is teed to a log on failure, and `rtk proxy <cmd>` runs any command raw. Remove it all with
+  `rtk init -g --uninstall`.
+
 ## A note on restraint (R10)
 
 Every plugin is surface area to maintain and another thing that can drift. Install the universal

--- a/docs/11-whats-built-in.md
+++ b/docs/11-whats-built-in.md
@@ -38,6 +38,10 @@ For the reasoning behind any of it, the cross-links point back to the doc that e
   what *not* to run it on.
 - **MCP picker** — `setup.sh --with-mcp <name[,name]>` writes the right block from
   `config/mcp.example.json` into the project's `.mcp.json`.
+- **rtk output compressor** — `setup.sh`/`setup.ps1 --with-rtk` (default-ON for `software-dev` /
+  `devops-setup`; `--no-rtk` to skip) installs [`rtk`](https://github.com/rtk-ai/rtk) and runs its
+  own `rtk init -g` to wire a PreToolUse hook that compresses noisy CLI output 60–90% before it
+  reaches context. A binary + hook, not a plugin — see [`../config/plugins.md`](../config/plugins.md).
 - **Org-policy variant** — `sudo setup.sh --org-policy` installs a managed `CLAUDE.md` at the OS
   policy path (applies to all users on a shared box) + a stricter, no-bypass settings profile.
 - **Cowork / claude.ai export** — `setup.sh --export-instructions` emits a single paste-ready

--- a/setup.ps1
+++ b/setup.ps1
@@ -38,6 +38,7 @@
 #    ./setup.ps1 --assemble-only ...    # skip the config/plugins install; still writes CLAUDE.md
 #                                       #   (under --global that IS ~/.claude/CLAUDE.md — see above)
 #    ./setup.ps1 --with-plugins dev-workflow,stack-lsp ...   # opt-in plugin packs (latest)
+#    ./setup.ps1 --with-rtk | --no-rtk   # rtk CLI-output compressor (default: ON for software-dev/devops-setup)
 #    ./setup.ps1 --with-mcp playwright,context7 ...   # add named MCP server(s) to project .mcp.json
 #    ./setup.ps1 --with-skills ...      # install the bundled skill pack (handoff, verify, harness-doctor,
 #                                       #   new-research, new-feedback, harness-help); project mode →
@@ -110,7 +111,7 @@ $o = @{
   TrackerPolicyAllowed = "**writes are authorized** (the operator opted in at setup) — file it directly, and make agent work visible there (a note when work starts and when it lands)."
   Global = $false; ProfileOnly = $false; AssembleOnly = $false; Force = $false; DryRun = $false
   AlsoAgents = $false; AlsoGemini = $false; WithSkills = $false; WithHooks = $false; WithHandoffHooks = $false
-  WithPlugins = ''; WithMcp = ''
+  WithPlugins = ''; WithMcp = ''; WithRtk = 'auto'   # auto = install rtk for code profiles; --with-rtk forces on, --no-rtk off
   UpdatePlugins = $false; Doctor = $false; Export = $false; OrgPolicy = $false; Wizard = $false
   SelfUpdate = $false; SelfUpdateRemote = ''; NoReassemble = $false; Uninstall = $false
   Safety = 'trusted'   # trusted = bypassPermissions (flag-path default); cautious = acceptEdits (wizard default)
@@ -188,6 +189,8 @@ for ($i = 0; $i -lt $args.Count; $i++) {
     '--global'            { $o.Global = $true }
     '--profile-only'      { $o.ProfileOnly = $true }
     '--with-plugins'      { $o.WithPlugins = $args[++$i] }
+    '--with-rtk'          { $o.WithRtk = 'true' }
+    '--no-rtk'            { $o.WithRtk = 'false' }
     '--with-mcp'          { $o.WithMcp = $args[++$i] }
     '--with-skills'       { $o.WithSkills = $true }
     '--with-hooks'        { $o.WithHooks = $true }
@@ -379,6 +382,52 @@ function Get-Recommendation ([string]$Profile) {
   return $r
 }
 
+function Rtk-Wanted {  # install rtk? explicit flag wins; else auto = only for code profiles (software-dev/devops-setup)
+  if ($o.WithRtk -eq 'true')  { return $true }
+  if ($o.WithRtk -eq 'false') { return $false }
+  foreach ($p in $ProfileArr) { if ($p -in @('software-dev','devops-setup')) { return $true } }
+  return $false
+}
+
+function Install-Rtk {  # install the rtk binary (per-OS), then let rtk wire its own Claude Code hook
+  if (Have-Cmd rtk) {
+    Ok "rtk already installed ($(try { rtk --version } catch { 'present' }))"
+  } else {
+    Say 'Installing rtk — token-compressing CLI proxy (github.com/rtk-ai/rtk)'
+    if ($IsWindows) {
+      try {
+        $bin = Join-Path $HOME '.local\bin'; New-Item -ItemType Directory -Force -Path $bin | Out-Null
+        $tmp = Join-Path ([System.IO.Path]::GetTempPath()) "rtk-$PID"; New-Item -ItemType Directory -Force -Path $tmp | Out-Null
+        if (Have-Cmd gh) {
+          gh release download --repo rtk-ai/rtk --pattern 'rtk-x86_64-pc-windows-msvc.zip' --dir $tmp --clobber 2>$null
+          $zip = Join-Path $tmp 'rtk-x86_64-pc-windows-msvc.zip'
+        } else {
+          $rel = Invoke-RestMethod 'https://api.github.com/repos/rtk-ai/rtk/releases/latest' -Headers @{ 'User-Agent' = 'agentsmith-setup' }
+          $url = ($rel.assets | Where-Object { $_.name -match 'windows-msvc.*\.zip$' } | Select-Object -First 1).browser_download_url
+          $zip = Join-Path $tmp 'rtk.zip'; Invoke-WebRequest $url -OutFile $zip
+        }
+        Expand-Archive -Path $zip -DestinationPath (Join-Path $tmp 'x') -Force
+        $exe = Get-ChildItem (Join-Path $tmp 'x') -Recurse -Filter 'rtk.exe' | Select-Object -First 1
+        Copy-Item $exe.FullName (Join-Path $bin 'rtk.exe') -Force
+        $userPath = [Environment]::GetEnvironmentVariable('Path','User')
+        if ($userPath -notmatch [regex]::Escape('\.local\bin')) {
+          [Environment]::SetEnvironmentVariable('Path', "$userPath;$bin", 'User'); Ok "added $bin to your user PATH (new shells)"
+        }
+        if ($env:Path -notmatch [regex]::Escape($bin)) { $env:Path = "$env:Path;$bin" }
+      } catch { Warn 'rtk: Windows install failed — grab rtk.exe from https://github.com/rtk-ai/rtk/releases and add it to PATH'; return }
+    } elseif (Have-Cmd brew) {
+      try { brew install rtk *> $null } catch { Warn 'rtk: brew install failed — see https://github.com/rtk-ai/rtk#installation'; return }
+    } else {
+      Warn 'rtk: no supported installer found — install by hand: https://github.com/rtk-ai/rtk#installation'; return
+    }
+  }
+  if (-not (Have-Cmd rtk)) { Warn 'rtk not on PATH after install — open a new shell, then run: rtk init -g --auto-patch'; return }
+  if (-not (Have-Cmd rg))  { Warn 'rtk: ripgrep (rg) not on PATH — some filters need it (winget install BurntSushi.ripgrep.MSVC)' }
+  rtk init -g --auto-patch *> $null
+  if ($LASTEXITCODE -eq 0) { Ok 'rtk wired into Claude Code (hook + RTK.md) — restart Claude Code to load it' }
+  else { Warn "rtk: 'rtk init -g --auto-patch' failed — run it by hand to wire the hook" }
+}
+
 function Install-GlobalConfig {
   Say "Installing global config into $CcDir"
   New-Item -ItemType Directory -Force -Path $CcDir | Out-Null
@@ -427,6 +476,8 @@ function Install-GlobalConfig {
     Install-Marketplace 'Piebald-AI/claude-code-lsps'
     foreach ($spec in @('go-dev@gopher-ai','tailwind@gopher-ai','gopls@claude-code-lsps','typescript-lsp@claude-plugins-official','gopls-lsp@claude-plugins-official')) { Install-Plugin $spec }
   }
+  # rtk — token-compressing CLI proxy (github.com/rtk-ai/rtk). Default-ON for code profiles; --no-rtk opts out.
+  if (Rtk-Wanted) { Install-Rtk }
   if ($o.WithSkills) { Install-Skills $SkillsDest }
   if ($o.WithHandoffHooks) { Install-HandoffHooks }
 }
@@ -1089,6 +1140,7 @@ if ($o.Uninstall) {
     Say "Uninstall — removing the Agentsmith core from $(Join-Path $CcDir 'CLAUDE.md')"
     Uninstall-From (Join-Path $CcDir 'CLAUDE.md')
     Warn 'Global config (settings.json, plugins) left in place — remove those by hand if you want them gone.'
+    if (Have-Cmd rtk) { Say 'rtk hook left in place. Remove it with:  rtk init -g --uninstall   (then remove the binary via brew/scoop/del).' }
   } else {
     if (-not $o.Target) { $o.Target = (Get-Location).Path }
     if (-not (Test-Path $o.Target -PathType Container)) { Die "Target dir does not exist: $($o.Target)" }

--- a/setup.sh
+++ b/setup.sh
@@ -37,6 +37,7 @@
 #    ./setup.sh --assemble-only ...     # skip the config/plugins install; still writes CLAUDE.md
 #                                       #   (under --global that IS ~/.claude/CLAUDE.md — see above)
 #    ./setup.sh --with-plugins dev-workflow,stack-lsp ...   # opt-in plugin packs (latest)
+#    ./setup.sh --with-rtk | --no-rtk   # rtk CLI-output compressor (default: ON for software-dev/devops-setup)
 #    ./setup.sh --with-mcp playwright,context7 ...   # add named MCP server(s) to project .mcp.json
 #    ./setup.sh --with-skills ...       # install the bundled skill pack (handoff, verify,
 #                                       #   harness-doctor, new-research, new-feedback, harness-help);
@@ -100,6 +101,7 @@ SKILLS_DEST=""            # empty → install_skills defaults to global ~/.claud
 WITH_HOOKS=false
 WITH_HANDOFF_HOOKS=false
 WITH_PLUGINS=""
+WITH_RTK="auto"           # auto = install rtk for code profiles (software-dev/devops-setup); --with-rtk forces on, --no-rtk off
 WITH_MCP=""
 DO_UPDATE_PLUGINS=false
 DO_DOCTOR=false
@@ -546,6 +548,8 @@ while [ $# -gt 0 ]; do
     --global) GLOBAL=true;;
     --profile-only) PROFILE_ONLY=true;;
     --with-plugins) shift; WITH_PLUGINS="${1:-}";;
+    --with-rtk) WITH_RTK=true;;
+    --no-rtk) WITH_RTK=false;;
     --with-mcp) shift; WITH_MCP="${1:-}";;
     --with-skills) WITH_SKILLS=true;;
     --with-hooks) WITH_HOOKS=true;;
@@ -782,6 +786,8 @@ install_global_config() {
     install_marketplace Piebald-AI/claude-code-lsps
     for spec in go-dev@gopher-ai tailwind@gopher-ai gopls@claude-code-lsps typescript-lsp@claude-plugins-official gopls-lsp@claude-plugins-official; do install_plugin "$spec"; done ;;
   esac
+  # rtk — token-compressing CLI proxy (github.com/rtk-ai/rtk). Default-ON for code profiles; --no-rtk opts out.
+  rtk_wanted && install_rtk
   $WITH_SKILLS && install_skills "$SKILLS_DEST"
   $WITH_HANDOFF_HOOKS && install_handoff_hooks
   return 0   # never let a false trailing `&&` (both hooks/skills off) abort the caller under set -e
@@ -798,6 +804,35 @@ install_skills() {  # [dest] — default global ~/.claude/skills; project mode p
     cp -r "$d" "$dest/$name"; ok "skill $name"; n=$((n+1))
   done
   ok "skills installed: $n (into $dest/)"
+}
+
+rtk_wanted() {  # install rtk? explicit flag wins; else auto = only for code profiles (software-dev/devops-setup)
+  case "$WITH_RTK" in true) return 0;; false) return 1;; esac
+  local p
+  for p in "${PROFILE_ARR[@]:-}"; do
+    case "$p" in software-dev|devops-setup) return 0;; esac
+  done
+  return 1
+}
+
+install_rtk() {  # install the rtk binary (per-OS), then let rtk wire its own Claude Code hook
+  if command -v rtk >/dev/null 2>&1; then
+    ok "rtk already installed ($(rtk --version 2>/dev/null || echo present))"
+  else
+    say "Installing rtk — token-compressing CLI proxy (github.com/rtk-ai/rtk)"
+    if command -v brew >/dev/null 2>&1; then
+      brew install rtk >/dev/null 2>&1 || { warn "rtk: 'brew install rtk' failed — install by hand: https://github.com/rtk-ai/rtk#installation"; return 0; }
+    else
+      curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/master/install.sh | sh >/dev/null 2>&1 \
+        || { warn "rtk: installer failed — install by hand: https://github.com/rtk-ai/rtk#installation"; return 0; }
+    fi
+  fi
+  command -v rtk >/dev/null 2>&1 || { warn "rtk installed but not on PATH — add \$HOME/.local/bin to PATH, then run: rtk init -g --auto-patch"; return 0; }
+  command -v rg  >/dev/null 2>&1 || warn "rtk: ripgrep (rg) not on PATH — some filters need it (install ripgrep via brew/apt/winget)"
+  # rtk writes its own PreToolUse hook + RTK.md + settings.json entry + @RTK.md import — idempotent, no prompt
+  if rtk init -g --auto-patch >/dev/null 2>&1; then ok "rtk wired into Claude Code (hook + RTK.md) — restart Claude Code to load it"
+  else warn "rtk: 'rtk init -g --auto-patch' failed — run it by hand to wire the hook"; fi
+  return 0
 }
 
 build_verify_conf() {  # <dest> — generate .harness/verify.conf from the chosen profile preset(s)
@@ -1138,6 +1173,7 @@ if $DO_UNINSTALL; then
     say "Uninstall — removing the Agentsmith core from $CC_DIR/CLAUDE.md"
     uninstall_from "$CC_DIR/CLAUDE.md"
     warn "Global config (settings.json, plugins) left in place — remove those by hand if you want them gone."
+    command -v rtk >/dev/null 2>&1 && say "rtk hook left in place. Remove it with:  rtk init -g --uninstall   (then remove the binary via brew/cargo/rm)."
   else
     [ -n "$TARGET" ] || TARGET="$(pwd)"
     [ -d "$TARGET" ] || die "Target dir does not exist: $TARGET"

--- a/skills/RECOMMENDED.md
+++ b/skills/RECOMMENDED.md
@@ -39,6 +39,9 @@ Project mode installs these into `<project>/.claude/skills/`; `--global` install
 - **ui-ux-pro-max** — third-party (MIT). Only if the work has a front end; skip it for backend,
   CLI, or library work. Needs **Python 3**, which nothing else here does. See `creative-design`
   below for the install commands.
+- **rtk** — token-compressing CLI proxy (Apache-2.0), **auto-installed for this profile** (pass
+  `--no-rtk` to skip). Cuts `git`/test/build output 60–90% before it hits the context window. It's
+  a binary + hook, not a plugin — details in `../config/plugins.md`.
 
 ## deep-research
 <!-- MAP deep-research | packs: - | skills: deep-research -->
@@ -66,6 +69,9 @@ Project mode installs these into `<project>/.claude/skills/`; `--global` install
 <!-- MAP devops-setup | packs: - | skills: - -->
 - Leans on **MCP servers** (cloud/CI/registry) and the **sentry-cli** skill for post-deploy
   monitoring more than on bundled skills. Add a skill when you find yourself repeating a runbook.
+- **rtk** — token-compressing CLI proxy (Apache-2.0), **auto-installed for this profile** (pass
+  `--no-rtk` to skip): compresses noisy `kubectl`/`terraform`/`docker`/test output before the agent
+  reads it. Binary + hook, not a plugin — see `../config/plugins.md`.
 
 ## autonomous-loops
 <!-- MAP autonomous-loops | packs: - | skills: using-git-worktrees,verify -->


### PR DESCRIPTION
## What
Adds [`rtk`](https://github.com/rtk-ai/rtk) (Rust Token Killer — Apache-2.0, ~71k★) as an auto-installed default for the code profiles. rtk is a CLI proxy that compresses noisy command output (git, tests, package managers, kubectl/terraform) **60–90%** before it reaches the context window.

## Why
It's the harness's own token-economics / context-rot discipline applied to **tool output** instead of the rules file. Recommended by an advisor as a sensible default.

## How it's wired
rtk is a **binary + PreToolUse hook, not a Claude Code plugin**, so it installs on its own track (not via the plugin packs):

- Per-OS binary install (Homebrew / official installer / native Windows zip), then rtk's own `rtk init -g --auto-patch` writes the hook + `RTK.md` + `settings.json` entry — the harness hand-maintains none of that. **Restart Claude Code** after install to load the hook.
- **Default-ON for `software-dev` and `devops-setup`**; off elsewhere. `--with-rtk` forces on, `--no-rtk` off.
- Layered `--global` core flow has no profile, so pass `--global --with-rtk` there to opt in.
- Windows needs ripgrep (`rg`) for some filters — `winget install BurntSushi.ripgrep.MSVC`.

## Safety / evidence
Nothing is silently hidden: the hook only touches Bash calls (Read/Grep/Glob bypass it), full output tees to a log on failure, and `rtk proxy <cmd>` runs any command raw. Full removal: `rtk init -g --uninstall`.

## Testing
- **setup.sh** — `bash -n` clean; `rtk_wanted` truth table verified (6 cases); `--with-rtk`/`--no-rtk` parse; help renders the flag.
- **setup.ps1** — PowerShell parser clean; the real `Rtk-Wanted` body run against the same 6-case truth table; help renders the flag.
- **End-to-end** — installed rtk 0.43.0 on Windows: `rtk init --show` all-green, `rtk git status` compresses, `rtk proxy git status` returns raw.

## Docs (R6)
`config/plugins.md` (new binary-vs-plugin section), `skills/RECOMMENDED.md` (both code profiles), `docs/11-whats-built-in.md`.

## Deliberately not included
No version pin — installs latest, consistent with how `--with-plugins` pulls latest from source; rtk ships ~monthly and is actively maintained. Add `RTK_VERSION`-based pinning later if reproducibility becomes a concern.
