### PR TITLE
ci(verify): skip the gate on human-reviewed docs and specs

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -13,11 +13,39 @@
 # verify.conf and it runs here automatically, with no YAML change.
 name: verify
 
+# ── RULE: this gate is for executable surface, NOT human-reviewed prose. ─────────────────────
+# What CI proves here is machine-checkable breakage: shell that won't parse, a profile that won't
+# assemble into a followable CLAUDE.md, an installer that hangs, the R8 guardrail regressing.
+# Documentation and specs (docs/**, the top-level READMEs, LICENSE) are authored and REVIEWED BY A
+# HUMAN — there is nothing here for CI to prove about a prose edit. Running the full Linux+Windows
+# gate on a doc-only push is wasted minutes AND a misleading signal (a red X that means nothing
+# about the change). So doc-only pushes/PRs skip the gate via paths-ignore.
+#   • Removes NO secret coverage: real secret scanning is the pre-commit hook (scripts/secret-scan.sh),
+#     which runs on every commit whatever it touches. The CI secret-scan/leak-gate phases are
+#     fixture unit tests of that guardrail, not a scan of the tree — nothing is lost by skipping them.
+#   • A push that touches a doc AND any gated file still runs: paths-ignore only skips when EVERY
+#     changed path matches. workflow_dispatch always runs, so a gate can be forced by hand.
+#   • Adding a new pure-docs path? Add it to BOTH paths-ignore lists below — push and pull_request
+#     must stay in sync. Do NOT add core/ or profiles/ here: those assemble into CLAUDE.md and are
+#     covered by the `assemble` phase.
+# Why this rule exists (incident + reasoning): docs/feedback/0005-ci-gate-on-human-reviewed-docs.md
 on:
   push:
     branches: ['**']
+    paths-ignore:
+      - 'docs/**'
+      - 'README.md'
+      - 'INSTALL.md'
+      - 'AGENT-INSTALL.md'
+      - 'LICENSE'
   pull_request:
     branches: [master]
+    paths-ignore:
+      - 'docs/**'
+      - 'README.md'
+      - 'INSTALL.md'
+      - 'AGENT-INSTALL.md'
+      - 'LICENSE'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Why

The verify gate exists to catch **machine-checkable breakage** — shell that won't parse, a profile that won't assemble into a followable `CLAUDE.md`, an installer that hangs, the R8 guardrail regressing.

Prose under `docs/**`, the top-level READMEs and `LICENSE` is authored and **reviewed by a person**. CI has nothing to prove about a prose edit, so running the full Linux + Windows gate on a doc-only push is wasted minutes *plus* a misleading red/green signal on a change it never inspected.

## What changed

`paths-ignore` added to **both** the `push` and `pull_request` triggers in `.github/workflows/verify.yml`:

```
docs/**  ·  README.md  ·  INSTALL.md  ·  AGENT-INSTALL.md  ·  LICENSE
```

## Why this is safe

- **No secret coverage removed.** Real scanning is the always-on pre-commit hook (`scripts/secret-scan.sh`), which runs on every commit whatever it touches. The CI `secret-scan`/`leak-gate` phases are *fixture unit tests of that guardrail*, not a scan of the tree — nothing is lost by skipping them on a doc-only change.
- **Mixed changes still run.** `paths-ignore` only skips when *every* changed path matches. A doc + code push is still gated.
- **`workflow_dispatch` still forces a manual run.**
- **`core/` and `profiles/` stay gated** — they assemble into `CLAUDE.md` and are covered by the `assemble` phase.

## Verification

This PR touches `.github/workflows/verify.yml`, which is *not* in `paths-ignore` — so the full gate runs on this PR itself, which is the end-to-end proof that the YAML is valid and the triggers still fire.

An in-file comment block documents the rule and warns that new pure-docs paths must be added to **both** lists.