### PR TITLE
test(leak-gate): fail loud on a broken msys scratch repo instead of a fake 18/16

### DIFF
--- a/scripts/test-leak-gate.sh
+++ b/scripts/test-leak-gate.sh
@@ -34,9 +34,36 @@ bad() { printf '  \033[31m✗\033[0m %s\n' "$1"; fail=$((fail+1)); }
 # and no re-init per case.
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
+# mktemp hands back an msys path (/tmp/tmp.XXX) under git-bash, and this suite drives the scratch
+# repo with native git-for-Windows (git -C "$TMP" ...). Native git can only reach that path if msys
+# converts it first; when it doesn't — path-conversion disabled, or a cold /tmp mount right after a
+# reboot — every `git -C "$TMP" ...` dies with "cannot change to '/tmp/...'". The setup calls below
+# suppress stderr, so the scratch repo would then end up EMPTY, the gate would find nothing, and
+# every "expect-flagged" case would silently pass the gate — surfacing as fake leak-gate logic
+# failures (the infamous 18 passed / 16 failed) that say nothing about the guardrail. Normalise to a
+# path native git resolves on any platform: cygpath on git-bash, a no-op fallback on Linux/macOS.
+TMP="$(cygpath -m "$TMP" 2>/dev/null || printf '%s' "$TMP")"
 git -C "$TMP" init -q
 mkdir -p "$TMP/scripts"
 cp "$GATE" "$TMP/scripts/leak-gate.sh"
+
+# SANITY — the belt to that suspenders. Prove git can actually track AND grep a file in the scratch
+# repo before running a single case, using the same `git -C "$TMP"` the cases rely on. If it can't
+# (residual path issue, no git on PATH, read-only TEMP), the whole suite is meaningless: fail LOUD
+# with the real diagnosis instead of 16 fake logic failures a reader would chase into leak-gate.sh.
+# R2/core-60: a guard that reports an environment fault as a logic fault is not a guard.
+printf 'PROBE_51_75_20_9\n' > "$TMP/.sanity-probe"
+git -C "$TMP" add -A >/dev/null 2>&1
+if ! git -C "$TMP" grep -q PROBE_51_75_20_9 -- .sanity-probe 2>/dev/null; then
+  echo "FATAL: git cannot track/grep a file in the scratch repo at:" >&2
+  echo "         $TMP" >&2
+  echo "  This is an ENVIRONMENT problem (msys path conversion, git on PATH, or TEMP perms)," >&2
+  echo "  NOT a leak-gate failure. On git-bash it is usually mktemp handing native git an msys" >&2
+  echo "  /tmp path it cannot resolve. Fix the environment, then re-run — leave leak-gate.sh alone." >&2
+  exit 2
+fi
+rm -f "$TMP/.sanity-probe"
+git -C "$TMP" add -A >/dev/null 2>&1
 
 # Run the gate over a scratch repo whose only content is $1. Echoes output; returns gate exit.
 gate_on() {


### PR DESCRIPTION
## Symptom

On Windows/git-bash, `bash scripts/verify.sh` intermittently failed the **leak-gate** phase with `test-leak-gate: 18 passed, 16 failed` — every "expect-flagged" detection case failing, every "expect-clean" case passing. CI (Linux) was always green, so the local red read as noise and trained us to ignore the gate.

## Root cause (diagnosed, not guessed)

`test-leak-gate.sh` builds its throwaway repo with `mktemp -d`, which on git-bash returns an **msys path** (`/tmp/tmp.XXX`), then drives it with **native git-for-Windows** (`git -C "$TMP" …`). Native git can only reach that path if msys converts it to a Windows path first. When it doesn't — path-conversion disabled, or a cold `/tmp` mount right after a reboot — every `git -C "$TMP" …` dies with `fatal: cannot change to '/tmp/…'`.

The setup calls suppressed stderr (`>/dev/null 2>&1`), so the scratch repo silently ended up **empty** → the gate's `git grep` found nothing → the gate reported "clean" on every planted leak → all 16 detection cases "failed" and all clean cases "passed" = exactly **18/16**.

**The gate and its regexes were correct the whole time.** This was a test-harness robustness bug that masked an environment fault as 16 fake logic failures.

Deterministic proof: `MSYS_NO_PATHCONV=1 bash scripts/test-leak-gate.sh` reproduces 18/16 on demand (forces the git-can't-resolve-`/tmp` state).

## Fix — two layers, entirely in the test harness (`leak-gate.sh` itself is untouched)

1. **Normalise the temp path** with `cygpath -m` (a no-op off Windows) so native git resolves it regardless of msys path-conversion state — removes the common trigger.
2. **Sanity probe**: assert git can track *and* grep a file in the scratch repo before any case runs. If it can't, exit `2` with the real diagnosis instead of 16 fake logic failures. (R2 / core-60: a guard that reports an environment fault as a logic fault is not a guard.)

## Verification

- `MSYS_NO_PATHCONV=1` run (deterministically 18/16 before) → now **34/0**.
- A copy with `git init` stripped (scratch repo genuinely non-functional) → trips the probe, prints `FATAL: …`, exits **2** — the loud path works.
- Full `bash scripts/verify.sh` → **all 6 phases green**.
- **Linux CI unaffected**: `cygpath` is absent there, so the fallback leaves the path as-is and native git works — this PR's Linux run is that proof.

## Why not a PowerShell port of verify.sh

The bash gate is fine; only its temp-repo setup was fragile on Windows. A full PowerShell port would double the maintenance surface (R10) — and `setup.ps1` is already noted in-repo as prone to silent drift. Linux CI stays the authoritative signal; this just makes the local Windows run honest.