### PR TITLE
feat: design-system awareness for UI work

### DIFF
--- a/.harness/verify.conf
+++ b/.harness/verify.conf
@@ -17,3 +17,4 @@ leak-gate  :: bash scripts/test-leak-gate.sh
 identity   :: bash scripts/test-operator-identity.sh
 assemble   :: bash scripts/test-assemble.sh
 consent    :: bash scripts/test-tracker-consent.sh
+ui-design-hook :: bash scripts/test-ui-design-reminder.sh

--- a/docs/07-how-to-pick-a-profile.md
+++ b/docs/07-how-to-pick-a-profile.md
@@ -35,6 +35,12 @@ state — a filled `CLAUDE.md` project-specifics layer and a real `.harness/veri
   supervised, not what the work is. A loop that fixes code wants `software-dev,autonomous-loops`;
   one that sweeps a server wants `devops-setup,autonomous-loops`. Add it the moment the output
   stops passing under a human's eyes, and drop it when you go back to watching each step.
+- **Product UI is `software-dev`.** A web/app frontend lives under `software-dev` — not
+  `creative-design`, which is diagrams, decks, and brand artifacts. UI projects expect a root
+  `DESIGN.md`: the design system the agent reads before building any screen. Establish it at install
+  (`./setup.sh --design-system stub|catalog:<brand>|generate`) or drop one in from the
+  [awesome-design-md](https://github.com/VoltAgent/awesome-design-md) catalog, so the UI isn't built
+  ad-hoc and off-brand.
 - **When in doubt**, `general-admin` is the safe catch-all — it assumes outward-facing/irreversible
   actions need confirmation and that summaries must be faithful.
 - You can **re-assemble any time** as a project's focus shifts: re-run `setup.sh --assemble-only`

--- a/docs/11-whats-built-in.md
+++ b/docs/11-whats-built-in.md
@@ -26,6 +26,12 @@ For the reasoning behind any of it, the cross-links point back to the doc that e
   in [`04-why-your-agent-ignored-the-rule.md`](04-why-your-agent-ignored-the-rule.md).
 - **Handoff hooks** — `setup.sh --with-handoff-hooks` installs a reliable "handoff"-keyword prompt
   hook plus a best-effort context-% nudge (the % part is fragile by design — see `hooks/README.md`).
+- **Design-system scaffold** — `setup.sh --design-system stub|catalog:<brand>|generate` (software-dev
+  UI projects) drops a root `DESIGN.md` the agent reads before building UI: an empty template to fill,
+  a ready-made one from the [awesome-design-md](https://github.com/VoltAgent/awesome-design-md) catalog,
+  or the ui-ux-pro-max generate steps. Pair it with `--with-ui-design-hook` — a once-per-session
+  PreToolUse nudge to consult `DESIGN.md` on UI edits. Why it exists:
+  [`07-how-to-pick-a-profile.md`](07-how-to-pick-a-profile.md) (product UI is `software-dev`).
 - **Guardrail hooks** — `scripts/install-git-hooks.sh` / `setup.sh --with-hooks`: secret-scan +
   protect-main + conventional-commit (default), branch-naming + tests-green (opt-in). These are the
   deterministic guards behind the rules ([`14-safety-model.md`](14-safety-model.md) covers the posture).

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -66,6 +66,42 @@ never a blocked prompt).
 
 ---
 
+## UI design-system nudge (`ui-design-reminder.sh`) — PreToolUse — opt-in
+
+A third session hook, for the `software-dev` profile's design-system discipline. On an `Edit`/
+`Write`/`MultiEdit` to a **UI file** (`*.tsx *.jsx *.vue *.svelte *.css *.scss *.less *.astro`, or a
+path under `components/`/`ui/`) it injects a **once-per-session**, **non-blocking** reminder to
+consult `DESIGN.md` and match the declared design system. It **self-gates on a `DESIGN.md` at the
+project root**, so backend/CLI/library projects never see it, and it uses PreToolUse
+`additionalContext` only — it never blocks the edit and never auto-approves it (normal permission
+flow still applies). Every surprise (no `jq`, non-UI path, no `DESIGN.md`, already nudged) is a
+silent no-op.
+
+Install it at setup, when you tell the wizard the project has a UI:
+
+```bash
+./setup.sh --profile software-dev --design-system stub      # scaffolds DESIGN.md, then offers the hook
+```
+
+Or wire it by hand (global `~/.claude/settings.json`):
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      { "matcher": "Edit|Write|MultiEdit",
+        "hooks": [ { "type": "command", "command": "bash ~/.claude/hooks/ui-design-reminder.sh" } ] }
+    ]
+  }
+}
+```
+
+Non-regression test: `bash scripts/test-ui-design-reminder.sh` (wired as the `ui-design-hook` phase
+in this repo's `.harness/verify.conf`) — it fails if the nudge regresses to silent, fires on backend
+files, or fires more than once per session.
+
+---
+
 ## Git guardrails (`hooks/git/`)
 
 Per-repo git hooks that enforce the harness's git discipline. Install with:

--- a/hooks/ui-design-reminder.sh
+++ b/hooks/ui-design-reminder.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# PreToolUse nudge — remind the agent to consult DESIGN.md when it edits UI (opt-in, fail-safe).
+#
+# Fires at most ONCE per session, and only when BOTH hold:
+#   • the edit targets a UI file — *.tsx *.jsx *.vue *.svelte *.css *.scss *.less *.astro, or a
+#     path under a components/ or ui/ directory; AND
+#   • a DESIGN.md exists at the project root (so backend/CLI/library projects never see it).
+# It NEVER blocks the edit and NEVER auto-approves it: it only injects a one-line reminder via the
+# PreToolUse `additionalContext` field, then lets the normal permission flow proceed. Every surprise
+# — no jq, malformed input, non-UI path, no DESIGN.md, already nudged — is a silent no-op.
+#
+# Model: hooks/context-budget-nudge.sh (once-per-session marker, jq-guarded, fail-open).
+#
+# Wire it (global ~/.claude/settings.json):
+#   "hooks": { "PreToolUse": [ { "matcher": "Edit|Write|MultiEdit", "hooks": [
+#     { "type": "command", "command": "bash ~/.claude/hooks/ui-design-reminder.sh" } ] } ] }
+#
+# Hook stdin/output schemas can drift between Claude Code versions; this stays fail-open (a bad read
+# or an unknown field → no-op, never a blocked edit). Verified against the PreToolUse contract
+# (tool_input.file_path input; hookSpecificOutput.additionalContext, exit 0 = normal flow) at time
+# of writing — see docs at code.claude.com/docs/en/hooks.
+set -euo pipefail
+command -v jq >/dev/null 2>&1 || exit 0
+
+input=$(cat)
+tool=$(printf '%s' "$input" | jq -r '.tool_name // empty' 2>/dev/null) || exit 0
+case "$tool" in Edit|Write|MultiEdit) ;; *) exit 0 ;; esac
+
+fp=$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty' 2>/dev/null) || exit 0
+[ -n "$fp" ] || exit 0
+fp=${fp//\\//}                                 # normalise Windows backslashes so dir globs match
+case "$fp" in
+  *.tsx|*.jsx|*.vue|*.svelte|*.css|*.scss|*.less|*.astro|*/components/*|*/ui/*) ;;
+  *) exit 0 ;;                                  # not a UI file → silent
+esac
+
+# The self-gate: a DESIGN.md at the project root. No design system declared → stay silent, so backend
+# projects never see this. Check the session cwd first, then the git root (covers a subdir cwd).
+cwd=$(printf '%s' "$input" | jq -r '.cwd // empty' 2>/dev/null) || exit 0
+[ -n "$cwd" ] || cwd=.
+root="$cwd"
+if [ ! -f "$root/DESIGN.md" ]; then
+  gr=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null) || gr=""
+  [ -n "$gr" ] && root="$gr"
+fi
+[ -f "$root/DESIGN.md" ] || exit 0
+
+# Once per session (marker keyed by session_id): a screen's worth of edits nudges once, not N times.
+sid=$(printf '%s' "$input" | jq -r '.session_id // empty' 2>/dev/null) || exit 0
+marker="${TMPDIR:-/tmp}/claude-uidesign-${sid:-default}.nudged"
+[ -f "$marker" ] && exit 0
+: > "$marker" 2>/dev/null || true
+
+jq -n --arg f "$fp" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    additionalContext: ("Editing UI (" + $f + "). This project declares a design system in DESIGN.md — read it and match it (colors, type, spacing, components, states) before changing UI. If DESIGN.md still reads \"[TODO]\", establish the design system first. Update DESIGN.md in the same change when you add or restyle a component.")
+  }
+}'
+exit 0

--- a/profiles/software-dev.md
+++ b/profiles/software-dev.md
@@ -29,6 +29,29 @@ The sequence for every code change (sharpens R2/R5):
 "It compiles and the unit test passes" is within-a-layer evidence only. If a
 human could click a button and see it break, you haven't verified it.
 
+### Design system (UI work)
+
+**If this project has a UI, its design system is the spec for how that UI looks — and it lives in
+`DESIGN.md` at the project root.** This is the product-UI analogue of the brand block in the
+creative-design profile: establish the look once, write it down, and hold every screen to it.
+
+- **Read `DESIGN.md` before you write or change any UI, and match it** — colors, type, spacing,
+  components, layout, states. A screen that ignores it is off-brand the moment it ships, and that
+  only shows up after the fact.
+- **If `DESIGN.md` is missing or still reads `[TODO]`, STOP and establish one first.** Three ways,
+  pick per project: *bring the brand* (brand guide + existing assets → write them in), *pick a
+  ready-made one* (a `DESIGN.md` from the awesome-design-md catalog), or *generate one* (the
+  ui-ux-pro-max skill produces and persists a design system). Then write the choice into `DESIGN.md`
+  so the next session doesn't re-ask — exactly how the brand block persists a palette.
+- **When you add, rename, or restyle a component, update `DESIGN.md` in the same unit of work (R6).**
+  The design system and the code drift apart the instant one changes without the other.
+- **No UI? This section is inert.** Backend, CLI, library, and data work have no design system to
+  honor — skip it.
+
+Adherence is a judgment rule, not something a script can grep for. It's held by the quality-gate
+checkbox below, the STOP-table row, and the UI-edit nudge hook — deliberately **not** by
+`verify.sh` (design correctness isn't automatable, so the verify preset stays out of it).
+
 ### Quality gates
 Before calling code done, tick each — "deferred: reason" is allowed, silence is not:
 
@@ -39,6 +62,8 @@ Before calling code done, tick each — "deferred: reason" is allowed, silence i
 - [ ] the **full** test suite passes, not just the new test (R5)
 - [ ] the changed path was **run for real** once (CLI invocation / live request /
       browser click-through), including every fan-out consumer (R3)
+- [ ] UI changes match the design system declared in `DESIGN.md` (or `DESIGN.md` updated to
+      match) — inert if this project has no UI
 - [ ] docs, changelog, help text, and inline comments that the change made wrong
       are fixed in this same unit (R6)
 - [ ] a defect ticket exists for anything found-but-not-fixed (R7)
@@ -66,6 +91,9 @@ sessions.
 - **Stale-workspace noise.** Compiler/LSP errors pointing at a sibling worktree or
   a path your branch doesn't use are stale. Trust the build/typecheck command's
   output, not editor popups.
+- **UI built ad-hoc, ignoring the project's design system.** Components drift, every
+  screen reinvents spacing/color/controls, and the product looks assembled by five
+  different people. Read `DESIGN.md` first; if none exists, establish one before building UI.
 
 ### Recommended skills & tools
 Map to the loop — pull these in, don't reinvent them:
@@ -104,3 +132,4 @@ branch. No `code-review`/codex gate? Do the second-pass read — and an independ
 | "I'll fix all these in one commit." | One bad change hides in N and breaks bisect. Atomic only (R4). |
 | "That type/lint error is in another workspace — ignore it." | Confirm with the build/typecheck command. If it's truly a sibling worktree, it's noise; if it's yours, it's a blocker — don't guess. |
 | "The docs aren't really part of this change." | If the change made a doc/help/comment wrong, fixing it IS the change (R6). |
+| "I'll match the design system later." | Later is the off-brand screen that ships. Read DESIGN.md first; if none exists, establish it before building UI. |

--- a/scripts/test-ui-design-reminder.sh
+++ b/scripts/test-ui-design-reminder.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# test-ui-design-reminder.sh — non-regression suite for hooks/ui-design-reminder.sh.
+#
+# This is the core/60 guard for the design-system feature: the reason the harness now nudges on UI
+# edits is a real incident (a portal shipped ignoring its design system). This suite fails if that
+# nudge regresses — either by going silent when it should fire, or by firing when it must not
+# (backend projects, non-UI files) or firing on every edit instead of once per session.
+#
+# Point it at a deliberately-broken copy to prove it can fail (a guard nobody has watched fail is a
+# claim, not a guard — R2):   HOOK_BIN=/path/to/broken.sh bash scripts/test-ui-design-reminder.sh
+#
+# Usage: bash scripts/test-ui-design-reminder.sh     # exit 0 = all pass, 1 = a test failed
+set -uo pipefail   # deliberately NOT -e: run every test, then report
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="${HOOK_BIN:-$SCRIPT_DIR/../hooks/ui-design-reminder.sh}"
+BASH_BIN="$(command -v bash)"
+
+# jq is a harness prerequisite (CI installs it, setup.sh requires it, the hook uses it). Without jq
+# the hook no-ops by design, so the nudge path cannot be exercised at all — fail-safe, not fail-loud.
+# Skip LOUDLY rather than paint a false red on a jq-less dev box; CI always has jq and runs it fully.
+if ! command -v jq >/dev/null 2>&1; then
+  echo "test-ui-design-reminder: SKIP — jq not installed, nudge path not exercised (CI covers it)."
+  exit 0
+fi
+
+# Isolate markers + fixtures under one throwaway TMPDIR: the hook writes its once-per-session marker
+# to $TMPDIR, and every fixture project lives here too, so cases can't leak into each other or the
+# real /tmp. mktemp -d fixtures are NOT git repos, so the hook's git-root fallback is a clean no-op.
+WORK="$(mktemp -d)"; export TMPDIR="$WORK"
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0; fail=0
+ok()  { printf '  \033[32m✓\033[0m %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  \033[31m✗\033[0m %s\n' "$1"; fail=$((fail+1)); }
+
+# emit <cwd> <tool> <file_path> <session_id> -> the hook's stdout
+emit() {
+  printf '{"tool_name":"%s","tool_input":{"file_path":"%s"},"cwd":"%s","session_id":"%s"}' \
+    "$2" "$3" "$1" "$4" | bash "$HOOK" 2>/dev/null
+}
+nudged()  { grep -q 'DESIGN.md' <<<"$1"; }   # a real nudge names DESIGN.md in additionalContext
+silent()  { [ -z "${1//[[:space:]]/}" ]; }   # a no-op prints nothing
+
+echo "test-ui-design-reminder — fires on UI edits with a DESIGN.md"
+
+proj="$(mktemp -d)"; : > "$proj/DESIGN.md"
+out="$(emit "$proj" Edit "$proj/Button.tsx" sess-1)"
+if nudged "$out"; then ok ".tsx edit + DESIGN.md present → nudges once"; else bad ".tsx edit + DESIGN.md present → NOT nudged (the incident would recur)"; fi
+
+# Same session, second UI edit → silent. This is the "once per session, not per edit" property.
+out="$(emit "$proj" Edit "$proj/Card.tsx" sess-1)"
+if silent "$out"; then ok "second UI edit, same session → silent (once per session, not per edit)"; else bad "second UI edit re-nudged — would nag on every edit"; fi
+
+# A new session gets a fresh nudge: the marker is per-session, not global.
+out="$(emit "$proj" Edit "$proj/Modal.tsx" sess-2)"
+if nudged "$out"; then ok "new session → nudges again (marker is per-session)"; else bad "new session stayed silent — marker leaked across sessions"; fi
+
+# A file under components/ that isn't a listed extension still counts as UI.
+out="$(emit "$proj" Write "$proj/components/nav.ts" sess-3)"
+if nudged "$out"; then ok "components/ path (non-listed ext) → nudges"; else bad "components/ path → NOT nudged"; fi
+
+echo "test-ui-design-reminder — stays silent when it must"
+
+# Backend file, DESIGN.md present → silent (this is the whole point: don't nag non-UI work).
+out="$(emit "$proj" Edit "$proj/main.go" sess-4)"
+if silent "$out"; then ok ".go edit → silent"; else bad ".go edit nudged — would fire on backend work"; fi
+
+# UI file but NO DESIGN.md at root → silent (backend/CLI projects with no design system).
+noproj="$(mktemp -d)"    # deliberately no DESIGN.md
+out="$(emit "$noproj" Edit "$noproj/Button.tsx" sess-5)"
+if silent "$out"; then ok ".tsx edit + no DESIGN.md → silent (self-gates on DESIGN.md)"; else bad ".tsx edit without DESIGN.md nudged — self-gate broken"; fi
+
+echo "test-ui-design-reminder — fail-open (never blocks an edit)"
+
+# jq absent: run with an empty PATH so `command -v jq` finds nothing. The hook must no-op silently,
+# never emit a blocking decision. (bash builtins need no PATH; the guard exits before reading stdin.)
+out="$(printf '{"tool_name":"Edit","tool_input":{"file_path":"%s"},"cwd":"%s","session_id":"sess-6"}' "$proj/Button.tsx" "$proj" | PATH="" "$BASH_BIN" "$HOOK" 2>/dev/null)"
+if silent "$out"; then ok "jq absent → silent no-op"; else bad "jq absent produced output — not fail-safe"; fi
+
+# Malformed input → silent no-op, not a crash or a block.
+out="$(printf 'not json {{' | bash "$HOOK" 2>/dev/null)"
+if silent "$out"; then ok "malformed input → silent no-op"; else bad "malformed input produced output"; fi
+
+# The emitted nudge must NEVER carry a permission decision (that would block or auto-approve).
+freshproj="$(mktemp -d)"; : > "$freshproj/DESIGN.md"
+out="$(emit "$freshproj" Edit "$freshproj/App.tsx" sess-7)"
+if nudged "$out" && ! grep -q 'permissionDecision' <<<"$out"; then
+  ok "nudge injects additionalContext only — no permissionDecision (never blocks/auto-approves)"
+else
+  bad "nudge carried a permissionDecision — could block or auto-approve the edit"
+fi
+
+echo
+printf 'test-ui-design-reminder: %d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ] || exit 1

--- a/setup.ps1
+++ b/setup.ps1
@@ -49,6 +49,11 @@
 #    ./setup.ps1 --profile X --export-instructions > inst.md   # paste-ready blob for web/Cowork
 #    sudo ./setup.ps1 --org-policy      # machine-wide managed CLAUDE.md + hardened (no-bypass) settings
 #    ./setup.ps1 --with-handoff-hooks   # install reliable 'handoff' keyword hook (+ best-effort ctx-% nudge)
+#    ./setup.ps1 --design-system skip|stub|catalog:<slug>|generate   # software-dev UI projects: establish a
+#                                       #   design system. stub = scaffold DESIGN.md to fill in; catalog:stripe =
+#                                       #   pull a ready-made one from the awesome-design-md catalog; generate =
+#                                       #   print the ui-ux-pro-max steps. default = skip (no DESIGN.md).
+#    ./setup.ps1 --with-ui-design-hook  # global PreToolUse nudge: consult DESIGN.md when editing UI files
 #    ./setup.ps1 --self-update          # pull the latest harness into this checkout + re-assemble managed CLAUDE.md
 #                                       #   remote: --from <url> | $env:HARNESS_REMOTE | .harness/remote | the checkout's origin
 #                                       #   auth:   git@/ssh:// -> SSH key; https:// -> $env:HARNESS_GH_TOKEN (never stored)
@@ -111,6 +116,7 @@ $o = @{
   TrackerPolicyAllowed = "**writes are authorized** (the operator opted in at setup) — file it directly, and make agent work visible there (a note when work starts and when it lands)."
   Global = $false; ProfileOnly = $false; AssembleOnly = $false; Force = $false; DryRun = $false
   AlsoAgents = $false; AlsoGemini = $false; WithSkills = $false; WithHooks = $false; WithHandoffHooks = $false
+  WithUiDesignHook = $false; DesignSystem = ''   # '' / skip = no DESIGN.md; stub | catalog:<slug> | generate for a UI project
   WithPlugins = ''; WithMcp = ''; WithRtk = 'auto'   # auto = install rtk for code profiles; --with-rtk forces on, --no-rtk off
   UpdatePlugins = $false; Doctor = $false; Export = $false; OrgPolicy = $false; Wizard = $false
   SelfUpdate = $false; SelfUpdateRemote = ''; NoReassemble = $false; Uninstall = $false
@@ -195,6 +201,11 @@ for ($i = 0; $i -lt $args.Count; $i++) {
     '--with-skills'       { $o.WithSkills = $true }
     '--with-hooks'        { $o.WithHooks = $true }
     '--with-handoff-hooks'{ $o.WithHandoffHooks = $true }
+    '--with-ui-design-hook'{ $o.WithUiDesignHook = $true }
+    '--design-system'     { $o.DesignSystem = $args[++$i]
+                            if ($o.DesignSystem -notmatch '^(skip|stub|generate|catalog:.+)$') {
+                              Die "--design-system must be skip | stub | catalog:<slug> | generate (got '$($o.DesignSystem)')"
+                            } }
     '--update-plugins'    { $o.UpdatePlugins = $true }
     '--doctor'            { $o.Doctor = $true }
     '--export-instructions'{ $o.Export = $true }
@@ -480,6 +491,7 @@ function Install-GlobalConfig {
   if (Rtk-Wanted) { Install-Rtk }
   if ($o.WithSkills) { Install-Skills $SkillsDest }
   if ($o.WithHandoffHooks) { Install-HandoffHooks }
+  if ($o.WithUiDesignHook) { Install-UiDesignHook }
 }
 
 function Build-VerifyConf ([string]$dest) {
@@ -611,6 +623,70 @@ function Install-HandoffHooks {
   Write-Host ''; Say "Handoff hooks installed."
   Write-Host "  • 'handoff' / 'wrap up' in a prompt → injects the safe-state + recall-prompt protocol (reliable)"
   Write-Host "  • context ≥ threshold used → one best-effort nudge (fragile — see hooks/README.md)"
+}
+
+# ---- design system (software-dev UI projects) ------------------------------
+# Establish a design system so UI isn't built ad-hoc and off-brand. The durable artifact is a
+# project-root DESIGN.md the agent reads before every UI change; the software-dev profile points at
+# it every turn, and (optionally) the ui-design-reminder hook nudges on UI edits.
+function Print-DesignSources {
+  Write-Host "      Fill DESIGN.md three ways (also in its header):"
+  Write-Host "        • bring your brand — transcribe your brand guide + assets into it"
+  Write-Host "        • pick a ready-made one — https://github.com/VoltAgent/awesome-design-md (design-md/<brand>/DESIGN.md)"
+  Write-Host "        • generate one — /plugin marketplace add nextlevelbuilder/ui-ux-pro-max-skill"
+  Write-Host "                         /plugin install ui-ux-pro-max@ui-ux-pro-max-skill   (needs Python 3)"
+}
+function Scaffold-DesignSystem {  # honor --design-system for a UI project. Idempotent: never overwrites a DESIGN.md.
+  if ($o.DesignSystem -in @('', 'skip')) { return }
+  $dest = Join-Path $o.Target 'DESIGN.md'
+  $tpl  = Join-Path $HarnessDir 'templates/design-system.md'
+  if (Test-Path $dest) { Ok 'DESIGN.md already present — left as-is'; return }
+  if ($o.DesignSystem -eq 'stub') {
+    Copy-Item $tpl $dest -Force; Ok 'added DESIGN.md (design-system template — fill in the [TODO]s)'
+    Print-DesignSources
+  } elseif ($o.DesignSystem -like 'catalog:*') {
+    $slug = $o.DesignSystem.Substring('catalog:'.Length)
+    $url = "https://raw.githubusercontent.com/VoltAgent/awesome-design-md/main/design-md/$slug/DESIGN.md"
+    Say "Fetching a starter DESIGN.md for '$slug' from the awesome-design-md catalog…"
+    # Degrade gracefully (infra idempotency): offline or an unknown slug falls back to the template.
+    $fetched = $false
+    try { Invoke-WebRequest -Uri $url -OutFile $dest -UseBasicParsing -ErrorAction Stop; if ((Test-Path $dest) -and (Get-Item $dest).Length -gt 0) { $fetched = $true } } catch { $fetched = $false }
+    if ($fetched) { Ok "added DESIGN.md from catalog:$slug (review + adapt it to your brand)" }
+    else {
+      if (Test-Path $dest) { Remove-Item $dest -Force }
+      Warn "could not fetch catalog:$slug (offline, or no such brand) — using the template instead."
+      Write-Host "      Browse brands: https://github.com/VoltAgent/awesome-design-md/tree/main/design-md"
+      Copy-Item $tpl $dest -Force; Ok 'added DESIGN.md (template fallback)'
+    }
+  } elseif ($o.DesignSystem -eq 'generate') {
+    # setup.ps1 CANNOT run Claude Code /plugin commands — never a silent half-install; scaffold the
+    # template so there's always a DESIGN.md, and print the exact generate steps to run yourself.
+    Copy-Item $tpl $dest -Force; Ok 'added DESIGN.md (template — ui-ux-pro-max will fill it)'
+    Say 'Generate the design system with ui-ux-pro-max, then it lands in DESIGN.md:'
+    Write-Host '        /plugin marketplace add nextlevelbuilder/ui-ux-pro-max-skill'
+    Write-Host '        /plugin install ui-ux-pro-max@ui-ux-pro-max-skill'
+    Write-Host '        …then ask the assistant to generate a design system into DESIGN.md.'
+    Write-Host '      Or via its npm CLI (needs Node + Python 3):  npm i -g ui-ux-pro-max-cli && uipro'
+  }
+}
+function Install-UiDesignHook {  # global PreToolUse nudge; PowerShell parses settings.json natively (no jq needed)
+  $hooksDir = Join-Path $CcDir 'hooks'
+  New-Item -ItemType Directory -Force -Path $hooksDir | Out-Null
+  Copy-Item (Join-Path $HarnessDir 'hooks/ui-design-reminder.sh') (Join-Path $hooksDir 'ui-design-reminder.sh') -Force
+  Ok "UI design-system hook script → $hooksDir"
+  $settings = Join-Path $CcDir 'settings.json'
+  if (-not (Test-Path $settings)) { '{}' | Set-Content $settings -Encoding utf8 }
+  $cmd = 'bash ~/.claude/hooks/ui-design-reminder.sh'
+  if (Select-String -Path $settings -SimpleMatch $cmd -Quiet) { Ok 'UI design-system hook already wired in settings.json'; return }
+  Copy-Item $settings "$settings.bak.$PID" -Force
+  try {
+    $s = Get-Content $settings -Raw | ConvertFrom-Json -AsHashtable
+    if (-not $s.ContainsKey('hooks')) { $s['hooks'] = @{} }
+    if (-not $s['hooks'].ContainsKey('PreToolUse')) { $s['hooks']['PreToolUse'] = @() }
+    $s['hooks']['PreToolUse'] = @($s['hooks']['PreToolUse']) + @(@{ matcher = 'Edit|Write|MultiEdit'; hooks = @(@{ type = 'command'; command = $cmd }) })
+    $s | ConvertTo-Json -Depth 100 | Set-Content $settings -Encoding utf8
+    Ok "wired UI design-system hook into settings.json (backup .bak.$PID)"
+  } catch { Warn 'merge failed — add the PreToolUse snippet from hooks/README.md by hand' }
 }
 
 # ============================================================================
@@ -804,6 +880,27 @@ function Run-Wizard {
       Wiz-Note 'Git guardrails are automatic safety checks in this project: block committing a'
       Wiz-Note 'password, block committing straight to your main branch, keep commit messages tidy.'
       if (Wiz-Yn 'Install git guardrail hooks (recommended)?' 'y') { $A += '--with-hooks' }
+      # Design system: only meaningful for software-dev projects with a UI.
+      if ($picks -contains 'software-dev') {
+        Write-Host ''
+        Wiz-Note 'If this project has a UI, its design system lives in DESIGN.md — the assistant reads it'
+        Wiz-Note "before building any screen and matches it, so the UI isn't built ad-hoc and off-brand."
+        if (Wiz-Yn 'Does this project have a UI (web/app frontend)?' 'n') {
+          Write-Host '      Establish the design system:'
+          Write-Host '        1) Scaffold a DESIGN.md template to fill in yourself (bring your brand)   [default]'
+          Write-Host '        2) Start from a ready-made one in the awesome-design-md catalog'
+          Write-Host '        3) Generate one with the ui-ux-pro-max skill'
+          $dsc = ''
+          while ($true) { $dsc = Read-Host '      Choose [1-3, default 1]'; if (-not $dsc) { $dsc = '1' }; if ($dsc -match '^[1-3]$') { break }; Write-Host '      ! enter 1-3' }
+          switch ($dsc) {
+            '1' { $A += '--design-system'; $A += 'stub' }
+            '2' { $dslug = Wiz-Ask 'Brand slug (e.g. stripe, linear, vercel, notion)' 'stripe'; $A += '--design-system'; $A += "catalog:$dslug" }
+            '3' { $A += '--design-system'; $A += 'generate' }
+          }
+          Wiz-Note 'The nudge hook reminds the assistant to consult DESIGN.md whenever it edits a UI file.'
+          if (Wiz-Yn 'Install the UI-edit nudge hook globally?' 'y') { $A += '--with-ui-design-hook' }
+        }
+      }
       Wiz-Note 'Handoff hooks help the assistant save its place before it runs low on working memory.'
       if (Wiz-Yn "Install handoff hooks globally ('handoff' keyword + best-effort context nudge)?" 'n') { $A += '--with-handoff-hooks' }
       if (Wiz-Yn 'Also write AGENTS.md (for Codex & other assistants)?' 'n') { $A += '--also-agents-md' }
@@ -1134,6 +1231,7 @@ if ($o.SelfUpdate) { Self-Update; exit 0 }
 if ($o.Export)    { Export-Instructions; exit 0 }
 if ($o.OrgPolicy) { OrgPolicy-Install; exit 0 }
 if ($o.WithHandoffHooks -and (-not $o.Global) -and (-not $o.Profiles)) { Install-HandoffHooks; exit 0 }
+if ($o.WithUiDesignHook -and (-not $o.Global) -and (-not $o.Profiles)) { Install-UiDesignHook; exit 0 }
 
 if ($o.Uninstall) {
   if ($o.Global) {
@@ -1208,6 +1306,7 @@ if ($o.DryRun) {
   else { Write-Host '    + .claude/        settings.local.json.example, skills/ pack (/handoff, /verify, /harness-help + 3 more)' }
   Write-Host '    + docs/           feedback/README.md, research/ (+ _archive dirs)'
   Write-Host '    + FIRST-STEPS.md'
+  if ($o.DesignSystem -and $o.DesignSystem -ne 'skip') { Write-Host "    + DESIGN.md       (--design-system $($o.DesignSystem))" }
   if ($o.AlsoAgents) { Write-Host '    + AGENTS.md       (--also-agents-md)' }
   if ($o.AlsoGemini) { Write-Host '    + GEMINI.md       (--also-gemini-md)' }
   if ($o.WithMcp) { Write-Host "    + .mcp.json       (--with-mcp: $($o.WithMcp))" }
@@ -1246,6 +1345,7 @@ else {
     Set-Content $firstSteps -Encoding utf8
   Ok 'added FIRST-STEPS.md (your getting-started card)'
 }
+Scaffold-DesignSystem   # honors --design-system for a UI project (no-op on the default/backend path)
 
 if ($o.WithMcp) { Say "Adding MCP server(s) to .mcp.json: $($o.WithMcp)"; Add-McpServers $o.WithMcp }
 
@@ -1271,6 +1371,7 @@ Write-Host "         3) copy .claude/settings.local.json.example to settings.loc
 Write-Host '         4) docs/01-harness-philosophy.md · docs/07-how-to-pick-a-profile.md · docs/12-platforms-and-tools.md'
 Write-Host ''
 Report-Todos (Join-Path $o.Target 'CLAUDE.md')
+Report-Todos (Join-Path $o.Target 'DESIGN.md')   # names DESIGN_SYSTEM when a design system was scaffolded but not filled
 Write-Host ''
 Write-Host '  ▶ First 30 minutes' -ForegroundColor Cyan -NoNewline; Write-Host '  (also saved to FIRST-STEPS.md)'
 Write-Host '     1) start:  claude          — run it inside this folder'

--- a/setup.sh
+++ b/setup.sh
@@ -48,6 +48,11 @@
 #    ./setup.sh --profile X --export-instructions > inst.md   # paste-ready blob for web/Cowork
 #    sudo ./setup.sh --org-policy       # machine-wide managed CLAUDE.md + hardened (no-bypass) settings
 #    ./setup.sh --with-handoff-hooks    # install reliable 'handoff' keyword hook (+ best-effort ctx-% nudge)
+#    ./setup.sh --design-system skip|stub|catalog:<slug>|generate   # software-dev UI projects: establish a
+#                                       #   design system. stub = scaffold DESIGN.md to fill in; catalog:stripe =
+#                                       #   pull a ready-made one from the awesome-design-md catalog; generate =
+#                                       #   print the ui-ux-pro-max steps. default = skip (no DESIGN.md).
+#    ./setup.sh --with-ui-design-hook   # global PreToolUse nudge: consult DESIGN.md when editing UI files
 #    ./setup.sh --self-update           # pull the latest harness into this checkout + re-assemble managed CLAUDE.md
 #                                       #   remote: --from <url> | $HARNESS_REMOTE | .harness/remote | the checkout's origin
 #                                       #   auth:   git@/ssh:// → SSH key; https:// → $HARNESS_GH_TOKEN (never stored)
@@ -100,6 +105,8 @@ WITH_SKILLS=false
 SKILLS_DEST=""            # empty → install_skills defaults to global ~/.claude/skills; project mode sets $TARGET/.claude/skills
 WITH_HOOKS=false
 WITH_HANDOFF_HOOKS=false
+WITH_UI_DESIGN_HOOK=false
+DESIGN_SYSTEM=""          # "" / skip = no DESIGN.md; stub | catalog:<slug> | generate for a UI project
 WITH_PLUGINS=""
 WITH_RTK="auto"           # auto = install rtk for code profiles (software-dev/devops-setup); --with-rtk forces on, --no-rtk off
 WITH_MCP=""
@@ -444,6 +451,27 @@ run_wizard() {
       wiz_note "Git guardrails are automatic safety checks in this project: block committing a"
       wiz_note "password, block committing straight to your main branch, keep commit messages tidy."
       wiz_yn "Install git guardrail hooks (recommended)?" y && A+=(--with-hooks)
+      # Design system: only meaningful for software-dev projects with a UI.
+      case ",$WIZ_PROFILES," in *,software-dev,*)
+        echo
+        wiz_note "If this project has a UI, its design system lives in DESIGN.md — the assistant reads it"
+        wiz_note "before building any screen and matches it, so the UI isn't built ad-hoc and off-brand."
+        if wiz_yn "Does this project have a UI (web/app frontend)?" n; then
+          echo "      Establish the design system:"
+          echo "        1) Scaffold a DESIGN.md template to fill in yourself (bring your brand)   [default]"
+          echo "        2) Start from a ready-made one in the awesome-design-md catalog"
+          echo "        3) Generate one with the ui-ux-pro-max skill"
+          local dsc; while :; do printf '      Choose [1-3, default 1]: '; read -r dsc || dsc=1; [ -z "$dsc" ] && dsc=1; [[ "$dsc" =~ ^[1-3]$ ]] && break; echo "      ! enter 1-3"; done
+          case "$dsc" in
+            1) A+=(--design-system stub);;
+            2) local dslug; wiz_ask dslug "Brand slug (e.g. stripe, linear, vercel, notion)" "stripe"; A+=(--design-system "catalog:$dslug");;
+            3) A+=(--design-system generate);;
+          esac
+          wiz_note "The nudge hook reminds the assistant to consult DESIGN.md whenever it edits a UI file."
+          wiz_yn "Install the UI-edit nudge hook globally?" y && A+=(--with-ui-design-hook)
+        fi
+        ;;
+      esac
       wiz_note "Handoff hooks help the assistant save its place before it runs low on working memory."
       wiz_yn "Install handoff hooks globally ('handoff' keyword + best-effort context nudge)?" n && A+=(--with-handoff-hooks)
       wiz_yn "Also write AGENTS.md (for Codex & other assistants)?" n && A+=(--also-agents-md)
@@ -554,6 +582,12 @@ while [ $# -gt 0 ]; do
     --with-skills) WITH_SKILLS=true;;
     --with-hooks) WITH_HOOKS=true;;
     --with-handoff-hooks) WITH_HANDOFF_HOOKS=true;;
+    --with-ui-design-hook) WITH_UI_DESIGN_HOOK=true;;
+    --design-system) shift; DESIGN_SYSTEM="${1:-}"
+      case "$DESIGN_SYSTEM" in
+        skip|stub|generate|catalog:?*) ;;
+        *) die "--design-system must be skip | stub | catalog:<slug> | generate (got '$DESIGN_SYSTEM')";;
+      esac;;
     --update-plugins) DO_UPDATE_PLUGINS=true;;
     --doctor) DO_DOCTOR=true;;
     --export-instructions) DO_EXPORT=true;;
@@ -790,6 +824,7 @@ install_global_config() {
   rtk_wanted && install_rtk
   $WITH_SKILLS && install_skills "$SKILLS_DEST"
   $WITH_HANDOFF_HOOKS && install_handoff_hooks
+  $WITH_UI_DESIGN_HOOK && install_ui_design_hook
   return 0   # never let a false trailing `&&` (both hooks/skills off) abort the caller under set -e
 }
 
@@ -972,6 +1007,71 @@ install_handoff_hooks() {  # global: 'handoff' keyword hook (reliable) + best-ef
   echo; say "$(c '1;32' 'Handoff hooks installed.')"
   echo "  • 'handoff' / 'wrap up' in a prompt → injects the safe-state + recall-prompt protocol (reliable)"
   echo "  • context ≥ ${HANDOFF_PCT_THRESHOLD:-30}% used → one best-effort nudge to hand off early (fragile — see hooks/README.md)"
+}
+
+# ---- design system (software-dev UI projects) ------------------------------
+# Establish a design system so UI isn't built ad-hoc and off-brand. The durable artifact is a
+# project-root DESIGN.md the agent reads before every UI change; the software-dev profile points at
+# it every turn, and (optionally) the ui-design-reminder hook nudges on UI edits.
+print_design_sources() {
+  echo "      Fill DESIGN.md three ways (also in its header):"
+  echo "        • bring your brand — transcribe your brand guide + assets into it"
+  echo "        • pick a ready-made one — https://github.com/VoltAgent/awesome-design-md (design-md/<brand>/DESIGN.md)"
+  echo "        • generate one — /plugin marketplace add nextlevelbuilder/ui-ux-pro-max-skill"
+  echo "                         /plugin install ui-ux-pro-max@ui-ux-pro-max-skill   (needs Python 3)"
+}
+scaffold_design_system() {  # honor --design-system for a UI project. Idempotent: never overwrites a DESIGN.md.
+  case "$DESIGN_SYSTEM" in ""|skip) return 0 ;; esac
+  local dest="$TARGET/DESIGN.md"
+  if [ -e "$dest" ]; then ok "DESIGN.md already present — left as-is"; return 0; fi
+  case "$DESIGN_SYSTEM" in
+    stub)
+      cp "$HARNESS_DIR/templates/design-system.md" "$dest"; ok "added DESIGN.md (design-system template — fill in the [TODO]s)"
+      print_design_sources ;;
+    catalog:*)
+      local slug="${DESIGN_SYSTEM#catalog:}"
+      local url="https://raw.githubusercontent.com/VoltAgent/awesome-design-md/main/design-md/${slug}/DESIGN.md"
+      say "Fetching a starter DESIGN.md for '$slug' from the awesome-design-md catalog…"
+      # Degrade gracefully (infra idempotency): offline or an unknown slug falls back to the template.
+      if command -v curl >/dev/null 2>&1 && curl -fsSL "$url" -o "$dest" 2>/dev/null && [ -s "$dest" ]; then
+        ok "added DESIGN.md from catalog:$slug (review + adapt it to your brand)"
+      else
+        rm -f "$dest"
+        warn "could not fetch catalog:$slug (offline, or no such brand) — using the template instead."
+        echo "      Browse brands: https://github.com/VoltAgent/awesome-design-md/tree/main/design-md"
+        cp "$HARNESS_DIR/templates/design-system.md" "$dest"; ok "added DESIGN.md (template fallback)"
+      fi ;;
+    generate)
+      # setup.sh (bash) CANNOT run Claude Code /plugin commands — never a silent half-install; scaffold
+      # the template so there's always a DESIGN.md, and print the exact generate steps to run yourself.
+      cp "$HARNESS_DIR/templates/design-system.md" "$dest"; ok "added DESIGN.md (template — ui-ux-pro-max will fill it)"
+      say "Generate the design system with ui-ux-pro-max, then it lands in DESIGN.md:"
+      echo "        /plugin marketplace add nextlevelbuilder/ui-ux-pro-max-skill"
+      echo "        /plugin install ui-ux-pro-max@ui-ux-pro-max-skill"
+      echo "        …then ask the assistant to generate a design system into DESIGN.md."
+      echo "      Or via its npm CLI (needs Node + Python 3):  npm i -g ui-ux-pro-max-cli && uipro" ;;
+  esac
+}
+install_ui_design_hook() {  # global PreToolUse nudge; warn-and-skip (don't abort setup) if jq is missing
+  if ! command -v jq >/dev/null 2>&1; then
+    warn "UI design-system hook needs jq to edit settings.json — skipped (install jq, then --with-ui-design-hook)."
+    return 0
+  fi
+  mkdir -p "$CC_DIR/hooks"
+  cp "$HARNESS_DIR/hooks/ui-design-reminder.sh" "$CC_DIR/hooks/ui-design-reminder.sh"
+  chmod +x "$CC_DIR/hooks/ui-design-reminder.sh" 2>/dev/null || true
+  [ -f "$CC_DIR/settings.json" ] || echo '{}' > "$CC_DIR/settings.json"
+  local cmd="bash ~/.claude/hooks/ui-design-reminder.sh"
+  if grep -qF "$cmd" "$CC_DIR/settings.json" 2>/dev/null; then
+    ok "UI design-system hook already wired in settings.json"; return 0
+  fi
+  cp "$CC_DIR/settings.json" "$CC_DIR/settings.json.bak.$$"
+  if jq --arg c "$cmd" '.hooks.PreToolUse = ((.hooks.PreToolUse // []) + [{matcher:"Edit|Write|MultiEdit", hooks:[{type:"command", command:$c}]}])' \
+       "$CC_DIR/settings.json" > "$CC_DIR/settings.json.new"; then
+    mv "$CC_DIR/settings.json.new" "$CC_DIR/settings.json"; ok "wired UI design-system hook into settings.json (backup .bak.$$)"
+  else
+    rm -f "$CC_DIR/settings.json.new"; warn "jq merge failed — add the PreToolUse snippet from hooks/README.md by hand"
+  fi
 }
 
 # ---- self-update -----------------------------------------------------------
@@ -1167,6 +1267,7 @@ if $DO_SELF_UPDATE; then self_update; exit 0; fi
 if $DO_EXPORT; then export_instructions; exit 0; fi
 if $DO_ORG_POLICY; then org_policy_install; exit 0; fi
 if $WITH_HANDOFF_HOOKS && ! $GLOBAL && [ -z "$PROFILES" ]; then install_handoff_hooks; exit 0; fi
+if $WITH_UI_DESIGN_HOOK && ! $GLOBAL && [ -z "$PROFILES" ]; then install_ui_design_hook; exit 0; fi
 
 if $DO_UNINSTALL; then
   if $GLOBAL; then
@@ -1244,6 +1345,7 @@ if $DRY_RUN; then
   fi
   echo "    + docs/           feedback/README.md, research/ (+ _archive dirs)"
   echo "    + FIRST-STEPS.md"
+  if [ -n "$DESIGN_SYSTEM" ] && [ "$DESIGN_SYSTEM" != skip ]; then echo "    + DESIGN.md       (--design-system $DESIGN_SYSTEM)"; fi
   if $ALSO_AGENTS_MD; then echo "    + AGENTS.md       (--also-agents-md)"; fi
   if $ALSO_GEMINI_MD; then echo "    + GEMINI.md       (--also-gemini-md)"; fi
   if [ -n "$WITH_MCP" ]; then echo "    + .mcp.json       (--with-mcp: $WITH_MCP)"; fi
@@ -1279,6 +1381,7 @@ cpa "$HARNESS_DIR/templates/progress-log.md"    "$TARGET/.planning/progress-log.
 cpa "$HARNESS_DIR/config/settings.local.$SAFETY.json.example" "$TARGET/.claude/settings.local.json.example"
 mkdir -p "$TARGET/.harness/templates"; cp "$HARNESS_DIR"/templates/*.md "$TARGET/.harness/templates/" 2>/dev/null || true; ok "templates in .harness/templates/"
 write_first_steps "$TARGET/FIRST-STEPS.md"
+scaffold_design_system   # honors --design-system for a UI project (no-op on the default/backend path)
 
 if [ -n "$WITH_MCP" ]; then
   say "Adding MCP server(s) to .mcp.json: $WITH_MCP"
@@ -1314,6 +1417,7 @@ echo "         3) cp .claude/settings.local.json.example .claude/settings.local.
 echo "         4) docs/01-harness-philosophy.md · docs/07-how-to-pick-a-profile.md · docs/12-platforms-and-tools.md"
 echo
 report_todos "$TARGET/CLAUDE.md"
+report_todos "$TARGET/DESIGN.md"   # names DESIGN_SYSTEM when a design system was scaffolded but not filled
 echo
 echo "  $(c '1;36' '▶ First 30 minutes')  (also saved to FIRST-STEPS.md)"
 echo "     1) start:  claude          — run it inside this folder"

--- a/skills/RECOMMENDED.md
+++ b/skills/RECOMMENDED.md
@@ -36,9 +36,14 @@ Project mode installs these into `<project>/.claude/skills/`; `--global` install
 - **test-driven-development**, **using-git-worktrees** — `superpowers`.
 - the `code-review` skill + the **codex** two-AI gate (plugins) for review.
 - language LSP / dev plugins (stack-lsp pack) for navigation + fixes.
-- **ui-ux-pro-max** — third-party (MIT). Only if the work has a front end; skip it for backend,
-  CLI, or library work. Needs **Python 3**, which nothing else here does. See `creative-design`
-  below for the install commands.
+- **Design system (any front end):** a UI project's look is defined in a root `DESIGN.md` the agent
+  reads before every UI change — set it up with `./setup.sh --design-system stub|catalog:<brand>|generate`
+  (and `--with-ui-design-hook` for a nudge on UI edits). Two ways to fill it:
+  - **awesome-design-md** — a catalog of 50+ ready-made `DESIGN.md` files
+    ([VoltAgent/awesome-design-md](https://github.com/VoltAgent/awesome-design-md)); drop one in and adapt it.
+  - **ui-ux-pro-max** — third-party (MIT); generates AND persists a full design system (palette, type,
+    layout, components) into `DESIGN.md`. Only if the work has a front end; skip it for backend, CLI, or
+    library work. Needs **Python 3**, which nothing else here does. Install commands under `creative-design` below.
 - **rtk** — token-compressing CLI proxy (Apache-2.0), **auto-installed for this profile** (pass
   `--no-rtk` to skip). Cuts `git`/test/build output 60–90% before it hits the context window. It's
   a binary + hook, not a plugin — details in `../config/plugins.md`.

--- a/templates/design-system.md
+++ b/templates/design-system.md
@@ -1,0 +1,77 @@
+<!--
+  DESIGN.md — the design system for this project's UI.
+  Scaffolded by the harness (software-dev profile). This is the single source of truth for how the
+  UI looks; the agent reads it before writing or changing any UI and matches it. Keep it in the
+  project root so tools (and coding agents) find it by convention.
+
+  THREE WAYS TO FILL IT — pick one, then delete the [TODO]s:
+    1. Bring your brand. You already have a brand guide / existing product. Transcribe the palette,
+       type, spacing, and component rules into the sections below. Most durable — it's YOUR system.
+    2. Pick a ready-made one. Copy a DESIGN.md from the awesome-design-md catalog and adapt it:
+       https://github.com/VoltAgent/awesome-design-md  (files live at design-md/<brand>/DESIGN.md).
+       Or scaffold it at setup:  ./setup.sh --profile software-dev --design-system catalog:<brand>
+    3. Generate one. The ui-ux-pro-max skill produces and persists a full design system from a brief:
+         /plugin marketplace add nextlevelbuilder/ui-ux-pro-max-skill
+         /plugin install ui-ux-pro-max@ui-ux-pro-max-skill
+       Its MASTER.md can point at this DESIGN.md so the two stay in sync.
+
+  Format follows the awesome-design-md convention (frontmatter + the H2 sections below) so external
+  tools recognize it. While DESIGN.md still reads "[TODO: set DESIGN_SYSTEM]", nobody has chosen a
+  design system yet — the agent will stop and ask, or (worse) invent one. Fill it before building UI.
+-->
+---
+name: [TODO: set DESIGN_SYSTEM]        # e.g. "Acme Console — dark-first product UI"
+description: [TODO: one or two sentences on the overall look and the feeling it should evoke]
+colors:
+  primary: "[TODO: #hex]"
+  # add the rest of your roles (background, surface, text, accent, success, warning, danger)
+---
+
+## Visual Theme & Atmosphere
+
+[TODO: the overall mood in a few sentences — light or dark first, dense or airy, playful or serious,
+flat or layered. What should someone feel in the first second? Name the one idea every screen serves.]
+
+## Color Palette & Roles
+
+[TODO: list each color as a role, not just a swatch — background, surface/card, primary/action,
+text-primary, text-muted, border, success/warning/danger. Give the hex and WHEN to use it. State the
+contrast rule you hold to (e.g. body text ≥ 4.5:1). No off-palette hues, no "close enough".]
+
+## Typography
+
+[TODO: the type families (display / body / mono), the scale (sizes + line-heights), the weights you
+use and don't, and letter-spacing rules. When is bold allowed? What's the smallest legible size?]
+
+## Component Stylings
+
+[TODO: the recurring components and their rules — buttons (variants, radius, padding, states),
+inputs, cards, tables, modals, nav. Radius, border, shadow, and the hover/active/focus/disabled
+states. This is what stops every screen from reinventing a button.]
+
+## Layout Principles
+
+[TODO: the spacing scale (e.g. 4/8px grid), container widths, gutters, and how density is decided.
+Alignment and grid rules. What "breathing room" means here.]
+
+## Depth & Elevation
+
+[TODO: how layering is expressed — shadows, borders, overlays, blur. The elevation levels and what
+sits at each. Flat, or soft-shadowed, or hard-edged?]
+
+## Do's and Don'ts
+
+[TODO: the short list that prevents the most common drift.
+- Do: …
+- Don't: …]
+
+## Responsive Behavior
+
+[TODO: breakpoints, what reflows vs. what hides, touch-target minimums, and how the layout adapts
+from mobile to wide. What's the smallest screen you support?]
+
+## Agent Prompt Guide
+
+[TODO: the one paragraph you'd paste to a coding agent so it builds on-system UI without reading the
+rest of this file — the palette, the type, the component library, and the single most important rule.
+Update this whenever the system changes.]

--- a/templates/first-steps.md
+++ b/templates/first-steps.md
@@ -13,6 +13,12 @@ That opens Claude Code with these rules loaded. Type in plain English — no spe
 
 ## Three things to try first
 
+> **Step 0 — building a UI?** Establish your design system *before* the first screen. If setup
+> scaffolded a `DESIGN.md` in this folder, fill it in (bring your brand, pick one from the
+> awesome-design-md catalog, or generate one with ui-ux-pro-max); if not, re-run
+> `./setup.sh --profile software-dev --design-system stub --target .` to get the template. The
+> assistant reads `DESIGN.md` before writing any UI and holds every screen to it. **No UI? Skip this.**
+
 1. **Get your bearings.** Ask:
    *"what does my harness do, and what are my rules?"*
    The assistant reads `CLAUDE.md` and explains the setup in plain language.


### PR DESCRIPTION
## Why

Running the harness on a real project, the agent built a portal without applying the chosen design system until told, and setup never pushed for one. Root cause: `profiles/software-dev.md` had **zero** design-system content — "design system" appeared exactly once in the whole harness. So the agent correctly treated it as the user's concern, never a rule (a core/60 config gap).

## What

Generalizes `creative-design`'s brand-block pattern to product UI, on the existing rails (content assembled into `CLAUDE.md` every turn; `{{TOKEN}}`→`[TODO]`→`report_todos` at setup; a `DESIGN.md` artifact in the awesome-design-md convention):

- **Rule** — a self-contained "Design system (UI work)" section in `software-dev.md`: read `DESIGN.md` before any UI change and match it; if missing/`[TODO]`, establish one first (bring the brand · pick from awesome-design-md · generate with ui-ux-pro-max); update it in the same unit when a component changes (R6); **inert** for backend/CLI/library work. Plus a quality-gate checkbox, a STOP-table row, and a failure-mode bullet.
- **Artifact** — `templates/design-system.md` → scaffolded to a project-root `DESIGN.md`.
- **Setup** — `--design-system skip|stub|catalog:<slug>|generate` + a wizard "Does this project have a UI?" step (setup.sh + setup.ps1 parity); `report_todos` also scans `DESIGN.md`, surfacing an unfilled `DESIGN_SYSTEM`.
- **Deterministic nudge** — `hooks/ui-design-reminder.sh`: a once-per-session, non-blocking PreToolUse reminder on UI edits, self-gating on a root `DESIGN.md` (backend projects stay silent).

Design **adherence** is a judgment call, not a grep, so `config/verify-presets/software-dev.conf` is deliberately unchanged — it's held by the rule, the gate, the STOP row, and the nudge hook.

## Commits (atomic)

1. `feat(software-dev)` — the profile rule + gate + STOP row + failure mode
2. `feat(templates)` — the `DESIGN.md` template + first-steps Step 0
3. `feat(hooks)` — the nudge hook + its non-regression test (wired as the `ui-design-hook` verify phase)
4. `feat(setup)` — `--design-system` flag, wizard step, scaffold, `report_todos`, hook install
5. `feat(setup)` — `setup.ps1` parity
6. `docs` — RECOMMENDED.md + docs catalog

## Verification

- New `ui-design-hook` phase: hook nudges on UI+`DESIGN.md`, silent on backend / no-`DESIGN.md`, once per session, never carries a permission decision. **Proven to fail** on a hook regressed to silent.
- `scripts/verify.sh` green, all 7 phases (Linux + Windows `setup.ps1` job).
- Setup e2e in both shells: stub scaffolds + idempotent; `skip` writes nothing; catalog degrades gracefully on network/unknown-slug; hook install wires a valid PreToolUse entry.