### PR TITLE
feat(examples): UI/design-system worked example (Facet UI component library)

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Prefer to do it by hand? See [`INSTALL.md`](INSTALL.md).
 ```
 core/         The universal rules — loaded every session. Lean by design (static context).
 profiles/     9 work-type modules — one (or more) gets assembled into CLAUDE.md.
-examples/     5 worked end-to-end projects (filled CLAUDE.md + verify.conf, one bundles a skill).
+examples/     6 worked end-to-end projects (filled CLAUDE.md + verify.conf, two bundle a skill).
 config/       Global settings.json, statusline, MCP examples, the plugin matrix.
 skills/       Skill bundle: how-to, RECOMMENDED map, the 6-skill harness pack + example (--with-skills).
 scripts/      verify.sh (gate), new-research.sh, new-feedback.sh, handoff.sh, secret-scan.sh + leak-gate.sh (+their tests), install-git-hooks.sh.

--- a/docs/07-how-to-pick-a-profile.md
+++ b/docs/07-how-to-pick-a-profile.md
@@ -18,11 +18,12 @@ the core plus one (or a few) profiles.
 | `creative-design` | diagrams, slide decks, brand/visual artifacts, generated images/video |
 | `autonomous-loops` | work that lands with no human checking it first — scheduled/cron agents, `/loop` runs, long unattended orchestrations |
 
-**See one filled in.** Five of these profiles have a complete worked project under
-[`../examples/`](../examples/README.md) — `software-dev` (a FastAPI service, with a bundled skill),
-`document-creation` (a docs site), `data-crunching` (a churn analysis), `devops-setup` (a VPS app
-server), and `marketing-outreach` (a newsletter). Read the one nearest your work to see the end
-state — a filled `CLAUDE.md` project-specifics layer and a real `.harness/verify.conf`.
+**See one filled in.** [`../examples/`](../examples/README.md) has six complete worked projects
+across five profiles — `software-dev` (two: a FastAPI service *and* a React component library, each
+bundling a skill), `document-creation` (a docs site), `data-crunching` (a churn analysis),
+`devops-setup` (a VPS app server), and `marketing-outreach` (a newsletter). Read the one nearest
+your work to see the end state — a filled `CLAUDE.md` project-specifics layer and a real
+`.harness/verify.conf`.
 
 ## Choosing
 
@@ -40,7 +41,8 @@ state — a filled `CLAUDE.md` project-specifics layer and a real `.harness/veri
   `DESIGN.md`: the design system the agent reads before building any screen. Establish it at install
   (`./setup.sh --design-system stub|catalog:<brand>|generate`) or drop one in from the
   [awesome-design-md](https://github.com/VoltAgent/awesome-design-md) catalog, so the UI isn't built
-  ad-hoc and off-brand.
+  ad-hoc and off-brand. See it worked out end to end in
+  [`../examples/ui-component-library/`](../examples/ui-component-library/README.md).
 - **When in doubt**, `general-admin` is the safe catch-all — it assumes outward-facing/irreversible
   actions need confirmation and that summaries must be faithful.
 - You can **re-assemble any time** as a project's focus shifts: re-run `setup.sh --assemble-only`

--- a/docs/11-designing-uis.md
+++ b/docs/11-designing-uis.md
@@ -100,3 +100,8 @@ Four layers, each matched to what it can actually enforce:
 That's the whole loop. It rides the same rails as the rest of the harness — sticky content in
 `CLAUDE.md`, a `[TODO]` surfaced at setup, a durable per-project artifact, and a deterministic guard
 for the mechanical part — so there's nothing new to learn beyond "product UI expects a `DESIGN.md`."
+
+**See it worked out.** [`examples/ui-component-library/`](../examples/ui-component-library/README.md)
+is this whole loop as a finished project — *Facet UI*, a React component library that adopts the
+Linear system from the catalog (`--design-system catalog:linear.app`) and holds every component to
+it, with a bundled `design-review` skill for the judgment pass `verify.sh` can't do.

--- a/docs/12-whats-built-in.md
+++ b/docs/12-whats-built-in.md
@@ -54,9 +54,9 @@ For the reasoning behind any of it, the cross-links point back to the doc that e
   instructions blob for surfaces without on-disk config (web Projects, Cowork). See
   [`13-platforms-and-tools.md`](13-platforms-and-tools.md) for which surfaces need it.
 
-**Two more worth knowing about**, not flags but shipped assets: five **worked example projects**
-in [`examples/`](../examples/README.md) (each a filled `CLAUDE.md` + real `verify.conf` for one
-profile), and **`--self-update`**, which pulls a newer harness and re-assembles your managed
+**Two more worth knowing about**, not flags but shipped assets: six **worked example projects**
+in [`examples/`](../examples/README.md) (each a filled `CLAUDE.md` + real `verify.conf`; two also
+bundle a skill), and **`--self-update`**, which pulls a newer harness and re-assembles your managed
 `CLAUDE.md` blocks in one step (README → "Keeping the harness current").
 
 ## Continuous integration — why, where, and what *not* to run it on

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Worked examples — what a real project looks like
 
-The `profiles/` are the templates; these are five **filled-in projects** built on top of them, so
+The `profiles/` are the templates; these are six **filled-in projects** built on top of them, so
 you can see the end state instead of guessing what to write. Each one is a fictional-but-realistic
 project that uses the layered setup (universal **core** installed once globally, the **profile**
 assembled per project, then a hand-authored **project-specifics** layer on top).
@@ -12,6 +12,7 @@ assembled per project, then a hand-authored **project-specifics** layer on top).
 | [`data-analysis/`](data-analysis/) | `data-crunching` | **Tideline** — a monthly customer-churn analysis (pandas/DuckDB → report). |
 | [`devops-server/`](devops-server/) | `devops-setup` | **Harbor** — a self-hosted app server on a VPS (Docker Compose + Caddy). |
 | [`marketing-newsletter/`](marketing-newsletter/) | `marketing-outreach` | **Dispatch** — a weekly product newsletter & light outreach. |
+| [`ui-component-library/`](ui-component-library/) | `software-dev` | **Facet UI** — a React component library that adopts a catalog design system. Shows the **design-system feature** (`DESIGN.md`) + a **bundled skill**. |
 
 ## What's in each folder
 
@@ -21,8 +22,8 @@ assembled per project, then a hand-authored **project-specifics** layer on top).
   `setup.sh`; this is the part that's unique to the project. Fully filled, no `{{placeholders}}`.
 - **`.harness/verify.conf`** — the project's real definition of "shippable": concrete verify phases
   (the profile's preset, filled with actual commands). One phase per line, first failure stops.
-- **`.claude/skills/…`** (python-service only) — a project-bundled skill, showing that an example
-  can carry its own skills (or plugins) — not just rules.
+- **`.claude/skills/…`** (python-service and ui-component-library) — a project-bundled skill,
+  showing that an example can carry its own skills (or plugins) — not just rules.
 
 ## How to read them
 

--- a/examples/ui-component-library/.claude/skills/design-review/SKILL.md
+++ b/examples/ui-component-library/.claude/skills/design-review/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: design-review
+description: Use when adding or restyling a Facet UI component, or before merging a UI PR — walks the component against DESIGN.md (tokens, states, a11y, contrast, responsive) so the design system is matched, not just remembered. The judgment check verify.sh can't grep.
+---
+
+# Design Review — Facet UI
+
+`verify.sh` proves a component *builds, types, tests, and passes axe*. It cannot prove the component
+**matches the design system** — "is this on-system?" is a judgment call, not a grep (see
+[`docs/11`](../../../../../docs/11-designing-uis.md)). This skill is that judgment pass, as a checklist,
+so a component doesn't ship looking almost-right. It loads only when you're reviewing UI — everyday
+work doesn't pay for it.
+
+## When this fires
+
+You type `/design-review`, or you've added/restyled a component and are about to open or merge the PR.
+
+## Before you start
+
+Open [`DESIGN.md`](../../../DESIGN.md) and keep it beside the diff. Every check below is "does the
+component agree with `DESIGN.md`?" — if you're guessing, you haven't read it recently enough.
+
+## Checklist
+
+Walk these in order. Stop at the first miss, fix it, restart — an off-system component is not "done."
+
+1. **Tokens, not literals.** No raw hex, `px` font sizes, or magic radii in the component — every
+   value resolves to a token in `src/tokens/` that mirrors `DESIGN.md` (`color.primary`,
+   `radius.md`, `type.body`, `space.lg`). A literal `#5e6ad2` or `13px` is a miss even if it looks
+   identical, because the next token change won't reach it.
+2. **All states present and on-system.** Default, hover, active, `:focus-visible`, and disabled —
+   each matching `DESIGN.md` (e.g. a primary button: hover → `primary-hover` `#828fff`, focus → a
+   2px `primary-focus` ring). A missing state is the most common miss; check every interactive part.
+3. **Accessible.** Keyboard-operable, correct ARIA role/name, a **visible** focus ring (never
+   `outline: none` without an equal replacement), and contrast **≥ 4.5:1** for body text (≥ 3:1 for
+   large / UI). `test-storybook`'s axe pass is necessary but not sufficient — eyeball the focus ring.
+4. **Type and spacing scale.** Sizes, weights, line-heights, and letter-spacing come from the type
+   scale; padding/gaps come from the spacing scale. No one-off `600` weight where `DESIGN.md` says
+   `500`, no `10px` gap outside the 4px grid.
+5. **Right surface and elevation.** Backgrounds use the surface ladder (`canvas → surface-1 → …`) and
+   depth is carried by surface + hairline border per `DESIGN.md` — not an invented drop shadow or a
+   skipped surface level.
+6. **Responsive.** The component reflows per the breakpoints and holds touch-target minimums
+   (CTAs ≥ 40px, ≥ 44px on touch). Check the smallest supported width, not just desktop.
+7. **`DESIGN.md` moved with the code (R6).** If you added a new component pattern or variant, its
+   entry exists in `DESIGN.md`'s `components:` section **in this same PR**. If the pattern you needed
+   wasn't in `DESIGN.md`, it should have been added there first — fix the order, don't paper over it.
+8. **Story + test cover the above.** The `.stories.tsx` shows every state (so the a11y/interaction
+   runner and a reviewer both see them); the `.test.tsx` asserts them. A state with no story is a
+   state no one reviews.
+
+## Notes
+
+- If a value you need genuinely isn't in `DESIGN.md`, **stop and establish it there first**, then
+  build — don't invent an off-system value and reconcile later (that's the drift this whole example
+  exists to prevent).
+- Dark-only is intentional: `DESIGN.md` ships no light theme. Don't add light-mode styling here; if
+  it's needed, it's a `DESIGN.md` change first, not a per-component one.
+- This is a review of *adherence*, not correctness — run `scripts/verify.sh` for the mechanical gate.
+  Both have to pass before merge.

--- a/examples/ui-component-library/.harness/verify.conf
+++ b/examples/ui-component-library/.harness/verify.conf
@@ -1,0 +1,12 @@
+# ── software-dev · Facet UI (React component library) ─────────────────────────
+# "Shippable" = it formats clean, lints clean, types check, tests pass, the library builds,
+# and the components pass their accessibility + interaction checks.
+# Phases run top-to-bottom; the FIRST failure stops the run (fix it, re-run — don't skip ahead).
+# Note: adherence to DESIGN.md is deliberately NOT a phase here — it's a judgment call held by the
+# profile rule + the bundled design-review skill, not a grep (see ./README.md and docs/11).
+format :: prettier --check .
+lint   :: eslint .
+types  :: tsc --noEmit
+test   :: vitest run
+build  :: tsup src/index.ts --dts --format esm,cjs
+a11y   :: test-storybook

--- a/examples/ui-component-library/CLAUDE.md
+++ b/examples/ui-component-library/CLAUDE.md
@@ -1,0 +1,112 @@
+# Project: Facet UI
+
+Facet UI is a small in-house **React component library** — the shared buttons, inputs, cards,
+tabs, badges, and nav that every internal app builds screens from. It is a UI project, so its
+"user-facing surface" is the rendered components and the design system they implement. That design
+system is **adopted, not invented**: it's the **Linear** system pulled from the
+[awesome-design-md](https://github.com/VoltAgent/awesome-design-md) catalog and it lives in
+[`DESIGN.md`](DESIGN.md) at the project root (see that file's header). Operator: **Devon Rhodes**
+(frontend engineer). Work is tracked as **GitHub** issues and PRs.
+
+## Stack & layout
+
+- **React 18 + TypeScript** (strict), built as a library (ESM + CJS + `.d.ts`) with **tsup**.
+- **Storybook** for component dev/docs; **Vitest** + **Testing Library** for unit/interaction
+  tests; **@storybook/test-runner** (`test-storybook`) for accessibility + play-function checks.
+- **ESLint** + **Prettier**; **Changesets** for versioning the public package.
+- **Design tokens** in `src/tokens/` are the code mirror of `DESIGN.md` — one source, two forms.
+- Key directories/files:
+  - `DESIGN.md` — the design system (the adopted Linear system). The spec every component matches.
+  - `src/tokens/` — colors, type, spacing, radius as TS tokens, derived from `DESIGN.md`.
+  - `src/components/<Name>/` — one folder per component: `<Name>.tsx`, `<Name>.stories.tsx`,
+    `<Name>.test.tsx`, `index.ts`.
+  - `src/index.ts` — the public barrel; what consumers import. This file *is* the API surface.
+  - `.harness/verify.conf` — the verify phases; `scripts/verify.sh` runs them in order.
+
+## What "done" means here
+
+The profile's loop (read → failing test → implement → verify → commit) and its two-gate "verified"
+(within-a-layer **and** across-layers) apply as-is — and because this is UI, the profile's
+**"read `DESIGN.md` before any UI change and match it"** rule is live. Facet sharpens all of that:
+
+- **Tokens are the single source — no raw hex in components.** Every color, space, radius, and type
+  value comes from `src/tokens/` (which mirror `DESIGN.md`). A literal `#5e6ad2` typed into a
+  component is a bug even if it looks right, because the next token change won't reach it. If a value
+  you need isn't a token, it isn't in the design system yet — add it to `DESIGN.md` first.
+- **Every interactive component ships all its states.** Default, hover, active, `:focus-visible`,
+  and disabled — matching `DESIGN.md` (e.g. `button-primary` → hover `#828fff`, a 2px
+  `primary-focus` focus ring). A component missing `:focus-visible` is not done, it's half-drawn.
+- **Accessible by default.** Keyboard-operable, correct ARIA role/name, a **visible focus ring**
+  (never `outline: none` without an equal replacement), and contrast **≥ 4.5:1** for body text
+  (≥ 3:1 for large). The `a11y` verify phase (Storybook a11y addon via `test-storybook`) is the
+  deterministic floor; it does not replace reading `DESIGN.md`.
+- **A component = its story + its test.** The `.stories.tsx` is the living doc *and* the surface the
+  a11y/interaction runner exercises; the `.test.tsx` asserts behavior and the states above. No
+  component lands without both.
+- **The public API is the contract.** Exported prop types are semver-relevant. Renaming/removing a
+  prop, or adding a *required* one, is a **breaking change** → a Changeset + a `CHANGELOG` entry in
+  the **same** PR (R6). Consumers pin to this; a silent prop rename is the front-end version of the
+  API-contract drift the profile's R3 trace catches.
+- **`DESIGN.md` moves with the code (R6).** Add, rename, or restyle a component pattern and you
+  update `DESIGN.md`'s `components:` section in the *same* commit. The spec and the code drift apart
+  the instant one moves without the other — and here the spec is what the next agent reads first.
+
+A concrete across-layers trace (the R3 five-liner, in the PR body before commit) for the accent
+color: `DESIGN.md` declares `primary: "#5e6ad2"` → `src/tokens/color.ts` exports it as
+`color.primary` → `<Button variant="primary">` sets its background to `color.primary` → the Button
+story renders that exact lavender → a consuming app imports `Button` and sees the same lavender on
+its CTA. If the token is right in `DESIGN.md` but a component hardcodes a different hex, only the
+trace — not a green unit test — catches that the CTA is off-system.
+
+## verify.conf phases
+
+`scripts/verify.sh` reads `.harness/verify.conf` and runs these top-to-bottom; the **first failure
+stops the run** so you fix the earliest break instead of chasing a cascade:
+
+1. **`format` — `prettier --check .`** — mechanical and cheapest; a diff means "run `prettier`,"
+   not "think." Runs first so nothing downstream argues about whitespace.
+2. **`lint` — `eslint .`** — unused imports, bad hooks deps, a11y lint rules (`eslint-plugin-jsx-a11y`)
+   before the slower type/test phases spend time on code we already know is wrong.
+3. **`types` — `tsc --noEmit`** — the prop types *are* the public contract; `tsc` catches a changed
+   or missing prop type statically, cheaper than a test run, and guards the semver promise above.
+4. **`test` — `vitest run`** — the full unit/interaction suite. Run the *whole* suite, not just your
+   new test (R5) — a shared token change can break a component you didn't touch.
+5. **`build` — `tsup src/index.ts --dts --format esm,cjs`** — actually bundle the library. This is
+   the cheapest catch for a broken **public export** (a component removed from `src/index.ts`, a
+   type that doesn't emit) — a thing unit tests pass right over.
+6. **`a11y` — `test-storybook`** — last, because it needs the built stories running: the Storybook
+   test-runner executes each story's play function and the a11y addon (axe) against the real DOM.
+   This is the deterministic part of "accessible by default"; the judgment part is the design-review
+   skill below.
+
+## Conventions
+
+- **Commit scope = the area touched:** `feat(button): …`, `fix(tokens): …`, `feat(card): …`,
+  `docs(design): …` (a `DESIGN.md` change), `chore(release): …`. The message says WHY (profile R4).
+- **One component per PR.** A button change and a card change are two PRs — atomic, reviewable,
+  revertible.
+- **Story + test are colocated** with the component and are part of the change, never a follow-up.
+- **No off-token values.** Colors/space/radius/type come from `src/tokens/`; a raw hex or a magic
+  `13px` in a component fails review even if `verify.sh` is green (that's what design-review is for).
+- **Every public change ships a Changeset.** `npx changeset` in the same PR; the changelog is
+  generated from these, so callers see breaking vs. additive at a glance.
+
+## Gotchas & decisions
+
+- **The design system is adopted from the catalog, not authored here.** `DESIGN.md` is the Linear
+  system fetched by `--design-system catalog:linear.app` (see its header). If you fork Facet for a
+  different brand, **adapt `DESIGN.md` first** (palette, type, name) — then the tokens, then the
+  components. Don't diverge the components from `DESIGN.md` and backfill the spec later.
+- **We don't ship the proprietary fonts.** `DESIGN.md`'s Typography note calls Linear's typefaces
+  proprietary and names substitutes; Facet uses **Inter** (500/600/700) and **JetBrains Mono**. The
+  token file records the substitute so no component reaches for an unavailable family.
+- **Never delete a focus outline for looks.** An early card grid set `outline: none` for a "cleaner"
+  look and shipped a keyboard-untraversable form. `:focus-visible` styling is mandatory and the
+  `a11y` phase now fails on a missing focus indicator — this is why that rule rarely needs a human.
+- **`test-storybook` needs Storybook running.** CI builds Storybook and serves it before the `a11y`
+  phase; locally, run `storybook dev` in another terminal first, or the phase errors on connection,
+  not on a real a11y failure.
+- **Dark-only, on purpose.** `DESIGN.md` documents no light theme ("Don't ship a light-mode…") and
+  lists it as a known gap. Don't invent light tokens ad-hoc; if light mode is needed, **establish it
+  in `DESIGN.md` first** (the profile's "missing/incomplete design system ⇒ stop and establish" rule),
+  then implement.

--- a/examples/ui-component-library/DESIGN.md
+++ b/examples/ui-component-library/DESIGN.md
@@ -1,0 +1,568 @@
+<!--
+  DESIGN.md — the design system for Facet UI (this example project).
+
+  Facet UI is a fictional in-house React component library. For this worked example it ADOPTS a
+  ready-made design system from the awesome-design-md catalog — the Linear system — exactly as the
+  harness scaffolds it (path #2, "pick a ready-made one"):
+
+      ./setup.sh --profile software-dev --design-system catalog:linear.app --with-ui-design-hook --target .
+
+  Everything below this comment is that catalog file, unmodified. It is the single source of truth
+  for how every Facet component looks: the agent reads it BEFORE writing or changing any component
+  and matches it (colors, type, spacing, components, states). See ./README.md for the workflow and
+  ./CLAUDE.md for how "done" is sharpened for a component library.
+
+  Source:  https://github.com/VoltAgent/awesome-design-md  (design-md/linear.app/DESIGN.md)
+  License: MIT © VoltAgent (awesome-design-md). Reproduced here under MIT for illustration. "Linear"
+  and its design language are trademarks of Linear Orbit, Inc.; this is a community design analysis,
+  not an official Linear asset. To make it your own, adapt the palette / type / name to your brand
+  (the proprietary Linear typefaces are NOT shipped — see the font-substitute note in Typography).
+-->
+---
+version: alpha
+name: Linear-design-analysis
+description: "A near-black product-focused marketing canvas built around #010102 (the deepest dark surface of any tool in this collection), light gray text (#f7f8f8), and the signature Linear lavender-blue (#5e6ad2) used as the single chromatic accent. The system reads as software-craft documentation: dense, technical, and quietly luxurious. Display type is set in the Linear custom sans (SF Pro Display fallback) at 500–700 with measured negative tracking. Cards live as charcoal panels (#0f1011) with hairline borders. The accent lavender appears on the brand mark, focus rings, and a few intentional CTAs — never decoratively. Page rhythm leans on product UI screenshots framed in dark panels rather than atmospheric color."
+
+colors:
+  primary: "#5e6ad2"
+  on-primary: "#ffffff"
+  primary-hover: "#828fff"
+  primary-focus: "#5e69d1"
+  ink: "#f7f8f8"
+  ink-muted: "#d0d6e0"
+  ink-subtle: "#8a8f98"
+  ink-tertiary: "#62666d"
+  canvas: "#010102"
+  surface-1: "#0f1011"
+  surface-2: "#141516"
+  surface-3: "#18191a"
+  surface-4: "#191a1b"
+  hairline: "#23252a"
+  hairline-strong: "#34343a"
+  hairline-tertiary: "#3e3e44"
+  inverse-canvas: "#ffffff"
+  inverse-surface-1: "#f5f6f6"
+  inverse-surface-2: "#f6f7f7"
+  inverse-ink: "#000000"
+  brand-secure: "#7a7fad"
+  semantic-success: "#27a644"
+  semantic-overlay: "#000000"
+
+typography:
+  display-xl:
+    fontFamily: Linear Display
+    fontSize: 80px
+    fontWeight: 600
+    lineHeight: 1.05
+    letterSpacing: -3.0px
+  display-lg:
+    fontFamily: Linear Display
+    fontSize: 56px
+    fontWeight: 600
+    lineHeight: 1.10
+    letterSpacing: -1.8px
+  display-md:
+    fontFamily: Linear Display
+    fontSize: 40px
+    fontWeight: 600
+    lineHeight: 1.15
+    letterSpacing: -1.0px
+  headline:
+    fontFamily: Linear Display
+    fontSize: 28px
+    fontWeight: 600
+    lineHeight: 1.20
+    letterSpacing: -0.6px
+  card-title:
+    fontFamily: Linear Display
+    fontSize: 22px
+    fontWeight: 500
+    lineHeight: 1.25
+    letterSpacing: -0.4px
+  subhead:
+    fontFamily: Linear Display
+    fontSize: 20px
+    fontWeight: 400
+    lineHeight: 1.40
+    letterSpacing: -0.2px
+  body-lg:
+    fontFamily: Linear Text
+    fontSize: 18px
+    fontWeight: 400
+    lineHeight: 1.50
+    letterSpacing: -0.1px
+  body:
+    fontFamily: Linear Text
+    fontSize: 16px
+    fontWeight: 400
+    lineHeight: 1.50
+    letterSpacing: -0.05px
+  body-sm:
+    fontFamily: Linear Text
+    fontSize: 14px
+    fontWeight: 400
+    lineHeight: 1.50
+    letterSpacing: 0
+  caption:
+    fontFamily: Linear Text
+    fontSize: 12px
+    fontWeight: 400
+    lineHeight: 1.40
+    letterSpacing: 0
+  button:
+    fontFamily: Linear Text
+    fontSize: 14px
+    fontWeight: 500
+    lineHeight: 1.20
+    letterSpacing: 0
+  eyebrow:
+    fontFamily: Linear Text
+    fontSize: 13px
+    fontWeight: 500
+    lineHeight: 1.30
+    letterSpacing: 0.4px
+  mono:
+    fontFamily: Linear Mono
+    fontSize: 13px
+    fontWeight: 400
+    lineHeight: 1.50
+    letterSpacing: 0
+
+rounded:
+  xs: 4px
+  sm: 6px
+  md: 8px
+  lg: 12px
+  xl: 16px
+  xxl: 24px
+  pill: 9999px
+  full: 9999px
+
+spacing:
+  xxs: 4px
+  xs: 8px
+  sm: 12px
+  md: 16px
+  lg: 24px
+  xl: 32px
+  xxl: 48px
+  section: 96px
+
+components:
+  button-primary:
+    backgroundColor: "{colors.primary}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.button}"
+    rounded: "{rounded.md}"
+    padding: 8px 14px
+  button-primary-pressed:
+    backgroundColor: "{colors.primary-focus}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.button}"
+    rounded: "{rounded.md}"
+  button-primary-hover:
+    backgroundColor: "{colors.primary-hover}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.button}"
+    rounded: "{rounded.md}"
+  button-secondary:
+    backgroundColor: "{colors.surface-1}"
+    textColor: "{colors.ink}"
+    typography: "{typography.button}"
+    rounded: "{rounded.md}"
+    padding: 8px 14px
+  button-tertiary:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.button}"
+    rounded: "{rounded.md}"
+    padding: 8px 14px
+  button-inverse:
+    backgroundColor: "{colors.inverse-canvas}"
+    textColor: "{colors.inverse-ink}"
+    typography: "{typography.button}"
+    rounded: "{rounded.md}"
+    padding: 8px 14px
+  pricing-card:
+    backgroundColor: "{colors.surface-1}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body}"
+    rounded: "{rounded.lg}"
+    padding: 24px
+  pricing-card-featured:
+    backgroundColor: "{colors.surface-2}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body}"
+    rounded: "{rounded.lg}"
+    padding: 24px
+  feature-card:
+    backgroundColor: "{colors.surface-1}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body}"
+    rounded: "{rounded.lg}"
+    padding: 24px
+  product-screenshot-card:
+    backgroundColor: "{colors.surface-1}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body}"
+    rounded: "{rounded.xl}"
+    padding: 24px
+  testimonial-card:
+    backgroundColor: "{colors.surface-1}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-lg}"
+    rounded: "{rounded.lg}"
+    padding: 32px
+  customer-logo-tile:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink-subtle}"
+    typography: "{typography.caption}"
+    rounded: "{rounded.xs}"
+    padding: 16px
+  text-input:
+    backgroundColor: "{colors.surface-1}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body}"
+    rounded: "{rounded.md}"
+    padding: 8px 12px
+  text-input-focused:
+    backgroundColor: "{colors.surface-1}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body}"
+    rounded: "{rounded.md}"
+    padding: 8px 12px
+  pricing-tab-default:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink-subtle}"
+    typography: "{typography.button}"
+    rounded: "{rounded.pill}"
+    padding: 6px 14px
+  pricing-tab-selected:
+    backgroundColor: "{colors.surface-2}"
+    textColor: "{colors.ink}"
+    typography: "{typography.button}"
+    rounded: "{rounded.pill}"
+    padding: 6px 14px
+  cta-banner:
+    backgroundColor: "{colors.surface-1}"
+    textColor: "{colors.ink}"
+    typography: "{typography.headline}"
+    rounded: "{rounded.lg}"
+    padding: 48px
+  changelog-row:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body}"
+    rounded: "{rounded.xs}"
+    padding: 24px 0
+  status-badge:
+    backgroundColor: "{colors.surface-2}"
+    textColor: "{colors.ink-muted}"
+    typography: "{typography.caption}"
+    rounded: "{rounded.pill}"
+    padding: 2px 8px
+  top-nav:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-sm}"
+    rounded: "{rounded.xs}"
+    height: 56px
+  footer:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink-subtle}"
+    typography: "{typography.caption}"
+    rounded: "{rounded.xs}"
+    padding: 64px 32px
+---
+
+## Overview
+
+Linear's marketing canvas is the deepest dark surface in this collection — `{colors.canvas}` is #010102, essentially pure black with a faint blue tint. On top sits a four-step surface ladder (`{colors.surface-1}` through `{colors.surface-4}`) for cards, panels, and lifted tiles, with hairline borders running from `{colors.hairline}` (#23252a) up through `{colors.hairline-strong}` and `{colors.hairline-tertiary}`. Light gray text (`{colors.ink}` #f7f8f8) carries the body and headlines.
+
+The single chromatic accent is **Linear lavender-blue** `{colors.primary}` (#5e6ad2) — used on the brand mark, focus rings, and the primary CTA button. A lighter hover state (`{colors.primary-hover}` #828fff) and a focus-tinted variant (`{colors.primary-focus}` #5e69d1) extend the same hue. Linear avoids saturated greens, oranges, reds, etc. on the marketing canvas — the only semantic color is `{colors.semantic-success}` (#27a644) for status pills and the rare success indicator.
+
+Display type runs Linear's custom sans (with `SF Pro Display` fallback) at weight 500–700 with negative letter-spacing scaling from -3.0px at 80px down to 0 at body. The body family is Linear's text cut, and a Linear Mono is reserved for code snippets in product screenshots.
+
+The page rhythm is **dense product screenshots** — Linear's marketing leads with high-fidelity captures of the product UI (issue list, project view, dashboard) framed in `{colors.surface-1}` panels with `{rounded.xl}` 16px corners. The chrome is intentionally minimal so the app screenshots can do the heavy lifting.
+
+**Key Characteristics:**
+- **Dark-canvas marketing system** — `{colors.canvas}` (#010102) is the deepest dark in this collection.
+- **Lavender-blue brand accent** (`{colors.primary}` #5e6ad2) — used scarcely on brand mark, focus, and the primary CTA.
+- Four-step surface ladder (canvas → surface-1 → surface-2 → surface-3 → surface-4) carries hierarchy without shadow.
+- Display tracking pulls aggressively negative (-3.0px at 80px); body holds at -0.05px.
+- Cards use `{rounded.lg}` 12px corners with 1px hairline borders — never pill, rarely 16px.
+- **Product UI screenshots** dominate the page. The marketing chrome is a dark frame for the app.
+- No second chromatic color. No atmospheric gradients. No spotlight cards.
+
+## Colors
+
+> Source pages: linear.app (home), /intake, /pricing, /contact/sales, /build.
+
+### Brand & Accent
+- **Lavender-Blue** ({colors.primary}): The signature Linear accent — primary CTA, brand mark, link emphasis.
+- **Lavender Hover** ({colors.primary-hover}): Lighter lavender (#828fff) — hovered state of the primary CTA.
+- **Lavender Focus** ({colors.primary-focus}): Focus-ring tint (#5e69d1) — focused inputs, focused buttons.
+- **Brand Secure** ({colors.brand-secure}): Muted lavender-gray (#7a7fad) — used in "Linear Security" surfaces.
+
+### Surface
+- **Canvas** ({colors.canvas}): Default page background — #010102, near-pure black with a faint blue tint.
+- **Surface 1** ({colors.surface-1}): One step above canvas — feature cards, pricing cards, product screenshot panels.
+- **Surface 2** ({colors.surface-2}): Two steps above — featured pricing card, hovered cards.
+- **Surface 3** ({colors.surface-3}): Three steps above — line-tertiary backgrounds, sub-nav.
+- **Surface 4** ({colors.surface-4}): Four steps above — bg-level-3, deepest lifted surface.
+- **Hairline** ({colors.hairline}): 1px borders on cards and dividers.
+- **Hairline Strong** ({colors.hairline-strong}): Stronger 1px borders — input focus rings.
+- **Hairline Tertiary** ({colors.hairline-tertiary}): Tertiary borders for nested surfaces.
+- **Inverse Canvas** ({colors.inverse-canvas}): Pure white — surface of the inverse pill CTA on a small set of section openers.
+- **Inverse Surface 1** ({colors.inverse-surface-1}): One step above inverse canvas.
+- **Inverse Surface 2** ({colors.inverse-surface-2}): Two steps above inverse canvas.
+
+### Text
+- **Ink** ({colors.ink}): All headlines and emphasized body type — light gray #f7f8f8.
+- **Ink Muted** ({colors.ink-muted}): Secondary type at #d0d6e0 — meta info on hero panels.
+- **Ink Subtle** ({colors.ink-subtle}): Tertiary type at #8a8f98 — deselected pricing tabs, footer columns.
+- **Ink Tertiary** ({colors.ink-tertiary}): Quaternary at #62666d — disabled, footnotes.
+
+### Semantic
+- **Success Green** ({colors.semantic-success}): Status pills, success indicators. The only semantic color on marketing.
+- **Overlay** ({colors.semantic-overlay}): Pure black overlay scrim for modals.
+
+## Typography
+
+### Font Family
+
+- **Linear Display** — Linear's custom display sans; fallback `SF Pro Display, -apple-system, system-ui, Segoe UI, Roboto`. Carries display-xl through subhead.
+- **Linear Text** — Linear's custom text sans (a slightly different cut tuned for body sizes); same fallback stack. Carries body sizes, button labels, captions.
+- **Linear Mono** — Linear's custom mono; fallback `ui-monospace, SF Mono, Menlo`. Used for code snippets in product screenshots and for status / ID tokens.
+
+The marketing surface treats Display and Text as one continuous voice; the family change is silent.
+
+### Hierarchy
+
+| Token | Size | Weight | Line Height | Letter Spacing | Use |
+|---|---|---|---|---|---|
+| `{typography.display-xl}` | 80px | 600 | 1.05 | -3.0px | Largest hero headline |
+| `{typography.display-lg}` | 56px | 600 | 1.10 | -1.8px | Section opener headlines |
+| `{typography.display-md}` | 40px | 600 | 1.15 | -1.0px | Sub-section headlines |
+| `{typography.headline}` | 28px | 600 | 1.20 | -0.6px | Pricing tier titles, CTA banner heading |
+| `{typography.card-title}` | 22px | 500 | 1.25 | -0.4px | Feature card title |
+| `{typography.subhead}` | 20px | 400 | 1.40 | -0.2px | Lead body, intro paragraphs |
+| `{typography.body-lg}` | 18px | 400 | 1.50 | -0.1px | Hero subhead, lead paragraphs |
+| `{typography.body}` | 16px | 400 | 1.50 | -0.05px | Default body |
+| `{typography.body-sm}` | 14px | 400 | 1.50 | 0 | Card body, footer columns |
+| `{typography.caption}` | 12px | 400 | 1.40 | 0 | Captions, meta, status |
+| `{typography.button}` | 14px | 500 | 1.20 | 0 | All button labels |
+| `{typography.eyebrow}` | 13px | 500 | 1.30 | 0.4px | Section eyebrow (slight positive tracking) |
+| `{typography.mono}` | 13px | 400 | 1.50 | 0 | Linear Mono for code in product screenshots |
+
+### Principles
+
+- **Aggressive negative tracking on display** (-3.0px at 80px ≈ 4% of size).
+- **Single voice from display to body.** Display-xl at 600 → body at 400 — same family, narrower weights.
+- **Eyebrow uses positive tracking** (+0.4px) — contrast against the negative-tracked display marks the eyebrow as taxonomy.
+- **Mono only in code contexts.** Linear Mono lives inside product screenshots — not on marketing chrome.
+
+### Note on Font Substitutes
+
+Linear's custom typeface isn't publicly distributed; the documented fallback `SF Pro Display, -apple-system, system-ui` is the recommended substitute on macOS. For cross-platform implementation, **Inter** at weight 500 / 600 / 700 is the closest free substitute. **Geist Sans** is also viable. For mono, **JetBrains Mono** or **Geist Mono** at weight 400 closely approximates Linear Mono.
+
+## Layout
+
+### Spacing System
+
+- **Base unit**: 4px.
+- **Tokens (front matter)**: `{spacing.xxs}` 4px · `{spacing.xs}` 8px · `{spacing.sm}` 12px · `{spacing.md}` 16px · `{spacing.lg}` 24px · `{spacing.xl}` 32px · `{spacing.xxl}` 48px · `{spacing.section}` 96px.
+- Card interior padding: `{spacing.lg}` 24px on feature/pricing cards; `{spacing.xl}` 32px on testimonial cards; `{spacing.xxl}` 48px on CTA banners.
+- Pill button padding: 8px vertical · 14px horizontal — Linear's compact button spec.
+- Form input padding: 8px vertical · 12px horizontal.
+
+### Grid & Container
+
+- Max content width sits around 1280px.
+- Card grids are 3-up at desktop, 2-up at tablet, 1-up at mobile.
+- Pricing tier grid is 3-up; comparison strip below shows checkmarks per tier.
+- Product screenshot panels span full content width — they're the protagonist.
+
+### Whitespace Philosophy
+
+The dark canvas IS the whitespace. Sections separate by lift onto surface-1 panels, not by gaps in white. Within a panel, generous `{spacing.lg}` 24px gaps between content blocks; `{spacing.section}` 96px between sections.
+
+## Elevation & Depth
+
+| Level | Treatment | Use |
+|---|---|---|
+| 0 (flat) | No shadow, no border | Default for body type, hero text, footer |
+| 1 (charcoal lift) | `{colors.surface-1}` background on canvas, 1px `{colors.hairline}` | Default cards, product panels |
+| 2 (surface-2 lift) | `{colors.surface-2}` background, 1px `{colors.hairline-strong}` | Featured pricing card, hovered cards |
+| 3 (surface-3 lift) | `{colors.surface-3}` background | Sub-nav, dropdown menus |
+| 4 (focus ring) | 2px `{colors.primary-focus}` outline at 50% opacity | Focused input, focused button |
+
+Linear's depth is carried by surface ladder + hairline borders. The brand resists drop shadows on dark almost entirely.
+
+### Decorative Depth
+
+- **Product UI screenshots** dominate as decorative depth.
+- **No atmospheric gradients, no spotlight cards.**
+- **Subtle white edge highlight** on the top edge of lifted panels — gives the dark surface a faint "pixel rendered" feel.
+
+## Shapes
+
+### Border Radius Scale
+
+| Token | Value | Use |
+|---|---|---|
+| `{rounded.xs}` | 4px | Small chips, status badges |
+| `{rounded.sm}` | 6px | Inline tags |
+| `{rounded.md}` | 8px | All buttons, form inputs |
+| `{rounded.lg}` | 12px | Pricing cards, feature cards, testimonial cards |
+| `{rounded.xl}` | 16px | Product screenshot panels |
+| `{rounded.xxl}` | 24px | Oversized CTA banners (rare) |
+| `{rounded.pill}` | 9999px | Pricing tab toggles, status pills |
+| `{rounded.full}` | 9999px | Avatar circles |
+
+### Photography & Illustration Geometry
+
+- Product UI screenshots dominate; they sit in `{rounded.xl}` 16px tiles with `{spacing.lg}` 24px outer padding.
+- Customer logo tiles render at small sizes (~24px logo height) on `{colors.canvas}` with no border.
+- Avatar circles in testimonial cards use `{rounded.full}` at 32–40px sizes.
+
+## Components
+
+### Buttons
+
+**`button-primary`** — Lavender CTA. The default primary CTA across all pages.
+- Background `{colors.primary}`, text `{colors.on-primary}`, type `{typography.button}`, padding 8px 14px, rounded `{rounded.md}`.
+- Pressed state lives in `button-primary-pressed` (background shifts to `{colors.primary-focus}`).
+- Hover state lives in `button-primary-hover` (background shifts to `{colors.primary-hover}` lighter lavender).
+
+**`button-secondary`** — Charcoal button. Used for secondary CTAs ("Sign in", "Read changelog").
+- Background `{colors.surface-1}`, text `{colors.ink}`, type `{typography.button}`, padding 8px 14px, rounded `{rounded.md}`. 1px `{colors.hairline}` border.
+
+**`button-tertiary`** — Plain text button.
+- Background `{colors.canvas}`, text `{colors.ink}`, type `{typography.button}`, rounded `{rounded.md}`, padding 8px 14px.
+
+**`button-inverse`** — White-on-dark inverse CTA.
+- Background `{colors.inverse-canvas}`, text `{colors.inverse-ink}`, type `{typography.button}`, rounded `{rounded.md}`, padding 8px 14px.
+
+### Pricing Tabs
+
+**`pricing-tab-default`** + **`pricing-tab-selected`** — Pill-toggle on `/pricing`.
+- Default: `{colors.canvas}` background, `{colors.ink-subtle}` text, rounded `{rounded.pill}`, padding 6px 14px.
+- Selected: `{colors.surface-2}` background, `{colors.ink}` text — selected = surface lift.
+
+### Cards & Containers
+
+**`pricing-card`** — Each tier on `/pricing`.
+- Background `{colors.surface-1}`, text `{colors.ink}`, type `{typography.body}`, rounded `{rounded.lg}`, padding 24px. 1px `{colors.hairline}` border.
+
+**`pricing-card-featured`** — Recommended tier — surface lift to surface-2.
+- Background `{colors.surface-2}`, otherwise identical structure.
+
+**`feature-card`** — Generic feature highlight tile.
+- Background `{colors.surface-1}`, text `{colors.ink}`, type `{typography.body}`, rounded `{rounded.lg}`, padding 24px.
+
+**`product-screenshot-card`** — The dominant card type — frames a high-fidelity Linear app UI screenshot.
+- Background `{colors.surface-1}`, text `{colors.ink}`, type `{typography.body}`, rounded `{rounded.xl}`, padding 24px.
+
+**`testimonial-card`** — Customer quote with avatar + name + role.
+- Background `{colors.surface-1}`, text `{colors.ink}`, type `{typography.body-lg}`, rounded `{rounded.lg}`, padding 32px.
+
+**`customer-logo-tile`** — Small tile in the customer marquee.
+- Background `{colors.canvas}`, text `{colors.ink-subtle}`, type `{typography.caption}`, rounded `{rounded.xs}`, padding 16px.
+
+**`cta-banner`** — Closing CTA panel near page bottom.
+- Background `{colors.surface-1}`, text `{colors.ink}`, type `{typography.headline}`, rounded `{rounded.lg}`, padding 48px.
+
+### Inputs & Forms
+
+**`text-input`** + **`text-input-focused`** — Form fields on `/contact/sales` and signup overlays.
+- Background `{colors.surface-1}`, text `{colors.ink}`, type `{typography.body}`, rounded `{rounded.md}`, padding 8px 12px.
+- Focused state retains the same surface; the focus ring is a 2px `{colors.primary-focus}` outline at 50% opacity.
+
+### Status & Build Page
+
+**`changelog-row`** — Each row in `/build` (changelog page) listing version, date, and changes.
+- Background `{colors.canvas}`, text `{colors.ink}`, type `{typography.body}`, rounded `{rounded.xs}`, padding 24px 0. 1px `{colors.hairline}` bottom rule.
+
+**`status-badge`** — Small status pill.
+- Background `{colors.surface-2}`, text `{colors.ink-muted}`, type `{typography.caption}`, rounded `{rounded.pill}`, padding 2px 8px.
+
+### Navigation
+
+**`top-nav`** — Sticky dark bar with the Linear wordmark left, primary nav links centered, and a `button-secondary` ("Sign in") + `button-primary` ("Get started") pair right.
+- Background `{colors.canvas}`, text `{colors.ink}`, type `{typography.body-sm}`, height 56px.
+
+### Footer
+
+**`footer`** — Dense link grid on `{colors.canvas}` with the Linear wordmark left.
+- Background `{colors.canvas}`, text `{colors.ink-subtle}`, type `{typography.caption}`, padding 64px 32px.
+
+## Do's and Don'ts
+
+### Do
+
+- Reserve `{colors.canvas}` (#010102) as the system's anchor surface — the faint blue tint is intentional.
+- Use `{colors.primary}` lavender ONLY for: brand mark, primary CTA, focus ring, link emphasis.
+- Use the four-step surface ladder for hierarchy. Avoid skipping levels.
+- Pair display weight 600 with body weight 400 — Linear resists 700+ display weights.
+- Apply negative letter-spacing aggressively on display.
+- Use product UI screenshots as the protagonist of every section.
+- Compose CTAs as `{rounded.md}` 8px corners.
+
+### Don't
+
+- Don't ship a light-mode marketing page.
+- Don't use lavender as a section background or card fill.
+- Don't introduce a second chromatic accent (orange, pink, green for marketing).
+- Don't add atmospheric gradients or spotlight cards.
+- Don't pill-round CTAs.
+- Don't use `#000000` true black as the canvas.
+- Don't combine multiple bright accents in product screenshot mockups.
+
+## Responsive Behavior
+
+### Breakpoints
+
+| Name | Width | Key Changes |
+|---|---|---|
+| Desktop-XL | 1440px | Default desktop layout |
+| Desktop | 1280px | Card grid 3-up maintained |
+| Tablet | 1024px | Card grid 3-up → 2-up |
+| Mobile-Lg | 768px | Pricing comparison becomes accordion; nav hamburger |
+| Mobile | 480px | Single-column; display-xl scales 80px → ~36px |
+
+### Touch Targets
+
+- CTAs hold ≥40px tap height across viewports.
+- Pricing tab pills hold ≥36px tap height; touch viewports grow to ≥44px.
+- Form inputs hold ≥44px tap target on touch.
+
+### Collapsing Strategy
+
+- **Top nav**: links collapse to hamburger below 768px.
+- **Card grids**: 3-up → 2-up at 1024px → 1-up below 768px.
+- **Pricing comparison**: per-tier accordion below 768px.
+- **Display type**: `{typography.display-xl}` 80px scales toward `{typography.display-md}` 40px on mobile.
+
+### Image Behavior
+
+- Product UI screenshots maintain aspect ratio and never crop.
+- Customer logos in the marquee may collapse from 6-up to 3-up below 768px.
+
+## Iteration Guide
+
+1. Focus on ONE component at a time and reference it by its `components:` token name.
+2. When introducing a section, decide first which surface lift it lives on.
+3. Default body to `{typography.body}` at weight 400.
+4. Run `npx @google/design.md lint DESIGN.md` after edits.
+5. Add new variants as separate component entries.
+6. Treat lavender as scarce: brand mark, primary CTA, focus, link emphasis.
+7. Lead every section with a product UI screenshot.
+
+## Known Gaps
+
+- The four-step surface ladder values are extracted directly from Linear's `--color-bg-level-3`, `--color-line-tint`, etc. CSS variables; they are Linear's canonical surface spec.
+- Form-field error and validation styling is not visible on the inspected pages.
+- Light mode is not documented because the marketing site does not ship a light theme.
+- Linear's actual product UI uses a richer color-tag palette (red, orange, yellow, green, blue, purple) for issue priorities and project labels — those colors live in the in-product surfaces shown in mockups.
+- The custom display, text, and mono families are proprietary; an open-source substitute is acceptable.

--- a/examples/ui-component-library/README.md
+++ b/examples/ui-component-library/README.md
@@ -1,0 +1,62 @@
+# Example: Facet UI — React component library (software-dev profile)
+
+**Scenario.** Facet UI is a small in-house **React component library** — TypeScript, built with
+tsup, documented in Storybook, tested with Vitest. It's the shared button/input/card/nav kit every
+internal app builds screens from. The operator is Devon Rhodes, a frontend engineer who tracks work
+as GitHub issues/PRs. This folder shows what the harness looks like *layered onto a UI project*:
+the universal core is installed globally on Devon's machine, and the project carries the software-dev
+profile, a **design system adopted from a catalog**, and the UI-edit nudge hook.
+
+This is the harness's **design-system feature** worked out end to end. Product UI is `software-dev`
+work (not `creative-design`) — see [`docs/11-designing-uis.md`](../../docs/11-designing-uis.md) — and
+UI has a correctness axis backend code doesn't: every screen must speak one visual language. The
+harness names that axis in a root [`DESIGN.md`](DESIGN.md) and holds the UI to it.
+
+**Set it up like this:**
+
+```bash
+# 1) Install the universal core once, globally (Devon's machine, all projects):
+./setup.sh --global --operator-name "Devon Rhodes" --operator-role "frontend engineer"
+
+# 2) Layer software-dev onto THIS repo, ADOPT a ready-made design system from the catalog, and
+#    install the UI-edit nudge hook (no core copied in — core is global):
+./setup.sh --profile software-dev --profile-only --target . \
+  --operator-name "Devon Rhodes" --operator-role "frontend engineer" \
+  --tracker github --with-hooks \
+  --design-system catalog:linear.app --with-ui-design-hook
+```
+
+**What to notice.**
+
+- **`DESIGN.md` is the single source of truth for how the UI looks — and here it came from the
+  catalog.** `--design-system catalog:linear.app` fetches the Linear system from
+  [awesome-design-md](https://github.com/VoltAgent/awesome-design-md) and drops it in as `DESIGN.md`
+  (that's [path #2 of three](../../docs/11-designing-uis.md#establishing-one--three-ways) — *bring
+  your brand*, *pick a ready-made one*, *generate one*). The file here is that fetched system, with
+  only an attribution header added — it's exactly what the flag produces. The agent reads it **before
+  writing or changing any component** and matches it.
+- **The design system is *adopted*, then it's the law.** Facet didn't invent a palette; it took a
+  coherent one and made it the contract. `CLAUDE.md` sharpens "done" around it: tokens are the single
+  source (no raw hex in components), every component ships all its states + a story + a test, the
+  public prop API is semver, and `DESIGN.md` is updated in the *same* commit when a component pattern
+  changes (R6).
+- **The UI-edit nudge hook is deterministic, not nagging.** `--with-ui-design-hook` installs a
+  once-per-session, non-blocking `PreToolUse` reminder that fires only when you edit a UI file
+  (`.tsx/.css/components/…`) **and** a `DESIGN.md` exists at the root. It self-gates on that file, so
+  backend projects never see it, and it never blocks the edit — see [`hooks/README.md`](../../hooks/README.md).
+- **Adherence is a judgment call, not a grep.** `.harness/verify.conf` checks the *mechanical* floor
+  — `format → lint → types → test → build → a11y`. It deliberately does **not** try to machine-verify
+  "does this match the design system?", because a green check that lies is worse than no check. That
+  axis is held by the profile rule, the quality gate, the STOP-table row, and the bundled
+  **`design-review`** skill below — a human or an agent makes the call.
+- **The bundled `design-review` skill** walks a new or changed component against `DESIGN.md` (tokens,
+  states, contrast, responsive, and whether `DESIGN.md` itself moved with the code). Like
+  python-service's `release-check`, it loads only when you need it, keeping everyday context lean.
+
+**Files here:**
+
+- `README.md` — this file.
+- `CLAUDE.md` — the project-specifics layer (Facet's stack, "done" for a component library, gotchas).
+- `DESIGN.md` — the adopted design system (the Linear system from the catalog; attribution in its header).
+- `.harness/verify.conf` — the concrete verify phases for this component library.
+- `.claude/skills/design-review/SKILL.md` — a small bundled skill for reviewing a component against `DESIGN.md`.


### PR DESCRIPTION
## What & why

The design-system feature (PR #6) shipped without a worked example, and `examples/` had no
creative-design/UI project (roadmap #13). This adds **`examples/ui-component-library/` — "Facet UI"**,
a fictional React component library, as that example — mirroring the `python-service` pattern.

For a component library, `DESIGN.md` *is* the spec the code implements, so it's the purest showcase
of the feature.

## What's in it

- **`DESIGN.md`** — demonstrates catalog **path #2** ("pick a ready-made one"): it's the **Linear**
  system fetched by `--design-system catalog:linear.app`, shipped **verbatim** with an attribution
  header (source: [awesome-design-md](https://github.com/VoltAgent/awesome-design-md), **MIT**). It's
  exactly what the flag produces.
- **`CLAUDE.md`** — sharpens "done" for a component library: tokens are the single source (no raw
  hex), every component ships all states + a11y + a story + a test, the public prop API is semver,
  and `DESIGN.md` moves with the code (R6).
- **`.harness/verify.conf`** — `format → lint → types → test → build → a11y` (adherence is
  deliberately *not* a phase — it's judgment, not a grep).
- **`.claude/skills/design-review/`** — a bundled skill that walks a component against `DESIGN.md`;
  the judgment pass `verify.sh` can't do (docs/11's thesis). Second example to bundle a skill.

## Docs reconciled (R6)

`examples/README` + `docs/07` + `docs/12` now read **six projects across five profiles**
(`software-dev` has two, both bundling a skill); linked from `docs/07` and `docs/11`.

## Verification

Local (Windows): **leak-gate clean**, **ui-design-hook 9/9**, **secret-scan detection 16/16**,
**assemble** passing per-profile. The secret-scan *speed* bound (22s>15s) and the leak-gate/assemble
*test-harness* timeouts are the known Windows+Dropbox environmental slowness — CI on Linux is
authoritative and runs all 7 phases.
