### PR TITLE
fix(setup): assemble correctly on macOS — BSD sed -i leaves raw {{placeholders}}

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -693,14 +693,21 @@ fill_placeholders() {  # in-place on a file
     allowed) tracker_policy="$TRACKER_POLICY_ALLOWED";;
     *)       tracker_policy="$TRACKER_POLICY_ASK";;
   esac
-  sed -i \
+  # Portable in-place edit. `sed -i` is not portable: GNU sed takes no argument,
+  # BSD sed (macOS) *requires* one, so -i and -i '' each break on the other platform.
+  # On macOS the GNU spelling fails with "sed: -e: No such file or directory" and the
+  # file is left with raw {{PLACEHOLDER}} tokens. Writing through a temp file needs no
+  # platform branch at all.
+  local tmp; tmp="$(mktemp)"
+  sed \
     -e "s|{{OPERATOR_NAME}}|$OPERATOR_NAME|g" \
     -e "s|{{OPERATOR_ROLE}}|$OPERATOR_ROLE|g" \
     -e "s|{{OPERATOR_BIO}}|$OPERATOR_BIO|g" \
     -e "s|{{TRACKER}}|$TRACKER|g" \
     -e "s|{{TRACKER_POLICY}}|$tracker_policy|g" \
-    "$1"
-  sed -i -E 's/\{\{([A-Z_]+)\}\}/[TODO: set \1]/g' "$1"
+    "$1" > "$tmp"
+  sed -E 's/\{\{([A-Z_]+)\}\}/[TODO: set \1]/g' "$tmp" > "$1"
+  rm -f "$tmp"
 }
 
 # Name the placeholders the human still has to fill, instead of hoping they skim for them.


### PR DESCRIPTION
## The bug

`setup.sh` cannot assemble a `CLAUDE.md` on macOS. Every run fails at `fill_placeholders()` with:

```
sed: -e: No such file or directory
```

`sed -i` is not portable. GNU sed takes no argument after `-i`; **BSD sed (macOS) requires one**, so it swallows the following `-e` as its backup suffix and then treats the script as a filename. `-i` and `-i ''` each break on the other platform.

## Why it matters more than the error suggests

`fill_placeholders()` returns having substituted nothing, and setup **still reports success**. The assembled `CLAUDE.md` ships with raw tokens in the rules the agent is meant to follow:

```
**{{OPERATOR_NAME}}** is the lead. Role: **{{OPERATOR_ROLE}}**.
```

The second `sed` — the one that renders unfilled `{{TOKEN}}` as `[TODO: set TOKEN]` — never runs either, so the deliberate "name the placeholders the human still has to fill" safety net is bypassed at exactly the moment it is needed. A macOS user gets a harness whose identity and tracker-consent rules are placeholder text, with no error surfaced after the fact.

macOS is clearly a supported target — `setup.sh` already branches on `Darwin` for the git install hint (~L349) and for the org-policy path (~L960).

## The fix

Write through a temp file. No `case $(uname -s)` branch, no `gsed` dependency, no change to behaviour on Linux — it stays a one-function fix, consistent with keeping the surface small.

## Verification

On macOS 15, BSD sed:

**Before** — `./setup.sh --global --dry-run` aborts with `sed: -e: No such file or directory`.

**After:**

```
» GLOBAL install — universal core → ~/.claude/CLAUDE.md
  ✓ kept the operator identity already in CLAUDE.md (… / …)
» DRY RUN — CLAUDE.md would be 381 lines (core=true, profiles=none)
```

and after a real run, `grep -c '{{' ~/.claude/CLAUDE.md` returns `0`.

`bash -n setup.sh` clean.

Existing suites, unchanged by this patch:

| Suite | Result |
|---|---|
| `test-assemble.sh` | 12 passed, 0 failed |
| `test-operator-identity.sh` | 14 passed, 0 failed |
| `test-tracker-consent.sh` | 16 passed, 0 failed |
| `test-secret-scan.sh` | 17 passed, 0 failed |
| `test-ui-design-reminder.sh` | 9 passed, 0 failed |

## Two unrelated findings, noted not fixed here

Both were found while verifying this patch. Neither is touched by this PR; happy to open separate issues.

1. **`test-leak-gate.sh` fails 21 passed / 13 failed on pristine `master`** (confirmed by stashing this patch and re-running, identical result). The failures are detection ones — `operator's first name — NOT flagged (this would ship)`, `routable IPv4 — NOT flagged`, `real email address — NOT flagged`. Not a BSD/GNU issue: `\b` word boundaries do work in this environment's `grep -E`. It looks like the TERMS list is empty in a fresh clone with no operator configured, which would mean the gate passes everything it is meant to catch.

2. **`BRAND_PALETTE` / `BRAND_FONT` are not preserved across re-runs.** Operator identity is carried over (`setup.sh:1176`, "kept the operator identity already in …"), but brand values are not — so a re-assembly silently reverts filled brand rules to `[TODO: set …]`, on the one profile (`creative-design`) whose entire quality gate is brand adherence. The `[TODO]` rendering itself is working as designed; the gap is that a filled value does not survive.
