### PR TITLE
fix(setup): assemble on macOS + calibrate explanations per domain

### DIFF
--- a/core/00-identity.md
+++ b/core/00-identity.md
@@ -14,8 +14,14 @@ never changes between projects; the profile tailors *what "done" means* to the k
 When you explain anything:
 - **Explain the WHY before the HOW.** "We do X because last time Y broke" beats "best practice
   says X." Reasons travel; rules don't.
-- **Match the explanation to their background.** Use analogies to what they already know. Say
-  what will happen in plain language *before* showing the command, the code, or the diff.
+- **Match the explanation to their background — which is uneven, not one dial.** An operator can
+  be expert in one area and still learning the next, so treating them as a single "technical
+  level" either patronizes them or loses them. Assume fluency where the bio says they are strong
+  and do not pad with basics they own; where it names something they are still learning, give the
+  mental model *before* the command — what it does, what state it changes, what happens if it
+  goes wrong — and never hand over an incantation to paste. Use analogies to the areas they
+  already own. If a topic's level is unknown, ask once and add it to the bio rather than
+  re-guessing every session.
 - **Push back on tool/scope creep.** If asked to install a new tool, skill, or plugin, ask what
   problem it solves that the current setup doesn't. More surface area is more to maintain and
   more to go wrong. A prior setup had 500+ skills and followed none of them.

--- a/core/30-anti-rationalization.md
+++ b/core/30-anti-rationalization.md
@@ -19,6 +19,7 @@ is a real failure mode, generalized from work that shipped broken because someon
 | "It's connected / it's in the rules, so I'm meant to use it." | Availability is not authorization. A named system is a pointer, not permission. Ask before the first write to anything outside this repo (core/10). |
 | "The checklist is too long today." | The one time the checklist gets skipped is the one time something ships broken. |
 | "I'll re-prompt the agent to simplify it." | Re-prompting rarely simplifies. If output is bloated, you collapse it yourself or it ships bloated. |
+| "They're technical, they'll know what this does." | Expertise is uneven. Strong in one area is not strong in this one — in anything the bio flags as still-learning, give the model and the blast radius before the command (core/00). |
 
 When in doubt, the move is always the same: **slow down by one step, produce the evidence, then
 proceed.** Speed comes from not having to redo broken work, not from skipping the check.

--- a/setup.sh
+++ b/setup.sh
@@ -693,14 +693,20 @@ fill_placeholders() {  # in-place on a file
     allowed) tracker_policy="$TRACKER_POLICY_ALLOWED";;
     *)       tracker_policy="$TRACKER_POLICY_ASK";;
   esac
-  sed -i \
+  # NOT `sed -i`. GNU sed takes an OPTIONAL suffix after -i; BSD/macOS sed REQUIRES one, so there
+  # is no spelling of in-place sed that works on both. On BSD, `sed -i -e ...` reads "-e" as the
+  # backup suffix and then tries to open the remaining -e flags as input files, failing with
+  # "sed: -e: No such file or directory" — which made every profile fail to assemble on macOS.
+  # Writing to a temp and moving has one spelling on both platforms.
+  local tmp="$1.tmp.$$"
+  sed \
     -e "s|{{OPERATOR_NAME}}|$OPERATOR_NAME|g" \
     -e "s|{{OPERATOR_ROLE}}|$OPERATOR_ROLE|g" \
     -e "s|{{OPERATOR_BIO}}|$OPERATOR_BIO|g" \
     -e "s|{{TRACKER}}|$TRACKER|g" \
     -e "s|{{TRACKER_POLICY}}|$tracker_policy|g" \
-    "$1"
-  sed -i -E 's/\{\{([A-Z_]+)\}\}/[TODO: set \1]/g' "$1"
+    "$1" > "$tmp" && mv "$tmp" "$1"
+  sed -E 's/\{\{([A-Z_]+)\}\}/[TODO: set \1]/g' "$1" > "$tmp" && mv "$tmp" "$1"
 }
 
 # Name the placeholders the human still has to fill, instead of hoping they skim for them.


### PR DESCRIPTION
Two changes, one blocking the other.

## 1. `setup.sh` could not assemble on macOS — `sed -i` is GNU-only

`fill_placeholders()` used `sed -i -e ...`. GNU sed treats the suffix after `-i` as optional; BSD/macOS sed **requires** one, so it read `-e` as the backup suffix and tried to open the remaining `-e` flags as input files (`sed: -e: No such file or directory`). Assembly aborted before any placeholder was filled — no operator on macOS could render a CLAUDE.md from `core/` + `profiles/` at all.

Present since the initial public release. `test-assemble` caught it every run (`1 passed, 11 failed`) but the sed error was swallowed by `>/dev/null`, so it read as eleven broken profiles rather than one broken assembler.

Fixed by writing to a temp and moving — one spelling on both platforms, no GNU/BSD branch to keep in sync.

**Evidence:** `test-assemble` 1/11 → **12/0**.

## 2. Calibrate explanations per domain, not by one technical level

"Match the explanation to their background" treated expertise as a single dial. Real operators are uneven — deep where they work daily, still building the model where they don't — and one dial gets both ends wrong: it pads what they already own and hands them an incantation in the area they are actually still learning.

The incident: an operator strong on sysadmin, infrastructure and marketing was handed `git rebase` instructions as bare commands on the assumption that "technical" covered git too. It did not.

The bullet now names where the calibration comes from (the bio), what to do on each side of it, and what to do when the level is unknown (ask once, write it into the bio). Paired with a STOP-table row, since this is a judgment rule no script can grep for — the same treatment the design-system rule gets.

## Verify status

6 of 7 phases green. **`leak-gate` fails 21/13 — pre-existing on `master`**, confirmed identical on a pristine clone at `HEAD` with zero modifications. Not touched by this branch; being handled separately.