### PR TITLE
fix(handoff): prevent silent hook drift

### DIFF
--- a/.harness/verify.conf
+++ b/.harness/verify.conf
@@ -19,4 +19,5 @@ assemble   :: bash scripts/test-assemble.sh
 consent    :: bash scripts/test-tracker-consent.sh
 ui-design-hook :: bash scripts/test-ui-design-reminder.sh
 handoff-hook :: bash scripts/test-handoff-on-keyword.sh
+context-budget-hook :: bash scripts/test-context-budget-nudge.sh
 platform-install :: bash scripts/test-platform-install.sh

--- a/config/statusline-command.sh
+++ b/config/statusline-command.sh
@@ -11,7 +11,9 @@ used=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
 # Persist context-usage % to a per-session temp file. No hook receives context% directly, so the
 # opt-in handoff Stop hook (hooks/context-budget-nudge.sh) reads it from here. Harmless if unused.
 sid=$(echo "$input" | jq -r '.session_id // empty')
-[ -n "$used" ] && printf '%s' "$used" > "${TMPDIR:-/tmp}/claude-ctx-${sid:-default}.pct" 2>/dev/null || true
+if [[ "$sid" =~ ^[A-Za-z0-9._-]{1,128}$ ]] && [[ "$used" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+  printf '%s' "$used" > "${TMPDIR:-/tmp}/claude-ctx-${sid}.pct" 2>/dev/null || true
+fi
 
 # PS1-style prefix: bold green user@host, reset, colon, bold blue cwd, reset
 prefix=$(printf '\033[01;32m%s@%s\033[00m:\033[01;34m%s\033[00m' "$(whoami)" "$(hostname -s)" "${cwd:-$(pwd)}")

--- a/docs/research/handoff-rollover-orchestration.md
+++ b/docs/research/handoff-rollover-orchestration.md
@@ -1,0 +1,87 @@
+# Research: automatic handoff rollover orchestration
+
+> Decision note, verified 2026-08-25 against the shipped hooks and the locally installed
+> `codex-cli 0.149.0`. Keep this source material under `docs/research/` (R9); obsolete material
+> moves to `_archive/`, never deletion.
+
+## Question / scope
+
+Should Agentsmith go beyond an early handoff cue and run a controller that verifies the current
+session's handoff, then starts its successor automatically around 25–30% context used? This note
+covers the minimum safe protocol and the build/no-build gate. It does not propose an implementation
+against undocumented runtime internals.
+
+## Sources consulted
+
+| # | Source | Date | Type |
+|---|---|---|---|
+| 1 | [Claude Code hooks reference](https://code.claude.com/docs/en/hooks) and [guide](https://code.claude.com/docs/en/hooks-guide) | 2026-08-25 | primary/vendor |
+| 2 | `hooks/context-budget-nudge.sh`, `hooks/handoff-on-keyword.sh`, `config/statusline-command.sh`, and `scripts/handoff.sh` in this repository | 2026-08-25 | primary/local |
+| 3 | Local `codex-cli 0.149.0` help for `queue`, `fork`, and experimental `app-server` | 2026-08-25 | primary/runtime |
+
+## Current trigger availability
+
+- **Claude:** `UserPromptSubmit` supplies the prompt, so the keyword cue is dependable. The early
+  percentage cue is only best-effort: the status line receives `used_percentage`, writes a
+  per-session temp file, and the Stop hook reads that side channel. With a valid ≥30% signal, Stop
+  blocks once and tells the agent to hand off. It does not perform or attest the handoff.
+- **Codex:** Agentsmith can install the keyword hook. The inspected supported hook/config surface
+  does not provide a first-party, per-session context-percentage signal, so no percentage cue is
+  shipped. `queue` can address an existing thread and `fork` can fork one; neither command's help
+  establishes a blank-context rollover contract. `app-server` is explicitly experimental.
+
+These are different problems: **triggering a cue** asks the current agent to preserve state;
+**automatic rollover** must prove that preservation happened and start exactly one clean successor.
+
+## Minimum safe rollover protocol
+
+1. **Stable trigger.** Receive a first-party event carrying runtime, session ID, current working
+   directory, and used-context percentage. A missing or malformed signal fails open to the keyword
+   path; an estimate derived from transcript scraping is not sufficient.
+2. **Completion receipt.** The source session writes the normal handoff note plus a small
+   machine-readable receipt keyed by session ID. It records note path, item, repository root,
+   branch, HEAD, safe-state kind (`clean`, `commit`, or `stash`) and reference, kickoff text, and
+   completion time. The controller treats the agent's prose as a claim until these fields agree
+   with git and the note exists.
+3. **Safe-state gate.** Never start the successor while tracked work is silently dirty. If a stash
+   is the safe state, record its exact reference; if the repo cannot be made safe, retain the
+   current session and surface the blocker.
+4. **Fresh-thread bootstrap.** Use a supported runtime API that creates a genuinely new context at
+   the same repository root and submits only the receipt's kickoff prompt. Continuing or queuing
+   the source thread is not rollover; forking is acceptable only if the runtime documents and can
+   prove blank-context semantics.
+5. **Idempotency and recovery.** Persist controller state outside the conversation. Deduplicate by
+   source session + threshold crossing, create at most one successor, and mark completion only
+   after its ID is recorded. On timeout, invalid receipt, dirty tree, or launch failure, do not
+   retry blindly: leave the current session usable and show the durable note/kickoff for manual
+   recovery.
+
+The receipt is the portable seam. Claude and Codex adapters may differ, but safe-state validation,
+idempotency, audit state, and the kickoff payload must not.
+
+## Go / no-go criteria
+
+Build a small, opt-in prototype for a runtime only when all of these are true:
+
+- a stable first-party event exposes per-session used-context percentage near 25–30%;
+- a supported API creates a blank successor session with explicit working directory and prompt;
+- the receipt and git checks can fail closed without losing or duplicating work;
+- crash recovery and duplicate-trigger tests prove at-most-one successor creation;
+- the adapter does not depend on experimental commands, private schemas, cached model metadata, or
+  transcript/token estimates.
+
+## Conclusion / recommendation
+
+**No-go for an automatic rollover orchestrator today.** Keep the 30%-used Claude nudge as a
+best-effort enforced cue and the keyword hook as the cross-runtime path. Do not build on Codex's
+experimental `app-server` or infer context consumption from internal/runtime files. Revisit with a
+bounded prototype when at least one runtime exposes both a stable context-usage event and a
+documented blank-session creation API; until then, automation would add a service without being
+able to prove the two facts that matter: *handoff completed* and *successor is fresh*.
+
+## Open questions / NOT checked
+
+- Whether future Claude or Codex releases add a stable early-context event.
+- Whether a future Codex session-creation API documents blank-context rather than fork semantics.
+- Cross-platform process supervision and UI presentation; these matter only after the two primary
+  API gates above pass.

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -28,26 +28,41 @@ open `/hooks`, inspect the definitions, and approve them. Needs `jq`.
 
 ## What you get
 
+These hooks automate the **cue inside the current session**, not the session transition itself.
+The keyword hook injects the handoff protocol, and Claude's Stop hook can prevent one stop long
+enough for the agent to run it. Neither hook proves that the tree is safe, verifies the handoff
+note, or opens a fresh context. Complete the safe-state + note steps, then start a fresh chat with
+the generated kickoff block. A controller that verifies those steps and creates the successor
+session would be a separate rollover orchestrator; it is not part of the current hook set.
+
 ### 1. `handoff-on-keyword.sh` — UserPromptSubmit — **reliable**
 When your prompt contains **"handoff"** or **"wrap up"**, it injects the handoff protocol
 (safe-state → handoff note → paste-ready recall prompt). This is the path to trust: it keys off
 the prompt text, which the hook always receives. This is the recommended primary trigger.
 
 ### 2. `context-budget-nudge.sh` — Stop — **best-effort / experimental**
-Claude Code only. This hook is not installed for Codex because it depends on Claude's status line.
+Claude Code only. This hook is not installed for Codex because it depends on Claude's status line;
+Codex therefore gets the reliable keyword hook, but no percentage-triggered handoff.
 
-When context **used** crosses a threshold (default **30%**, set `HANDOFF_PCT_THRESHOLD`), it nudges
-**once per session** toward a handoff. The default is deliberately *low* — the cue is to hand off
+When context **used** crosses a threshold (default **30%**, set `HANDOFF_PCT_THRESHOLD` to an
+integer from 1–100), it nudges **once per session** toward a handoff. The default is deliberately
+*low* — the cue is to hand off
 **early**, when the window is ~25–30% used, not when it's nearly full: model quality degrades as
 context fills (Opus 4.8's sweet spot is ~25–40% used, so you hand off near the bottom of the band).
+When a valid threshold signal exists, the Stop response is an enforced cue: it blocks that stop and
+returns the handoff reason to the agent. It still does not execute or verify the handoff itself.
 
 > **Honest caveat.** No Claude Code hook receives the live context-% — only the **statusline**
 > does. So this hook reads the % that `statusline-command.sh` writes to a temp file
 > (`$TMPDIR/claude-ctx-<session>.pct`). That makes it inherently fragile: the file can be stale
 > (the statusline hasn't re-rendered since the last turn) or missing (statusline not installed).
+> Files older than 300 seconds are ignored; `HANDOFF_SIGNAL_MAX_AGE_SECONDS` can set a 1–3600
+> second freshness window.
 > The dependable signals remain the **"handoff" keyword** above and the **human-watched
 > `ctx:NN%` gauge** in the status line. Treat this as a backstop, not a guarantee. Full
-> feasibility write-up: `docs/research/claude-code-hooks-and-managed-policy.md`.
+> feasibility write-up: `docs/research/claude-code-hooks-and-managed-policy.md`. The separate
+> automatic-rollover decision is recorded in
+> `docs/research/handoff-rollover-orchestration.md`.
 
 ## Manual wiring
 
@@ -122,9 +137,10 @@ For Codex, put the equivalent entry in `$CODEX_HOME/hooks.json` with matcher `^a
 an absolute command path to `$CODEX_HOME/hooks/ui-design-reminder.sh`, then approve it through
 `/hooks`.
 
-Non-regression tests: `bash scripts/test-handoff-on-keyword.sh` and
-`bash scripts/test-ui-design-reminder.sh`. They exercise both runtime schemas, fail-open behavior,
-once-per-session behavior, and Codex add/update/delete/multi-file patches.
+Non-regression tests: `bash scripts/test-handoff-on-keyword.sh`,
+`bash scripts/test-context-budget-nudge.sh`, and `bash scripts/test-ui-design-reminder.sh`. They
+exercise both runtime schemas, fail-open and threshold behavior, once-per-session behavior, and
+Codex add/update/delete/multi-file patches.
 
 ---
 

--- a/hooks/context-budget-nudge.sh
+++ b/hooks/context-budget-nudge.sh
@@ -16,7 +16,8 @@
 # full. Reason: model quality degrades as the window fills; for Opus 4.8 the sweet spot is ~25-40%
 # used, so you hand off near the BOTTOM of that band (leaving headroom to write the handoff and
 # clear before quality drifts). Default 30 used. Tune with HANDOFF_PCT_THRESHOLD (e.g. 25 to fire
-# earlier, up to ~40 to use more of the band).
+# earlier, up to ~40 to use more of the band). Signals older than 300 seconds fail open; tune that
+# bounded freshness window with HANDOFF_SIGNAL_MAX_AGE_SECONDS (1–3600).
 #
 # Wire it (global ~/.claude/settings.json):
 #   "hooks": { "Stop": [ { "hooks": [
@@ -25,19 +26,40 @@ set -euo pipefail
 command -v jq >/dev/null 2>&1 || exit 0
 
 THRESHOLD="${HANDOFF_PCT_THRESHOLD:-30}"
+MAX_SIGNAL_AGE="${HANDOFF_SIGNAL_MAX_AGE_SECONDS:-300}"
 input=$(cat)
-sid=$(printf '%s' "$input" | jq -r '.session_id // empty' 2>/dev/null)
-pf="${TMPDIR:-/tmp}/claude-ctx-${sid:-default}.pct"
-marker="${TMPDIR:-/tmp}/claude-ctx-${sid:-default}.nudged"
+sid=$(printf '%s' "$input" | jq -r '.session_id // empty' 2>/dev/null) || exit 0
+
+# Invalid configuration and unscoped events must stay silent. Falling back to a shared
+# "default" file can leak a percentage between sessions and produce a false handoff cue.
+[[ "$THRESHOLD" =~ ^[0-9]+$ ]] || exit 0
+[ "$THRESHOLD" -ge 1 ] 2>/dev/null && [ "$THRESHOLD" -le 100 ] 2>/dev/null || exit 0
+[[ "$MAX_SIGNAL_AGE" =~ ^[0-9]+$ ]] || exit 0
+[ "$MAX_SIGNAL_AGE" -ge 1 ] 2>/dev/null && [ "$MAX_SIGNAL_AGE" -le 3600 ] 2>/dev/null || exit 0
+[[ "$sid" =~ ^[A-Za-z0-9._-]{1,128}$ ]] || exit 0
+
+pf="${TMPDIR:-/tmp}/claude-ctx-${sid}.pct"
+marker="${TMPDIR:-/tmp}/claude-ctx-${sid}.nudged"
 
 [ -f "$pf" ] || exit 0                       # no signal yet → do nothing
 [ -f "$marker" ] && exit 0                    # already nudged this session → don't loop
 
-pct=$(tr -dc '0-9.' < "$pf" 2>/dev/null); pint=${pct%.*}
-[ -z "${pint:-}" ] && exit 0
+# A statusline may stop rendering or a runtime may reuse a session identifier after recovery.
+# Never act on a side-channel value older than five minutes (configurable, capped at one hour).
+mtime=$(stat -f %m "$pf" 2>/dev/null || stat -c %Y "$pf" 2>/dev/null) || exit 0
+now=$(date +%s 2>/dev/null) || exit 0
+[[ "$mtime" =~ ^[0-9]+$ ]] && [[ "$now" =~ ^[0-9]+$ ]] || exit 0
+age=$((now - mtime))
+[ "$age" -ge 0 ] 2>/dev/null && [ "$age" -le "$MAX_SIGNAL_AGE" ] 2>/dev/null || exit 0
+
+pct=$(tr -d '[:space:]' < "$pf" 2>/dev/null) || exit 0
+[[ "$pct" =~ ^[0-9]+([.][0-9]+)?$ ]] || exit 0
+pint=${pct%%.*}
+[ "$pint" -le 100 ] 2>/dev/null || exit 0
 
 if [ "$pint" -ge "$THRESHOLD" ]; then
+  output=$(jq -n --arg p "$pint" '{decision:"block", reason:("Context is at " + $p + "% used — at the handoff cue (hand off EARLY, while the model is still sharp, not when the window is nearly full). Before you stop: bring the working tree to a safe state (commit/stash), write a handoff note, and output a ready-to-paste post-/clear recall prompt (issue/branch IDs, what is done, exact next step, gotchas). Then stop.")}') || exit 0
   : > "$marker"
-  jq -n --arg p "$pint" '{decision:"block", reason:("Context is at " + $p + "% used — at the handoff cue (hand off EARLY, while the model is still sharp, not when the window is nearly full). Before you stop: bring the working tree to a safe state (commit/stash), write a handoff note, and output a ready-to-paste post-/clear recall prompt (issue/branch IDs, what is done, exact next step, gotchas). Then stop.")}'
+  printf '%s\n' "$output"
 fi
 exit 0

--- a/hooks/context-budget-nudge.sh
+++ b/hooks/context-budget-nudge.sh
@@ -46,7 +46,13 @@ marker="${TMPDIR:-/tmp}/claude-ctx-${sid}.nudged"
 
 # A statusline may stop rendering or a runtime may reuse a session identifier after recovery.
 # Never act on a side-channel value older than five minutes (configurable, capped at one hour).
-mtime=$(stat -f %m "$pf" 2>/dev/null || stat -c %Y "$pf" 2>/dev/null) || exit 0
+if mtime=$(stat -c %Y "$pf" 2>/dev/null); then       # GNU/Linux
+  :
+elif mtime=$(stat -f %m "$pf" 2>/dev/null); then    # BSD/macOS
+  :
+else
+  exit 0
+fi
 now=$(date +%s 2>/dev/null) || exit 0
 [[ "$mtime" =~ ^[0-9]+$ ]] && [[ "$now" =~ ^[0-9]+$ ]] || exit 0
 age=$((now - mtime))

--- a/scripts/test-context-budget-nudge.sh
+++ b/scripts/test-context-budget-nudge.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Non-regression suite for the Claude-only Stop hook context-budget nudge.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="${HOOK_BIN:-$SCRIPT_DIR/../hooks/context-budget-nudge.sh}"
+BASH_BIN="$(command -v bash)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "test-context-budget-nudge: SKIP — jq not installed, hook response not exercised (CI covers it)."
+  exit 0
+fi
+
+pass=0; fail=0
+ok()  { printf '  \033[32m✓\033[0m %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  \033[31m✗\033[0m %s\n' "$1"; fail=$((fail+1)); }
+silent() { [ -z "${1//[[:space:]]/}" ]; }
+signal_path() { printf '%s/claude-ctx-%s.pct' "$TMP" "$1"; }
+marker_path() { printf '%s/claude-ctx-%s.nudged' "$TMP" "$1"; }
+write_signal() { printf '%s' "$2" > "$(signal_path "$1")"; }
+emit() {
+  local sid="$1" threshold="${2:-}"
+  if [ -n "$threshold" ]; then
+    printf '{"hook_event_name":"Stop","session_id":"%s"}' "$sid" |
+      TMPDIR="$TMP" HANDOFF_PCT_THRESHOLD="$threshold" bash "$HOOK" 2>/dev/null
+  else
+    printf '{"hook_event_name":"Stop","session_id":"%s"}' "$sid" |
+      TMPDIR="$TMP" bash "$HOOK" 2>/dev/null
+  fi
+}
+
+echo "test-context-budget-nudge — threshold and fail-open behavior"
+
+out="$(emit missing)"; rc=$?
+if [ "$rc" -eq 0 ] && silent "$out" && [ ! -e "$(marker_path missing)" ]; then
+  ok "missing signal → successful silent no-op"
+else
+  bad "missing signal did not fail open"
+fi
+
+write_signal malformed '30 percent'
+out="$(emit malformed)"; rc=$?
+if [ "$rc" -eq 0 ] && silent "$out" && [ ! -e "$(marker_path malformed)" ]; then
+  ok "malformed signal → successful silent no-op"
+else
+  bad "malformed signal was interpreted as a percentage"
+fi
+
+write_signal stale 31
+touch -t 200001010000 "$(signal_path stale)"
+out="$(emit stale)"; rc=$?
+if [ "$rc" -eq 0 ] && silent "$out" && [ ! -e "$(marker_path stale)" ]; then
+  ok "stale signal → successful silent no-op"
+else
+  bad "stale signal triggered a handoff"
+fi
+
+write_signal below 29
+out="$(emit below)"
+if silent "$out" && [ ! -e "$(marker_path below)" ]; then
+  ok "29% used → silent below default threshold"
+else
+  bad "29% used unexpectedly nudged"
+fi
+
+write_signal boundary 30
+out="$(emit boundary)"
+if jq -e '.decision == "block" and (.reason | contains("30% used"))' >/dev/null 2>&1 <<<"$out" &&
+   [ -f "$(marker_path boundary)" ]; then
+  ok "30% used → block response and session marker"
+else
+  bad "30% boundary did not emit the Stop block response"
+fi
+
+write_signal override 25
+out="$(emit override 25)"
+if jq -e '.decision == "block" and (.reason | contains("25% used"))' >/dev/null 2>&1 <<<"$out"; then
+  ok "HANDOFF_PCT_THRESHOLD override controls the boundary"
+else
+  bad "threshold override was ignored"
+fi
+
+write_signal repeat 31
+first="$(emit repeat)"; second="$(emit repeat)"
+if ! silent "$first" && silent "$second" && [ -f "$(marker_path repeat)" ]; then
+  ok "repeat invocation nudges once per session"
+else
+  bad "repeat invocation did not stay silent after the first nudge"
+fi
+
+write_signal isolated-a 30
+write_signal isolated-b 30
+out_a="$(emit isolated-a)"; out_b="$(emit isolated-b)"
+if ! silent "$out_a" && ! silent "$out_b" &&
+   [ -f "$(marker_path isolated-a)" ] && [ -f "$(marker_path isolated-b)" ]; then
+  ok "different session IDs maintain independent marker state"
+else
+  bad "one session suppressed another session's nudge"
+fi
+
+write_signal invalid-threshold 99
+out="$(emit invalid-threshold not-a-number)"; rc=$?
+if [ "$rc" -eq 0 ] && silent "$out" && [ ! -e "$(marker_path invalid-threshold)" ]; then
+  ok "invalid threshold → successful silent no-op"
+else
+  bad "invalid threshold did not fail open"
+fi
+
+out="$(printf '%s' '{"session_id":"../../unsafe"}' | TMPDIR="$TMP" bash "$HOOK" 2>/dev/null)"; rc=$?
+if [ "$rc" -eq 0 ] && silent "$out"; then
+  ok "unsafe session ID → successful silent no-op"
+else
+  bad "unsafe session ID was accepted for a temp path"
+fi
+
+# A missing jq executable must also remain a successful silent no-op.
+out="$(printf '{"session_id":"no-jq"}' | TMPDIR="$TMP" PATH="" "$BASH_BIN" "$HOOK" 2>/dev/null)"; rc=$?
+if [ "$rc" -eq 0 ] && silent "$out"; then
+  ok "jq absent → successful silent no-op"
+else
+  bad "jq absent did not fail open"
+fi
+
+echo
+printf 'test-context-budget-nudge: %d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ] || exit 1

--- a/scripts/test-platform-install.ps1
+++ b/scripts/test-platform-install.ps1
@@ -38,6 +38,22 @@ function Assert-Toml ([string]$path) {
   & $python -c 'import sys,tomllib; tomllib.load(open(sys.argv[1], "rb"))' $path
   Assert-True ($LASTEXITCODE -eq 0) "invalid TOML: $path"
 }
+function Get-HookCommandCount ([string]$settingsPath, [string]$event, [string]$command) {
+  $settings = Get-Content $settingsPath -Raw | ConvertFrom-Json -AsHashtable
+  $count = 0
+  if ((-not $settings.ContainsKey('hooks')) -or
+      ($settings['hooks'] -isnot [Collections.IDictionary]) -or
+      (-not $settings['hooks'].ContainsKey($event))) { return 0 }
+  foreach ($group in @($settings['hooks'][$event])) {
+    if (($group -isnot [Collections.IDictionary]) -or (-not $group.ContainsKey('hooks'))) { continue }
+    foreach ($handler in @($group['hooks'])) {
+      if (($handler -is [Collections.IDictionary]) -and
+          $handler.ContainsKey('command') -and
+          $handler['command'] -eq $command) { $count++ }
+    }
+  }
+  return $count
+}
 
 New-Item -ItemType Directory -Force -Path $sandbox | Out-Null
 $oldHome = $env:HOME
@@ -59,6 +75,7 @@ try {
 
   # Seed foreign configuration and an existing skill; Agentsmith must preserve both.
   Set-Content (Join-Path $codex 'config.toml') "# keep user comment`nmodel = `"gpt-test`"`n`n[features]`nkeep_me = true`n" -Encoding utf8
+  Set-Content (Join-Path $codex 'hooks.json') '{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"foreign-user-hook"}]}],"Stop":[{"hooks":[{"type":"command","command":"foreign-stop-hook"}]}]}}' -Encoding utf8
   New-Item -ItemType Directory -Force -Path (Join-Path $project '.codex'),(Join-Path $project '.agents/skills/existing') | Out-Null
   Set-Content (Join-Path $project '.codex/config.toml') "# manual project server`n[mcp_servers.context7]`ncommand = `"manual-context7`"`n" -Encoding utf8
   Set-Content (Join-Path $project '.agents/skills/existing/SKILL.md') '# keep me' -Encoding utf8
@@ -76,23 +93,97 @@ try {
   Assert-Contains (Join-Path $project '.codex/config.toml') 'command = "manual-context7"'
   Assert-True (([regex]::Matches((Get-Content (Join-Path $project '.codex/config.toml') -Raw), '\[mcp_servers\.context7\]')).Count -eq 1) 'manual MCP conflict was duplicated'
   Assert-True ($first.Contains('defined outside the Agentsmith block')) 'manual MCP conflict did not emit an actionable warning'
+  Assert-True ((Get-HookCommandCount (Join-Path $codex 'hooks.json') 'UserPromptSubmit' 'foreign-user-hook') -eq 1) 'foreign Codex UserPromptSubmit hook was lost'
+  Assert-True ((Get-HookCommandCount (Join-Path $codex 'hooks.json') 'Stop' 'foreign-stop-hook') -eq 1) 'foreign Codex Stop hook was lost'
   Assert-Toml (Join-Path $codex 'config.toml')
   Assert-Toml (Join-Path $project '.codex/config.toml')
 
   # Re-run: update safety, union MCP selections, keep hook entries duplicate-free, and create backups.
+  Set-Content (Join-Path $codex 'hooks/handoff-on-keyword.sh') '# stale Codex handoff hook' -Encoding utf8
+  $codexHooksPath = Join-Path $codex 'hooks.json'
+  $codexBefore = Get-Content $codexHooksPath -Raw | ConvertFrom-Json -AsHashtable
+  $managedCodexCommand = @(
+    foreach ($group in @($codexBefore['hooks']['UserPromptSubmit'])) {
+      foreach ($handler in @($group['hooks'])) {
+        if (($handler -is [Collections.IDictionary]) -and $handler['command'].Contains('handoff-on-keyword.sh')) { $handler['command'] }
+      }
+    }
+  )[0]
+  $codexBefore['hooks']['UserPromptSubmit'] = @($codexBefore['hooks']['UserPromptSubmit']) + @(@{ hooks = @(@{ type = 'command'; command = $managedCodexCommand }) })
+  $codexBefore | ConvertTo-Json -Depth 100 | Set-Content $codexHooksPath -Encoding utf8
   Run-Setup @('--platform','codex','--profile','general-admin','--target',$project,'--safety','trusted','--with-skills','--with-mcp','excalidraw','--with-handoff-hooks','--with-ui-design-hook') | Out-Null
   Assert-Contains (Join-Path $codex 'config.toml') 'approval_policy = "never"'
   Assert-Contains (Join-Path $codex 'config.toml') 'sandbox_mode = "danger-full-access"'
   Assert-Contains (Join-Path $project '.codex/config.toml') '[mcp_servers.playwright]'
   Assert-Contains (Join-Path $project '.codex/config.toml') '[mcp_servers.excalidraw]'
   $hooks = Get-Content (Join-Path $codex 'hooks.json') -Raw | ConvertFrom-Json -AsHashtable
-  Assert-True (@($hooks['hooks']['UserPromptSubmit']).Count -eq 1) 'handoff hook duplicated on re-run'
+  $managedCodexHandoffCount = @(
+    foreach ($group in @($hooks['hooks']['UserPromptSubmit'])) {
+      foreach ($handler in @($group['hooks'])) {
+        if (($handler -is [Collections.IDictionary]) -and
+            $handler.ContainsKey('command') -and
+            $handler['command'].Contains('handoff-on-keyword.sh')) { $handler }
+      }
+    }
+  ).Count
+  Assert-True ($managedCodexHandoffCount -eq 1) 'handoff hook duplicated on re-run'
+  Assert-True ((Get-FileHash (Join-Path $codex 'hooks/handoff-on-keyword.sh')).Hash -eq (Get-FileHash (Join-Path $repo 'hooks/handoff-on-keyword.sh')).Hash) 'stale Codex handoff script was not refreshed'
   Assert-True (@($hooks['hooks']['PreToolUse']).Count -eq 1) 'UI hook duplicated on re-run'
   Assert-True ($hooks['hooks']['PreToolUse'][0]['matcher'] -eq '^apply_patch$') 'Codex UI matcher is wrong'
   Assert-True (-not (Test-Path (Join-Path $codex 'hooks/context-budget-nudge.sh'))) 'Codex received Claude context nudge'
   Assert-True (@(Get-ChildItem $codex -Filter 'config.toml.bak.*').Count -ge 1) 'Codex config was not backed up'
   Assert-Toml (Join-Path $codex 'config.toml')
   Assert-Toml (Join-Path $project '.codex/config.toml')
+
+  # Fresh Claude handoff install owns its bundled statusline and wires each hook once.
+  $freshClaudeHome = Join-Path $sandbox 'fresh Claude home'
+  $freshClaudeProject = Join-Path $sandbox 'fresh Claude project'
+  New-Item -ItemType Directory -Force -Path $freshClaudeHome,$freshClaudeProject | Out-Null
+  $env:HOME = $freshClaudeHome; $env:USERPROFILE = $freshClaudeHome
+  Run-Setup @('--platform','claude','--profile','general-admin','--target',$freshClaudeProject,'--with-handoff-hooks','--no-rtk') | Out-Null
+  $freshClaudeDir = Join-Path $freshClaudeHome '.claude'
+  Assert-True ((Get-FileHash (Join-Path $freshClaudeDir 'statusline-command.sh')).Hash -eq (Get-FileHash (Join-Path $repo 'config/statusline-command.sh')).Hash) 'fresh Claude handoff install did not supply the managed statusline'
+  $freshSettings = Join-Path $freshClaudeDir 'settings.json'
+  Assert-True ((Get-HookCommandCount $freshSettings 'UserPromptSubmit' 'bash ~/.claude/hooks/handoff-on-keyword.sh') -eq 1) 'fresh Claude keyword hook was not wired exactly once'
+  Assert-True ((Get-HookCommandCount $freshSettings 'Stop' 'bash ~/.claude/hooks/context-budget-nudge.sh') -eq 1) 'fresh Claude context hook was not wired exactly once'
+  $freshDoctor = Run-Setup @('--platform','claude','--doctor')
+  Assert-True ($freshDoctor.Contains('Claude keyword handoff script healthy')) 'doctor did not recognize the fresh Claude keyword script'
+  Assert-True ($freshDoctor.Contains('contains the per-session context-signal writer')) 'doctor did not recognize the managed statusline signal writer'
+
+  # Existing AgentSmith hooks are refreshed, while foreign hooks and a custom statusline survive.
+  $existingClaudeHome = Join-Path $sandbox 'existing Claude home'
+  $existingClaudeProject = Join-Path $sandbox 'existing Claude project'
+  $existingClaudeDir = Join-Path $existingClaudeHome '.claude'
+  $existingHooksDir = Join-Path $existingClaudeDir 'hooks'
+  New-Item -ItemType Directory -Force -Path $existingHooksDir,$existingClaudeProject | Out-Null
+  $customStatusline = Join-Path $existingClaudeDir 'statusline-command.sh'
+  [IO.File]::WriteAllText($customStatusline, "#!/usr/bin/env bash`nprintf 'custom statusline\n'`n", [Text.UTF8Encoding]::new($false))
+  $customStatuslineHash = (Get-FileHash $customStatusline).Hash
+  Set-Content (Join-Path $existingHooksDir 'handoff-on-keyword.sh') '# stale keyword hook' -Encoding utf8
+  Set-Content (Join-Path $existingHooksDir 'context-budget-nudge.sh') '# stale context hook' -Encoding utf8
+  $existingSettings = Join-Path $existingClaudeDir 'settings.json'
+  [IO.File]::WriteAllText($existingSettings, '{"statusLine":{"type":"command","command":"bash ~/.claude/statusline-command.sh"},"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"foreign-user-hook"}]},{"hooks":[{"type":"command","command":"bash ~/.claude/hooks/handoff-on-keyword.sh"}]},{"hooks":[{"type":"command","command":"bash ~/.claude/hooks/handoff-on-keyword.sh"}]}],"Stop":[{"hooks":[{"type":"command","command":"foreign-stop-hook"}]},{"hooks":[{"type":"command","command":"bash ~/.claude/hooks/context-budget-nudge.sh"}]},{"hooks":[{"type":"command","command":"bash ~/.claude/hooks/context-budget-nudge.sh"}]}]}}', [Text.UTF8Encoding]::new($false))
+  $env:HOME = $existingClaudeHome; $env:USERPROFILE = $existingClaudeHome
+  $doctorBefore = Run-Setup @('--platform','claude','--doctor')
+  Assert-True ($doctorBefore.Contains('Claude keyword handoff script stale or customized')) 'doctor did not report the stale Claude keyword script'
+  Run-Setup @('--platform','claude','--profile','general-admin','--target',$existingClaudeProject,'--with-handoff-hooks','--no-rtk') | Out-Null
+  Assert-True ((Get-FileHash (Join-Path $existingHooksDir 'handoff-on-keyword.sh')).Hash -eq (Get-FileHash (Join-Path $repo 'hooks/handoff-on-keyword.sh')).Hash) 'stale Claude keyword hook was not refreshed'
+  Assert-True ((Get-FileHash (Join-Path $existingHooksDir 'context-budget-nudge.sh')).Hash -eq (Get-FileHash (Join-Path $repo 'hooks/context-budget-nudge.sh')).Hash) 'stale Claude context hook was not refreshed'
+  Assert-True ((Get-FileHash $customStatusline).Hash -eq $customStatuslineHash) 'custom Claude statusline was overwritten'
+  Assert-True ((Get-HookCommandCount $existingSettings 'UserPromptSubmit' 'foreign-user-hook') -eq 1) 'foreign Claude UserPromptSubmit hook was lost'
+  Assert-True ((Get-HookCommandCount $existingSettings 'Stop' 'foreign-stop-hook') -eq 1) 'foreign Claude Stop hook was lost'
+  Assert-True ((Get-HookCommandCount $existingSettings 'UserPromptSubmit' 'bash ~/.claude/hooks/handoff-on-keyword.sh') -eq 1) 'pre-existing duplicate Claude keyword hooks were not collapsed'
+  Assert-True ((Get-HookCommandCount $existingSettings 'Stop' 'bash ~/.claude/hooks/context-budget-nudge.sh') -eq 1) 'pre-existing duplicate Claude context hooks were not collapsed'
+  Run-Setup @('--platform','claude','--profile','general-admin','--target',$existingClaudeProject,'--with-handoff-hooks','--no-rtk') | Out-Null
+  Assert-True ((Get-HookCommandCount $existingSettings 'UserPromptSubmit' 'bash ~/.claude/hooks/handoff-on-keyword.sh') -eq 1) 'Claude keyword hook duplicated on re-run'
+  Assert-True ((Get-HookCommandCount $existingSettings 'Stop' 'bash ~/.claude/hooks/context-budget-nudge.sh') -eq 1) 'Claude context hook duplicated on re-run'
+  Assert-True ((Get-FileHash $customStatusline).Hash -eq $customStatuslineHash) 'custom Claude statusline changed on re-run'
+  $doctorAfter = Run-Setup @('--platform','claude','--doctor')
+  Assert-True ($doctorAfter.Contains('Claude keyword handoff script healthy')) 'doctor did not recognize the refreshed Claude keyword script'
+  Assert-True ($doctorAfter.Contains('no per-session context-signal writer was detected')) 'doctor did not report the non-emitting custom statusline'
+
+  # Restore the original fixture account for the remaining Codex assertions.
+  $env:HOME = $fixtureHome; $env:USERPROFILE = $fixtureHome; $env:CODEX_HOME = $codex
 
   # Both produces byte-equivalent native rule files; dry-run produces no writes.
   $bothProject = Join-Path $sandbox 'both project'

--- a/scripts/test-platform-install.sh
+++ b/scripts/test-platform-install.sh
@@ -57,6 +57,7 @@ mkdir -p "$c/bin" "$c/project/.codex" "$c/project/.agents/skills/existing" "$c/O
 printf '#!/usr/bin/env bash\nprintf invoked >> "$AGENTSMITH_CALL_LOG"\n' > "$c/bin/claude"
 cp "$c/bin/claude" "$c/bin/rtk"; chmod +x "$c/bin/claude" "$c/bin/rtk"
 printf '# keep-user-comment\nmodel = "gpt-test"\n\n[foreign]\nvalue = 7\n' > "$c/Orca Account/codex home/config.toml"
+printf '%s\n' '{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"foreign-user-hook"}]}],"Stop":[{"hooks":[{"type":"command","command":"foreign-stop-hook"}]}]}}' > "$c/Orca Account/codex home/hooks.json"
 printf '# keep-project-comment\n\n[mcp_servers.playwright]\ncommand = "manual"\n' > "$c/project/.codex/config.toml"
 AGENTSMITH_CALL_LOG="$c/calls" PATH="$c/bin:$PATH" HOME="$c/home" CODEX_HOME="$c/Orca Account/codex home" \
   bash "$ROOT/setup.sh" --platform codex --profile general-admin --target "$c/project" --with-skills \
@@ -74,6 +75,8 @@ assert "foreign TOML comments survive" grep -Eq 'keep-user-comment' "$c/Orca Acc
 assert "foreign TOML tables survive" grep -Eq '^\[foreign\]' "$c/Orca Account/codex home/config.toml"
 assert "manual MCP name wins" grep -Eq 'command = "manual"' "$c/project/.codex/config.toml"
 assert "selected non-conflicting MCP is installed" grep -Eq '^\[mcp_servers\.context7\]' "$c/project/.codex/config.toml"
+assert "foreign Codex UserPromptSubmit hook survives" test "$(jq '[.hooks.UserPromptSubmit[].hooks[] | select(.command == "foreign-user-hook")] | length' "$c/Orca Account/codex home/hooks.json")" -eq 1
+assert "foreign Codex Stop hook survives" test "$(jq '[.hooks.Stop[].hooks[] | select(.command == "foreign-stop-hook")] | length' "$c/Orca Account/codex home/hooks.json")" -eq 1
 python3 - "$c/Orca Account/codex home/config.toml" "$c/project/.codex/config.toml" <<'PY'
 import sys, tomllib
 user = tomllib.load(open(sys.argv[1], 'rb'))
@@ -87,15 +90,56 @@ PY
 assert "cautious mapping and TOML parse exactly" test $? -eq 0
 
 # Re-run adds a new managed server, retains the prior selection, and does not duplicate hooks/tables.
+printf '%s\n' '# stale Codex handoff hook' > "$c/Orca Account/codex home/hooks/handoff-on-keyword.sh"
+jq '.hooks.UserPromptSubmit += [.hooks.UserPromptSubmit[] | select(any(.hooks[]?; .command | contains("handoff-on-keyword.sh")))]' \
+  "$c/Orca Account/codex home/hooks.json" > "$c/Orca Account/codex home/hooks.json.duplicated"
+mv "$c/Orca Account/codex home/hooks.json.duplicated" "$c/Orca Account/codex home/hooks.json"
 run "$c" --platform codex --profile general-admin --target "$c/project" --with-mcp excalidraw --with-handoff-hooks --with-ui-design-hook --safety cautious
 assert "re-run unions prior MCP selections" grep -Eq '^\[mcp_servers\.context7\]' "$c/project/.codex/config.toml"
 assert "re-run adds new MCP selection" grep -Eq '^\[mcp_servers\.excalidraw\]' "$c/project/.codex/config.toml"
 assert "managed MCP table is duplicate-free" test "$(grep -Ec '^\[mcp_servers\.context7\]$' "$c/project/.codex/config.toml")" -eq 1
 assert "handoff hook definition is duplicate-free" test "$(jq '[.hooks.UserPromptSubmit[].hooks[] | select(.command | contains("handoff-on-keyword.sh"))] | length' "$c/Orca Account/codex home/hooks.json")" -eq 1
+assert "stale Codex handoff script is refreshed" cmp -s "$ROOT/hooks/handoff-on-keyword.sh" "$c/Orca Account/codex home/hooks/handoff-on-keyword.sh"
 assert "UI hook definition is duplicate-free" test "$(jq '[.hooks.PreToolUse[].hooks[] | select(.command | contains("ui-design-reminder.sh"))] | length' "$c/Orca Account/codex home/hooks.json")" -eq 1
 assert "Codex UI hook matches apply_patch only" test "$(jq -r '.hooks.PreToolUse[] | select(any(.hooks[]; .command | contains("ui-design-reminder.sh"))) | .matcher' "$c/Orca Account/codex home/hooks.json")" = '^apply_patch$'
 assert "re-run produces parseable user TOML" python3 -c 'import sys,tomllib; tomllib.load(open(sys.argv[1],"rb"))' "$c/Orca Account/codex home/config.toml"
 assert "re-run produces parseable project TOML" python3 -c 'import sys,tomllib; tomllib.load(open(sys.argv[1],"rb"))' "$c/project/.codex/config.toml"
+
+echo "platform-install — Claude handoff hook refresh and statusline ownership"
+c="$(new_case claude-existing-handoff)"
+mkdir -p "$c/home/.claude/hooks"
+printf '%s\n' '#!/usr/bin/env bash' 'printf "custom statusline\\n"' > "$c/home/.claude/statusline-command.sh"
+cp "$c/home/.claude/statusline-command.sh" "$c/custom-statusline.before"
+printf '%s\n' '# stale keyword hook' > "$c/home/.claude/hooks/handoff-on-keyword.sh"
+printf '%s\n' '# stale context hook' > "$c/home/.claude/hooks/context-budget-nudge.sh"
+printf '%s\n' '{"statusLine":{"type":"command","command":"bash ~/.claude/statusline-command.sh"},"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"foreign-user-hook"}]},{"hooks":[{"type":"command","command":"bash ~/.claude/hooks/handoff-on-keyword.sh"}]},{"hooks":[{"type":"command","command":"bash ~/.claude/hooks/handoff-on-keyword.sh"}]}],"Stop":[{"hooks":[{"type":"command","command":"foreign-stop-hook"}]},{"hooks":[{"type":"command","command":"bash ~/.claude/hooks/context-budget-nudge.sh"}]},{"hooks":[{"type":"command","command":"bash ~/.claude/hooks/context-budget-nudge.sh"}]}]}}' > "$c/home/.claude/settings.json"
+HOME="$c/home" CODEX_HOME="$c/Orca Account/codex home" bash "$ROOT/setup.sh" --platform claude --doctor > "$c/doctor-before" 2>&1
+assert "doctor reports a stale Claude handoff script before repair" grep -q 'Claude keyword handoff hook stale or locally modified' "$c/doctor-before"
+run "$c" --platform claude --profile general-admin --target "$c/project" --with-handoff-hooks --no-rtk
+assert "stale Claude keyword hook is refreshed" cmp -s "$ROOT/hooks/handoff-on-keyword.sh" "$c/home/.claude/hooks/handoff-on-keyword.sh"
+assert "stale Claude context hook is refreshed" cmp -s "$ROOT/hooks/context-budget-nudge.sh" "$c/home/.claude/hooks/context-budget-nudge.sh"
+assert "existing custom Claude statusline is byte-identical" cmp -s "$c/custom-statusline.before" "$c/home/.claude/statusline-command.sh"
+assert "unrelated Claude UserPromptSubmit hook survives" test "$(jq '[.hooks.UserPromptSubmit[].hooks[] | select(.command == "foreign-user-hook")] | length' "$c/home/.claude/settings.json")" -eq 1
+assert "unrelated Claude Stop hook survives" test "$(jq '[.hooks.Stop[].hooks[] | select(.command == "foreign-stop-hook")] | length' "$c/home/.claude/settings.json")" -eq 1
+assert "pre-existing duplicate Claude keyword hooks collapse" test "$(jq '[.hooks.UserPromptSubmit[].hooks[] | select(.command == "bash ~/.claude/hooks/handoff-on-keyword.sh")] | length' "$c/home/.claude/settings.json")" -eq 1
+assert "pre-existing duplicate Claude context hooks collapse" test "$(jq '[.hooks.Stop[].hooks[] | select(.command == "bash ~/.claude/hooks/context-budget-nudge.sh")] | length' "$c/home/.claude/settings.json")" -eq 1
+run "$c" --platform claude --profile general-admin --target "$c/project" --with-handoff-hooks --no-rtk
+assert "Claude keyword hook remains duplicate-free" test "$(jq '[.hooks.UserPromptSubmit[].hooks[] | select(.command == "bash ~/.claude/hooks/handoff-on-keyword.sh")] | length' "$c/home/.claude/settings.json")" -eq 1
+assert "Claude context hook remains duplicate-free" test "$(jq '[.hooks.Stop[].hooks[] | select(.command == "bash ~/.claude/hooks/context-budget-nudge.sh")] | length' "$c/home/.claude/settings.json")" -eq 1
+assert "custom Claude statusline survives re-run byte-identically" cmp -s "$c/custom-statusline.before" "$c/home/.claude/statusline-command.sh"
+HOME="$c/home" CODEX_HOME="$c/Orca Account/codex home" bash "$ROOT/setup.sh" --platform claude --doctor > "$c/doctor" 2>&1
+assert "doctor reports current refreshed Claude scripts" grep -q 'Claude keyword handoff hook current' "$c/doctor"
+assert "doctor reports custom statusline without a signal writer" grep -q 'statusline has no context signal writer' "$c/doctor"
+
+c_missing="$(new_case handoff-doctor-missing)"
+mkdir -p "$c_missing/home/.claude"
+printf '%s\n' '{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"echo handoff-on-keyword.sh"}]}],"Stop":[{"hooks":[{"type":"command","command":"echo context-budget-nudge.sh"}]}]}}' > "$c_missing/home/.claude/settings.json"
+printf '%s\n' '{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"echo handoff-on-keyword.sh"}]}]}}' > "$c_missing/Orca Account/codex home/hooks.json"
+HOME="$c_missing/home" CODEX_HOME="$c_missing/Orca Account/codex home" bash "$ROOT/setup.sh" --platform both --doctor > "$c_missing/doctor" 2>&1
+assert "doctor reports missing Claude handoff script" grep -q 'Claude keyword handoff hook missing' "$c_missing/doctor"
+assert "doctor reports missing Codex handoff script" grep -q 'Codex keyword handoff hook missing' "$c_missing/doctor"
+assert "doctor rejects a Claude command that only names the hook" grep -q 'Claude keyword handoff hook not wired' "$c_missing/doctor"
+assert "doctor rejects a Codex command that only names the hook" grep -q 'Codex keyword handoff hook not wired' "$c_missing/doctor"
 
 c="$(new_case both-full)"
 mkdir -p "$c/bin"
@@ -112,6 +156,12 @@ assert "both full install writes Claude MCP" test -f "$c/project/.mcp.json"
 assert "both full install writes Codex MCP" test -f "$c/project/.codex/config.toml"
 assert "both installs Claude context nudge only in Claude home" test -f "$c/home/.claude/hooks/context-budget-nudge.sh"
 assert "both does not put context nudge in Codex home" test ! -e "$c/Orca Account/codex home/hooks/context-budget-nudge.sh"
+assert "fresh Claude handoff install supplies the managed statusline" cmp -s "$ROOT/config/statusline-command.sh" "$c/home/.claude/statusline-command.sh"
+assert "fresh Claude handoff install wires one keyword hook" test "$(jq '[.hooks.UserPromptSubmit[].hooks[] | select(.command == "bash ~/.claude/hooks/handoff-on-keyword.sh")] | length' "$c/home/.claude/settings.json")" -eq 1
+assert "fresh Claude handoff install wires one context hook" test "$(jq '[.hooks.Stop[].hooks[] | select(.command == "bash ~/.claude/hooks/context-budget-nudge.sh")] | length' "$c/home/.claude/settings.json")" -eq 1
+HOME="$c/home" CODEX_HOME="$c/Orca Account/codex home" bash "$ROOT/setup.sh" --platform both --doctor > "$c/doctor" 2>&1
+assert "doctor recognizes a healthy Claude context signal writer" grep -q 'statusline contains the per-session context signal writer' "$c/doctor"
+assert "doctor recognizes current Codex handoff script" grep -q 'Codex keyword handoff hook current' "$c/doctor"
 
 echo "platform-install — global paths, safety mapping, legacy flag, and uninstall"
 c="$(new_case claude-global)"

--- a/setup.ps1
+++ b/setup.ps1
@@ -784,30 +784,121 @@ function OrgPolicy-Install {
   Write-Host "  Admins: extend $orgSettings with org allow/deny rules as needed."
 }
 
+function Test-JsonHookCommand ([Collections.IDictionary]$settings, [string]$event, [string]$command) {
+  if (-not $settings.ContainsKey('hooks') -or ($settings['hooks'] -isnot [Collections.IDictionary])) { return $false }
+  if (-not $settings['hooks'].ContainsKey($event)) { return $false }
+  foreach ($group in @($settings['hooks'][$event])) {
+    if (($group -isnot [Collections.IDictionary]) -or (-not $group.ContainsKey('hooks'))) { continue }
+    foreach ($handler in @($group['hooks'])) {
+      if (($handler -is [Collections.IDictionary]) -and $handler.ContainsKey('command') -and $handler['command'] -eq $command) {
+        return $true
+      }
+    }
+  }
+  return $false
+}
+
+function Ensure-JsonHookCommand ([Collections.IDictionary]$settings, [string]$event, [string]$command, [string]$matcher = '') {
+  # Preserve every unrelated hook and the first matching handler, but collapse duplicate copies
+  # left by older installer runs. Each event is reconciled independently: a keyword hook must not
+  # make us assume the Stop hook is also present (or vice versa).
+  $changed = $false
+  if (-not $settings.ContainsKey('hooks')) { $settings['hooks'] = @{}; $changed = $true }
+  if ($settings['hooks'] -isnot [Collections.IDictionary]) { throw 'settings.json "hooks" must be a JSON object' }
+  if (-not $settings['hooks'].ContainsKey($event)) { $settings['hooks'][$event] = @(); $changed = $true }
+
+  $groups = @($settings['hooks'][$event])
+  $seen = $false
+  foreach ($group in $groups) {
+    if (($group -isnot [Collections.IDictionary]) -or (-not $group.ContainsKey('hooks'))) { continue }
+    $kept = @()
+    foreach ($handler in @($group['hooks'])) {
+      $isMatch = (($handler -is [Collections.IDictionary]) -and $handler.ContainsKey('command') -and $handler['command'] -eq $command)
+      if ($isMatch -and $seen) { $changed = $true; continue }
+      if ($isMatch) { $seen = $true }
+      $kept += @($handler)
+    }
+    if (@($kept).Count -ne @($group['hooks']).Count) { $group['hooks'] = @($kept) }
+  }
+  if (-not $seen) {
+    $entry = @{ hooks = @(@{ type = 'command'; command = $command }) }
+    if ($matcher) { $entry['matcher'] = $matcher }
+    $groups += @($entry)
+    $changed = $true
+  }
+  if ($changed) { $settings['hooks'][$event] = @($groups) }
+  return $changed
+}
+
+function Report-ManagedScriptHealth ([string]$label, [string]$source, [string]$installed) {
+  if (-not (Test-Path $installed -PathType Leaf)) { Warn "$label missing: $installed"; return }
+  if (-not (Test-Path $source -PathType Leaf)) { Warn "$label source missing from harness: $source"; return }
+  if ((Get-FileHash $source -Algorithm SHA256).Hash -eq (Get-FileHash $installed -Algorithm SHA256).Hash) {
+    Ok "$label healthy (matches this harness)"
+  } else {
+    Warn "$label stale or customized: $installed"
+  }
+}
+
+function Report-ClaudeStatuslineSignal ([string]$path) {
+  # Static inspection only. Doctor must never execute a user's configured statusLine command.
+  if (-not (Test-Path $path -PathType Leaf)) { Warn "standard Claude statusline missing: $path"; return }
+  $body = Get-Content $path -Raw
+  if (($body -match [regex]::Escape('context_window')) -and
+      ($body -match [regex]::Escape('used_percentage')) -and
+      ($body -match [regex]::Escape('session_id')) -and
+      ($body -match [regex]::Escape('claude-ctx-'))) {
+    Ok 'standard Claude statusline contains the per-session context-signal writer'
+  } else {
+    Warn 'standard Claude statusline is present but no per-session context-signal writer was detected'
+  }
+}
+
 function Install-ClaudeHandoffHooks {
   $hooksDir = Join-Path $CcDir 'hooks'
   New-Item -ItemType Directory -Force -Path $hooksDir | Out-Null
   Copy-Item (Join-Path $HarnessDir 'hooks/handoff-on-keyword.sh')   (Join-Path $hooksDir 'handoff-on-keyword.sh')   -Force
   Copy-Item (Join-Path $HarnessDir 'hooks/context-budget-nudge.sh') (Join-Path $hooksDir 'context-budget-nudge.sh') -Force
-  Ok "handoff hook scripts → $hooksDir"
-  Copy-Item (Join-Path $HarnessDir 'config/statusline-command.sh') (Join-Path $CcDir 'statusline-command.sh') -Force
+  Ok "handoff hook scripts refreshed → $hooksDir"
+
+  $statusline = Join-Path $CcDir 'statusline-command.sh'
+  if (Test-Path $statusline) {
+    Ok "existing Claude statusline preserved → $statusline"
+  } else {
+    Copy-Item (Join-Path $HarnessDir 'config/statusline-command.sh') $statusline -Force
+    Ok "Claude statusline installed → $statusline"
+  }
+  Report-ClaudeStatuslineSignal $statusline
+
   $settings = Join-Path $CcDir 'settings.json'
-  if (-not (Test-Path $settings)) { '{}' | Set-Content $settings -Encoding utf8 }
   $kw = 'bash ~/.claude/hooks/handoff-on-keyword.sh'
   $st = 'bash ~/.claude/hooks/context-budget-nudge.sh'
-  if (Select-String -Path $settings -SimpleMatch $kw -Quiet) { Ok "handoff hooks already wired in settings.json" }
-  else {
-    Copy-Item $settings "$settings.bak.$PID" -Force
-    try {
-      $s = Get-Content $settings -Raw | ConvertFrom-Json -AsHashtable
-      if (-not $s.ContainsKey('statusLine')) { $s['statusLine'] = @{ type = 'command'; command = 'bash ~/.claude/statusline-command.sh' } }
-      if (-not $s.ContainsKey('hooks')) { $s['hooks'] = @{} }
-      foreach ($evt in @('UserPromptSubmit','Stop')) { if (-not $s['hooks'].ContainsKey($evt)) { $s['hooks'][$evt] = @() } }
-      $s['hooks']['UserPromptSubmit'] = @($s['hooks']['UserPromptSubmit']) + @(@{ hooks = @(@{ type = 'command'; command = $kw }) })
-      $s['hooks']['Stop']             = @($s['hooks']['Stop'])             + @(@{ hooks = @(@{ type = 'command'; command = $st }) })
-      $s | ConvertTo-Json -Depth 100 | Set-Content $settings -Encoding utf8
-      Ok "wired handoff hooks into settings.json (backup .bak.$PID)"
-    } catch { Warn "merge failed — add the snippet from hooks/README.md by hand" }
+  try {
+    $existed = Test-Path $settings
+    $s = if ($existed) { Get-Content $settings -Raw | ConvertFrom-Json -AsHashtable } else { @{} }
+    if ($s -isnot [Collections.IDictionary]) { throw 'settings.json must contain a JSON object' }
+    $changed = $false
+    if (-not $s.ContainsKey('statusLine')) {
+      $s['statusLine'] = @{ type = 'command'; command = 'bash ~/.claude/statusline-command.sh' }
+      $changed = $true
+    }
+    if (Ensure-JsonHookCommand $s 'UserPromptSubmit' $kw) { $changed = $true }
+    if (Ensure-JsonHookCommand $s 'Stop' $st) { $changed = $true }
+
+    if ($changed) {
+      $bak = if ($existed) { Backup-File $settings } else { $null }
+      $tmp = "$settings.agentsmith-new"
+      $s | ConvertTo-Json -Depth 100 | Set-Content $tmp -Encoding utf8
+      Get-Content $tmp -Raw | ConvertFrom-Json -AsHashtable | Out-Null
+      Move-Item $tmp $settings -Force
+      if ($bak) { Ok "reconciled handoff hooks in settings.json (backup: $(Split-Path $bak -Leaf))" }
+      else { Ok 'wired handoff hooks into new settings.json' }
+    } else {
+      Ok 'handoff hooks already wired once each in settings.json'
+    }
+  } catch {
+    Remove-Item "$settings.agentsmith-new" -Force -ErrorAction SilentlyContinue
+    Warn "merge failed — settings.json left unchanged; add the snippet from hooks/README.md by hand ($($_.Exception.Message))"
   }
   Write-Host ''; Say "Handoff hooks installed."
   Write-Host "  • 'handoff' / 'wrap up' in a prompt → injects the safe-state + recall-prompt protocol (reliable)"
@@ -821,28 +912,15 @@ function Add-CodexHook ([string]$event, [string]$command, [string]$matcher = '')
   try { $s = Get-Content $settings -Raw | ConvertFrom-Json -AsHashtable }
   catch { Warn "Codex hooks merge failed — hooks.json is not valid JSON; left it unchanged. Add the snippet from hooks/README.md by hand."; return $false }
   if ($s -isnot [Collections.IDictionary]) { Warn 'Codex hooks merge failed — hooks.json must contain a JSON object; left it unchanged.'; return $false }
-  if (-not $s.ContainsKey('hooks')) { $s['hooks'] = @{} }
-  elseif ($s['hooks'] -isnot [Collections.IDictionary]) { Warn 'Codex hooks merge failed — hooks.json "hooks" must be a JSON object; left it unchanged.'; return $false }
-  if (-not $s['hooks'].ContainsKey($event)) { $s['hooks'][$event] = @() }
-  foreach ($group in @($s['hooks'][$event])) {
-    if (($group -isnot [Collections.IDictionary]) -or (-not $group.ContainsKey('hooks'))) { continue }
-    foreach ($handler in @($group['hooks'])) {
-      if (($handler -is [Collections.IDictionary]) -and $handler.ContainsKey('command') -and $handler['command'] -eq $command) {
-        Ok "Codex $event hook already wired in hooks.json"
-        return $true
-      }
-    }
-  }
-  $entry = @{ hooks = @(@{ type = 'command'; command = $command }) }
-  if ($matcher) { $entry['matcher'] = $matcher }
-  $s['hooks'][$event] = @($s['hooks'][$event]) + @($entry)
-  $bak = Backup-File $settings
   try {
+    $changed = Ensure-JsonHookCommand $s $event $command $matcher
+    if (-not $changed) { Ok "Codex $event hook already wired once in hooks.json"; return $true }
+    $bak = Backup-File $settings
     $tmp = "$settings.agentsmith-new"
     $s | ConvertTo-Json -Depth 100 | Set-Content $tmp -Encoding utf8
     Get-Content $tmp -Raw | ConvertFrom-Json -AsHashtable | Out-Null
     Move-Item $tmp $settings -Force
-    Ok "wired Codex $event hook (backup: $(Split-Path $bak -Leaf))"
+    Ok "reconciled Codex $event hook (backup: $(Split-Path $bak -Leaf))"
     return $true
   } catch {
     Remove-Item "$settings.agentsmith-new" -Force -ErrorAction SilentlyContinue
@@ -1476,12 +1554,39 @@ if ($o.Doctor) {
   Say "Harness doctor — platform: $($o.Platform)"
   if (Has-Claude) {
     $settings = Join-Path $CcDir 'settings.json'
-    if (Test-Path $settings) { Ok 'Claude settings.json present'; try { Get-Content $settings -Raw | ConvertFrom-Json -AsHashtable | Out-Null } catch { Warn 'Claude settings.json is not valid JSON' } }
-    else { Warn "no $settings" }
+    $claudeSettings = $null
+    if (Test-Path $settings) {
+      try {
+        $claudeSettings = Get-Content $settings -Raw | ConvertFrom-Json -AsHashtable
+        if ($claudeSettings -is [Collections.IDictionary]) { Ok 'Claude settings.json present and valid' }
+        else { Warn 'Claude settings.json must contain a JSON object'; $claudeSettings = $null }
+      }
+      catch { Warn 'Claude settings.json is not valid JSON' }
+    } else { Warn "no $settings" }
     $gmd = Join-Path $CcDir 'CLAUDE.md'
     if (Test-Path $gmd) { Ok "global Claude rules present ($(@(Get-Content $gmd).Count) lines)" } else { Warn 'no global Claude rules (per-project only)' }
     $skills = Join-Path $CcDir 'skills'
     if (Test-Path $skills) { Ok "Claude skills: $(@(Get-ChildItem $skills -Directory).Count)" } else { Warn 'no Claude skills directory' }
+    $kw = 'bash ~/.claude/hooks/handoff-on-keyword.sh'
+    $st = 'bash ~/.claude/hooks/context-budget-nudge.sh'
+    Report-ManagedScriptHealth 'Claude keyword handoff script' (Join-Path $HarnessDir 'hooks/handoff-on-keyword.sh') (Join-Path $CcDir 'hooks/handoff-on-keyword.sh')
+    Report-ManagedScriptHealth 'Claude context-budget script' (Join-Path $HarnessDir 'hooks/context-budget-nudge.sh') (Join-Path $CcDir 'hooks/context-budget-nudge.sh')
+    if ($claudeSettings -is [Collections.IDictionary]) {
+      if (Test-JsonHookCommand $claudeSettings 'UserPromptSubmit' $kw) { Ok 'Claude keyword handoff hook wired' } else { Warn 'Claude keyword handoff hook not wired' }
+      if (Test-JsonHookCommand $claudeSettings 'Stop' $st) { Ok 'Claude context-budget Stop hook wired' } else { Warn 'Claude context-budget Stop hook not wired' }
+      $standardStatusline = 'bash ~/.claude/statusline-command.sh'
+      if (-not $claudeSettings.ContainsKey('statusLine')) {
+        Warn 'Claude statusLine is not configured; the context-percentage handoff cannot receive a signal'
+      } elseif (($claudeSettings['statusLine'] -isnot [Collections.IDictionary]) -or
+                (-not $claudeSettings['statusLine'].ContainsKey('command'))) {
+        Warn 'Claude statusLine configuration has no command'
+      } elseif ($claudeSettings['statusLine']['command'] -eq $standardStatusline) {
+        Ok 'Claude statusLine uses the standard local path'
+      } else {
+        Warn 'Claude uses a custom statusLine command; doctor did not execute it'
+      }
+    }
+    Report-ClaudeStatuslineSignal (Join-Path $CcDir 'statusline-command.sh')
     if (Have-Cmd claude) { Ok "'claude' CLI on PATH" } else { Warn "'claude' CLI not on PATH" }
   }
   if (Has-Codex) {
@@ -1491,7 +1596,19 @@ if ($o.Doctor) {
     if (Test-Path $gmd) { Ok "global Codex rules present ($(@(Get-Content $gmd).Count) lines)" } else { Warn 'no global Codex rules (per-project only)' }
     $skills = Join-Path $HOME '.agents/skills'
     if (Test-Path $skills) { Ok "Codex skills: $(@(Get-ChildItem $skills -Directory).Count)" } else { Warn 'no Codex skills directory' }
-    if (Test-Path (Join-Path $CodexDir 'hooks.json')) { Ok 'Codex hooks.json present (review trust with /hooks)' } else { Warn 'no Codex hooks.json' }
+    $codexHookScript = Join-Path $CodexDir 'hooks/handoff-on-keyword.sh'
+    Report-ManagedScriptHealth 'Codex keyword handoff script' (Join-Path $HarnessDir 'hooks/handoff-on-keyword.sh') $codexHookScript
+    $codexHooks = Join-Path $CodexDir 'hooks.json'
+    if (Test-Path $codexHooks) {
+      try {
+        $codexSettings = Get-Content $codexHooks -Raw | ConvertFrom-Json -AsHashtable
+        if ($codexSettings -isnot [Collections.IDictionary]) { throw 'hooks.json must contain a JSON object' }
+        Ok 'Codex hooks.json present and valid (review trust with /hooks)'
+        $codexCommand = 'bash ' + (Quote-BashPath $codexHookScript)
+        if (Test-JsonHookCommand $codexSettings 'UserPromptSubmit' $codexCommand) { Ok 'Codex keyword handoff hook wired' }
+        else { Warn 'Codex keyword handoff hook not wired' }
+      } catch { Warn 'Codex hooks.json is not valid JSON' }
+    } else { Warn 'no Codex hooks.json' }
   }
   exit 0
 }

--- a/setup.sh
+++ b/setup.sh
@@ -167,6 +167,24 @@ warn() { echo "  $(c '0;33' '!') $*"; }
 die()  { echo "$(c '0;31' '✗') $*" >&2; exit 1; }
 usage() { sed -n '2,/^# ====/p' "$0" | sed 's/^# \{0,1\}//'; exit 0; }
 
+# Statusline files are user-controlled code, even at the standard path. Doctor and installer
+# checks inspect the known signal filename only; they must never execute the file implicitly.
+statusline_has_context_signal_writer() {  # <script>
+  [ -f "$1" ] \
+    && grep -qF 'context_window' "$1" 2>/dev/null \
+    && grep -qF 'used_percentage' "$1" 2>/dev/null \
+    && grep -qF 'session_id' "$1" 2>/dev/null \
+    && grep -qF 'claude-ctx-' "$1" 2>/dev/null
+}
+
+doctor_script_state() {  # <label> <installed> <source>
+  local label="$1" installed="$2" source="$3"
+  if [ ! -f "$installed" ]; then warn "$label missing: $installed"
+  elif cmp -s "$installed" "$source"; then ok "$label current"
+  else warn "$label stale or locally modified — re-run --with-handoff-hooks"
+  fi
+}
+
 # ---- profile auto-detect + uninstall (used by --profile auto, the wizard, --uninstall) -----
 _has() {  # <dir> <glob...> -> 0 if any glob matches an existing entry (glob-safe under set -e)
   local d="$1"; shift; local p f
@@ -666,6 +684,21 @@ if $DO_DOCTOR; then
   if has_claude; then
     [ -f "$CC_DIR/settings.json" ] && ok "Claude settings.json present" || warn "no ~/.claude/settings.json"
     [ -f "$CC_DIR/statusline-command.sh" ] && ok "Claude statusline installed" || warn "no Claude statusline-command.sh"
+    doctor_script_state "Claude keyword handoff hook" "$CC_DIR/hooks/handoff-on-keyword.sh" "$HARNESS_DIR/hooks/handoff-on-keyword.sh"
+    doctor_script_state "Claude context handoff hook" "$CC_DIR/hooks/context-budget-nudge.sh" "$HARNESS_DIR/hooks/context-budget-nudge.sh"
+    if [ -f "$CC_DIR/settings.json" ] && command -v jq >/dev/null 2>&1; then
+      claude_kw="bash ~/.claude/hooks/handoff-on-keyword.sh"
+      claude_st="bash ~/.claude/hooks/context-budget-nudge.sh"
+      jq -e --arg c "$claude_kw" 'any(.hooks.UserPromptSubmit[]?.hooks[]?; .command == $c)' "$CC_DIR/settings.json" >/dev/null 2>&1 \
+        && ok "Claude keyword handoff hook wired" || warn "Claude keyword handoff hook not wired"
+      jq -e --arg c "$claude_st" 'any(.hooks.Stop[]?.hooks[]?; .command == $c)' "$CC_DIR/settings.json" >/dev/null 2>&1 \
+        && ok "Claude 30% handoff hook wired" || warn "Claude 30% handoff hook not wired"
+    else
+      warn "cannot inspect Claude hook wiring (settings.json or jq missing)"
+    fi
+    statusline_has_context_signal_writer "$CC_DIR/statusline-command.sh" \
+      && ok "Claude statusline contains the per-session context signal writer" \
+      || warn "Claude statusline has no context signal writer — keyword handoff still works, 30% handoff does not"
     if [ -f "$CC_DIR/CLAUDE.md" ]; then
       ok "Claude global rules present ($(wc -l < "$CC_DIR/CLAUDE.md") lines)"
       [ -f "$HARNESS_DIR/scripts/lint-leanness.sh" ] && bash "$HARNESS_DIR/scripts/lint-leanness.sh" "$CC_DIR/CLAUDE.md" 2>/dev/null | sed 's/^/  /'
@@ -684,6 +717,15 @@ if $DO_DOCTOR; then
     else warn "no Codex global rules (per-project only)"; fi
     [ -d "$HOME/.agents/skills" ] && ok "Codex skills: $(find "$HOME/.agents/skills" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l | tr -d ' ')" || warn "no Codex global skills directory"
     [ -f "$CODEX_DIR/hooks.json" ] && ok "Codex hooks.json present (review trust with /hooks)" || warn "no Codex hooks.json"
+    doctor_script_state "Codex keyword handoff hook" "$CODEX_DIR/hooks/handoff-on-keyword.sh" "$HARNESS_DIR/hooks/handoff-on-keyword.sh"
+    printf -v codex_handoff_q '%q' "$CODEX_DIR/hooks/handoff-on-keyword.sh"
+    codex_handoff_cmd="bash $codex_handoff_q"
+    if [ -f "$CODEX_DIR/hooks.json" ] && command -v jq >/dev/null 2>&1 \
+       && jq -e --arg c "$codex_handoff_cmd" 'any(.hooks.UserPromptSubmit[]?.hooks[]?; .command == $c)' "$CODEX_DIR/hooks.json" >/dev/null 2>&1; then
+      ok "Codex keyword handoff hook wired (trust separately with /hooks)"
+    else
+      warn "Codex keyword handoff hook not wired"
+    fi
     command -v codex >/dev/null 2>&1 && ok "'codex' CLI on PATH" || warn "'codex' CLI not on PATH"
   fi
   if [ "$PLATFORM" = both ] && [ -f "$CC_DIR/CLAUDE.md" ] && [ -f "$CODEX_DIR/AGENTS.md" ]; then
@@ -1186,29 +1228,53 @@ org_policy_install() {  # machine-wide managed CLAUDE.md + hardened settings (al
 install_claude_handoff_hooks() {  # keyword hook + Claude-only status-line context nudge
   command -v jq >/dev/null 2>&1 || die "--with-handoff-hooks needs jq (it edits settings.json)."
   mkdir -p "$CC_DIR/hooks"
+  # These two paths are AgentSmith-owned: refresh them on every run so an existing JSON entry
+  # cannot disguise a stale, incompatible script as a healthy installation (feedback 0010).
   cp "$HARNESS_DIR/hooks/handoff-on-keyword.sh"   "$CC_DIR/hooks/handoff-on-keyword.sh"
   cp "$HARNESS_DIR/hooks/context-budget-nudge.sh" "$CC_DIR/hooks/context-budget-nudge.sh"
   chmod +x "$CC_DIR/hooks/"*.sh 2>/dev/null || true
   ok "handoff hook scripts → $CC_DIR/hooks/"
-  # refresh the statusline so it persists the context-% signal the Stop hook reads
-  cp "$HARNESS_DIR/config/statusline-command.sh" "$CC_DIR/statusline-command.sh"; chmod +x "$CC_DIR/statusline-command.sh" 2>/dev/null || true
+
+  # A statusline is user-facing and commonly customized. Install ours only when absent; an
+  # existing one must be preserved byte-for-byte and probed for the side-channel signal.
+  if [ ! -e "$CC_DIR/statusline-command.sh" ]; then
+    cp "$HARNESS_DIR/config/statusline-command.sh" "$CC_DIR/statusline-command.sh"
+    chmod +x "$CC_DIR/statusline-command.sh" 2>/dev/null || true
+    ok "statusline installed"
+  else
+    ok "existing statusline preserved"
+  fi
   [ -f "$CC_DIR/settings.json" ] || echo '{}' > "$CC_DIR/settings.json"
   local kw="bash ~/.claude/hooks/handoff-on-keyword.sh"
   local st="bash ~/.claude/hooks/context-budget-nudge.sh"
-  if grep -qF "$kw" "$CC_DIR/settings.json" 2>/dev/null; then
-    ok "handoff hooks already wired in settings.json"
-  else
-    cp "$CC_DIR/settings.json" "$CC_DIR/settings.json.bak.$$"
-    if jq --arg kw "$kw" --arg st "$st" '
-        .statusLine = (.statusLine // {type:"command", command:"bash ~/.claude/statusline-command.sh"})
-        | .hooks.UserPromptSubmit = ((.hooks.UserPromptSubmit // []) + [{hooks:[{type:"command", command:$kw}]}])
-        | .hooks.Stop = ((.hooks.Stop // []) + [{hooks:[{type:"command", command:$st}]}])
-      ' "$CC_DIR/settings.json" > "$CC_DIR/settings.json.new"; then
-      mv "$CC_DIR/settings.json.new" "$CC_DIR/settings.json"; ok "wired handoff hooks into settings.json (backup .bak.$$)"
+  if jq --arg kw "$kw" --arg st "$st" '
+      def without_command($groups; $cmd):
+        [$groups[]
+          | if (.hooks | type) == "array" then
+              .hooks = [.hooks[] | select((.command // "") != $cmd)]
+              | select((.hooks | length) > 0)
+            else . end];
+      .statusLine = (.statusLine // {type:"command", command:"bash ~/.claude/statusline-command.sh"})
+      | .hooks = (.hooks // {})
+      | .hooks.UserPromptSubmit = (without_command((.hooks.UserPromptSubmit // []); $kw)
+          + [{hooks:[{type:"command", command:$kw}]}])
+      | .hooks.Stop = (without_command((.hooks.Stop // []); $st)
+          + [{hooks:[{type:"command", command:$st}]}])
+    ' "$CC_DIR/settings.json" > "$CC_DIR/settings.json.new"; then
+    if cmp -s "$CC_DIR/settings.json" "$CC_DIR/settings.json.new"; then
+      rm -f "$CC_DIR/settings.json.new"
+      ok "handoff hooks already wired in settings.json"
     else
-      rm -f "$CC_DIR/settings.json.new"; warn "jq merge failed — add the snippet from hooks/README.md by hand"
+      local bak; bak="$(backup_file "$CC_DIR/settings.json")"
+      mv "$CC_DIR/settings.json.new" "$CC_DIR/settings.json"
+      ok "wired missing handoff hook entries (backup: $(basename "$bak"))"
     fi
+  else
+    rm -f "$CC_DIR/settings.json.new"; warn "jq merge failed — add the snippet from hooks/README.md by hand"
   fi
+  statusline_has_context_signal_writer "$CC_DIR/statusline-command.sh" \
+    && ok "statusline context signal writer detected" \
+    || warn "existing statusline has no context signal writer — keyword handoff works, 30% handoff will remain inactive"
   echo; say "$(c '1;32' 'Handoff hooks installed.')"
   echo "  • 'handoff' / 'wrap up' in a prompt → injects the safe-state + recall-prompt protocol (reliable)"
   echo "  • context ≥ ${HANDOFF_PCT_THRESHOLD:-30}% used → one best-effort nudge to hand off early (fragile — see hooks/README.md)"
@@ -1221,17 +1287,26 @@ install_codex_handoff_hooks() {
   chmod +x "$CODEX_DIR/hooks/handoff-on-keyword.sh" 2>/dev/null || true
   [ -f "$CODEX_DIR/hooks.json" ] || echo '{}' > "$CODEX_DIR/hooks.json"
   local script_q cmd; printf -v script_q '%q' "$CODEX_DIR/hooks/handoff-on-keyword.sh"; cmd="bash $script_q"
-  if jq -e --arg c "$cmd" 'any(.hooks.UserPromptSubmit[]?.hooks[]?; .command == $c)' "$CODEX_DIR/hooks.json" >/dev/null 2>&1; then
-    ok "Codex handoff hook already wired in hooks.json"
-  else
-    local bak; bak="$(backup_file "$CODEX_DIR/hooks.json")"
-    if jq --arg c "$cmd" '.hooks.UserPromptSubmit = ((.hooks.UserPromptSubmit // []) + [{hooks:[{type:"command", command:$c}]}])' \
-         "$CODEX_DIR/hooks.json" > "$CODEX_DIR/hooks.json.new"; then
-      mv "$CODEX_DIR/hooks.json.new" "$CODEX_DIR/hooks.json"
-      ok "wired Codex handoff keyword hook (backup: $(basename "$bak"))"
+  if jq --arg c "$cmd" '
+      .hooks = (.hooks // {})
+      | .hooks.UserPromptSubmit = (
+          [.hooks.UserPromptSubmit[]?
+            | if (.hooks | type) == "array" then
+                .hooks = [.hooks[] | select((.command // "") != $c)]
+                | select((.hooks | length) > 0)
+              else . end]
+          + [{hooks:[{type:"command", command:$c}]}])
+    ' "$CODEX_DIR/hooks.json" > "$CODEX_DIR/hooks.json.new"; then
+    if cmp -s "$CODEX_DIR/hooks.json" "$CODEX_DIR/hooks.json.new"; then
+      rm -f "$CODEX_DIR/hooks.json.new"
+      ok "Codex handoff hook already wired once in hooks.json"
     else
-      rm -f "$CODEX_DIR/hooks.json.new"; warn "Codex hooks merge failed — add the snippet from hooks/README.md by hand"
+      local bak; bak="$(backup_file "$CODEX_DIR/hooks.json")"
+      mv "$CODEX_DIR/hooks.json.new" "$CODEX_DIR/hooks.json"
+      ok "reconciled Codex handoff keyword hook (backup: $(basename "$bak"))"
     fi
+  else
+    rm -f "$CODEX_DIR/hooks.json.new"; warn "Codex hooks merge failed — add the snippet from hooks/README.md by hand"
   fi
   say "Codex does not receive the context-percentage nudge; it depends on Claude's status line."
   say "Open /hooks in Codex and trust the new hook before relying on it."


### PR DESCRIPTION
## Why

Configured handoff hooks could remain silently stale: the live macOS scripts used unsupported `grep -P`, the percentage path had no deterministic boundary suite, and rerunning setup risked overwriting a customized statusline.

## What changed

- refresh AgentSmith-owned Claude/Codex hook scripts while preserving custom statuslines and unrelated hooks
- reconcile managed hook entries independently and duplicate-free
- harden the 30%-used Claude cue with signal freshness, validation, and per-session isolation
- extend doctor diagnostics for missing/stale scripts, exact wiring, and context-signal capability
- document why full automatic session rollover remains a no-go on current stable runtime APIs

## Verification

- `bash scripts/verify.sh` — all 10 phases passed
- context-budget hook — 11/11 passed
- Bash platform installer — 97/97 passed
- ShellCheck warning level, secret scan, leak gate, and diff check passed
- live Claude statusline → 31% signal → Stop block verified; stale signals ignored
- live customized statusline and unrelated hook sets remained byte-identical

PowerShell parity received static and independent review; runtime execution is deferred because `pwsh` is unavailable on the development machine.
