### PR TITLE
Add spec-gated autonomous Claude/Codex runs

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -71,7 +71,7 @@ jobs:
       - name: shellcheck (advisory)
         continue-on-error: true
         run: |
-          sudo apt-get update -qq && sudo apt-get install -y -qq shellcheck
+          sudo apt-get update -qq && sudo apt-get install -y -qq shellcheck bubblewrap
           shellcheck --severity=warning setup.sh scripts/*.sh hooks/*.sh hooks/git/*.sh
 
       # The real gate. Same entry point the agent and the human use locally.

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # generated/assembled artifacts (the template ships sources, not outputs)
 *.zip
+__pycache__/
+*.pyc
 .harness/handoffs/
 # self-update remote (a user's private repo URL — keep it out of the tracked tree)
 .harness/remote

--- a/.harness/verify.conf
+++ b/.harness/verify.conf
@@ -17,7 +17,9 @@ leak-gate  :: bash scripts/test-leak-gate.sh
 identity   :: bash scripts/test-operator-identity.sh
 assemble   :: bash scripts/test-assemble.sh
 consent    :: bash scripts/test-tracker-consent.sh
+wayfinder-spec :: bash scripts/test-wayfinder-spec.sh
 ui-design-hook :: bash scripts/test-ui-design-reminder.sh
 handoff-hook :: bash scripts/test-handoff-on-keyword.sh
 context-budget-hook :: bash scripts/test-context-budget-nudge.sh
 platform-install :: bash scripts/test-platform-install.sh
+autonomous-run :: bash scripts/test-autonomous-run.sh

--- a/README.md
+++ b/README.md
@@ -165,11 +165,15 @@ Claude Code and Codex each layer their native global core with the project's nat
 
 That writes the selected native rule file(s) into your project, scaffolds the supporting structure,
 and installs only the selected platform's integration. Codex-only runs do not touch Claude
-marketplaces, plugins, status line, or `rtk` wiring. Re-run any time —
+marketplaces, plugins, or status line; RTK initializes Codex's own instruction wiring. Re-run any time —
 it's idempotent and only rewrites its own managed block.
 
+`software-dev` additionally receives the finite local autonomous-run controller and manifest
+template. Other profiles keep the universal Wayfinder skill without carrying coding-only runtime
+machinery.
+
 **Useful flags:** `--with-plugins dev-workflow,stack-lsp` (opt-in plugin packs, latest from
-source) · `--with-skills` (install the bundled 7-skill harness pack — see below) · `--with-hooks`
+source) · `--with-skills` (install the bundled 9-skill harness pack — see below) · `--with-hooks`
 (pre-commit secret-scan) · `--platform claude|codex|both` · `--also-agents-md` (deprecated,
 instruction-file-only compatibility) · `--also-gemini-md` ·
 `--update-plugins` · `--self-update` (pull a newer harness + re-assemble — see below) · `--doctor`
@@ -180,11 +184,13 @@ same scope, for example `./setup.sh --platform both --uninstall --target .` or `
 --global`; it removes managed content and reports config/scaffolding deliberately left in place.
 After installing Codex hooks, review and trust them with `/hooks`.
 
-**The bundled skill pack (`--with-skills`).** Seven self-contained, work-type-neutral skills you
+**The bundled skill pack (`--with-skills`).** Nine work-type-neutral skills you
 can invoke by name: **`/handoff`** (wrap up cleanly), **`/verify`** (is this shippable?),
 **`/harness-help`** (non-coder? start here — it explains your profile, rules, and what to type
 next), **`/harness-doctor`** (is my harness healthy?), **`/new-research`**, **`/new-feedback`**,
-**`/writing-rules`** (writing or reviewing anything an agent reads — a rule, a gate, a prompt).
+**`/writing-rules`** (writing or reviewing anything an agent reads — a rule, a gate, a prompt),
+**`/wayfinder`** (turn foggy work into an accepted spec and separate implementation tickets), and
+**`/autonomous-run`** (operate a bounded local maker/checker run from an accepted spec).
 They install into `.claude/skills` / `~/.claude/skills` for Claude and `.agents/skills` /
 `~/.agents/skills` for Codex; `both` creates independent copies. New to this? Start the selected
 runtime in your project and invoke `harness-help`.
@@ -210,9 +216,9 @@ core/         The universal rules — loaded every session. Lean by design (stat
 profiles/     10 work-type modules — one (or more) gets assembled into the native rule file.
 examples/     6 worked end-to-end projects (filled rule file + verify.conf, two bundle a skill).
 config/       Claude settings, Codex TOML support, statusline, MCP examples, the plugin matrix.
-skills/       Skill bundle: how-to, RECOMMENDED map, the 7-skill harness pack + example (--with-skills).
+skills/       Skill bundle: how-to, RECOMMENDED map, the 9-skill harness pack + example (--with-skills).
 scripts/      verify.sh (gate), new-research.sh, new-feedback.sh, handoff.sh, secret-scan.sh + leak-gate.sh (+their tests), install-git-hooks.sh.
-templates/    plan, progress-log, handoff, research-doc, quality-gate.
+templates/    plan, Wayfinder spec, progress-log, handoff, research-doc, quality-gate.
 docs/         The docs set — docs/README.md is the index: philosophy, newcomer guides, profiles, feedback/ log.
 setup.sh      Assembles native rule files + installs selected config/skills/hooks. The one command you run.
 setup.ps1     Native-Windows PowerShell port of setup.sh — same flags, same behaviour (incl. --wizard).

--- a/config/plugins.md
+++ b/config/plugins.md
@@ -97,19 +97,21 @@ compresses noisy command output — `git`, tests, package managers, `kubectl`/`t
 60–90% *before* it reaches the context window. It's the token-economics rule (keep context lean,
 fight context rot) applied to **tool output** instead of the rules file.
 
-Unlike everything else here it's **not a Claude Code plugin** — it's a small native binary plus a
-`PreToolUse` hook that transparently rewrites Bash commands (`git status` → `rtk git status`). So
-`setup.sh`/`setup.ps1` install it on its own track:
+Unlike everything else here it's **not a plugin** — it's a small native binary with runtime-specific
+wiring. Claude's `PreToolUse` hook transparently rewrites Bash commands (`git status` →
+`rtk git status`); Codex receives `RTK.md` command guidance because its hooks cannot replace tool
+input. `setup.sh`/`setup.ps1` install it on its own track:
 
 - **Default-ON for the code profiles** (`software-dev`, `devops-setup`); off everywhere else.
   Force it with `--with-rtk`, skip it with `--no-rtk`.
 - Install is per-OS (Homebrew / the official installer / a native Windows binary), then rtk's own
-  `rtk init -g --auto-patch` wires the hook, an `RTK.md`, and the `settings.json` entry — the
-  harness doesn't hand-maintain any of that. **Restart Claude Code** after install to load the hook.
+  initializer runs for every selected runtime: `rtk init -g --auto-patch` for Claude and
+  `rtk init -g --codex` for Codex (using the selected `CODEX_HOME`). The harness doesn't
+  hand-maintain those generated files. **Restart Claude Code** after install to load its hook.
 - Windows needs **ripgrep** (`rg`) on PATH for some filters (`winget install BurntSushi.ripgrep.MSVC`).
 - **Nothing is silently hidden:** the hook only touches Bash calls (Read/Grep/Glob bypass it), full
   output is teed to a log on failure, and `rtk proxy <cmd>` runs any command raw. Remove it all with
-  `rtk init -g --uninstall`.
+  the matching rtk uninstall command.
 
 ## A note on restraint (R10)
 

--- a/docs/05-operating-modes.md
+++ b/docs/05-operating-modes.md
@@ -1,11 +1,10 @@
-# Operating modes — sessions and loops
+# Operating modes — sessions, runs, and loops
 
-There are two ways to run this harness, and they differ in one thing only: **whether a human sees
-the output before it lands.** In an attended session you're in the loop — reading results,
-answering questions, merging PRs. In an autonomous loop the work takes effect with nobody
-watching. The dividing question, from the `autonomous-loops` profile: *"if this is wrong, will
-anyone notice before it lands?"* If yes, you're in session mode. If no, everything about how you
-operate has to change.
+There are three ways to run this harness, differing in duration and in whether a human sees the
+output before it lands. In an attended session, you read the result. A finite autonomous run works
+one accepted ticket overnight. A loop watches for recurring work. The dividing question from the
+`autonomous-loops` profile still governs both unattended modes: *"if this is wrong, will anyone
+notice before it lands?"* If no, the verification chain and blast-radius controls are mandatory.
 
 Rules live in the profiles (they're static context — restating them here would pay for them
 twice and drift). This doc is the part the profiles don't carry: when each mode fits, and how you
@@ -38,6 +37,18 @@ you, drop to conductor.**
 **End early, on purpose.** Hand off at ~25–30% of context *used* — quality degrades as the window
 fills, and the handoff note written while the agent still remembers everything is worth ten
 written at the bitter end. Saying "handoff" is not stopping work; it's how work survives.
+
+## Autonomous-run mode (finite, approved, unattended)
+
+A run is one accepted implementation ticket executed for hours without a person watching every
+turn. Unlike a loop, it has no watcher or schedule and cannot discover new work. Unlike an attended
+session, a controller automatically hands a committed attempt from a fresh maker to a fresh
+checker and either retries within the fixed contract or escalates.
+
+The run begins only after a human accepts a repository-owned terminal spec and names a separate
+implementation ticket. Its v1 authority ends at local commits on an isolated branch: no push,
+merge, tracker write, deployment, or other external action. See
+[`21-autonomous-runs.md`](21-autonomous-runs.md) for the protocol and commands.
 
 ## Loop mode (autonomy you earn, not configure)
 
@@ -122,10 +133,9 @@ regardless of which model or tool produced the work ([`03-verify-means-evidence.
 
 ## Choosing, and moving between them
 
-Start everything in session mode. Notice what's become routine — the items where you merge
-without reading closely, the sweeps you've watched succeed ten times. That's the work that's
-earned a loop, and the calibration you did watching it *was* L1. Move it out, one loop at a time,
-each with its own state file and metric.
+Start everything in session mode. A decision-complete, human-accepted ticket may graduate to a
+finite run. Repeated work that has become boring and measurable may graduate to a loop; the
+calibration you did while watching it was L1. Move it out one item or loop at a time.
 
 And the reverse rule is stricter: **a loop that surprises you drops back to session mode** —
 same day, no debate. Autonomy is cheap to revoke and expensive to over-extend. When a loop's work

--- a/docs/12-whats-built-in.md
+++ b/docs/12-whats-built-in.md
@@ -13,11 +13,11 @@ For the reasoning behind any of it, the cross-links point back to the doc that e
   you learn the flags. Direct commands use `--platform claude|codex|both`; default is `claude`.
 - **Native Windows setup** — `setup.ps1` is a PowerShell port of `setup.sh` with the same flags
   and behaviour (including `--wizard`), so Windows users don't need Git Bash just to set up.
-- **Bundled skill pack** — `setup.sh --with-skills` installs seven invoke-by-name skills:
+- **Bundled skill pack** — `setup.sh --with-skills` installs nine invoke-by-name skills:
   `/handoff`, `/verify`, `/harness-doctor`, `/harness-help`, `/new-research`, `/writing-rules`,
-  `/new-feedback`. The six procedural ones prefer a project-local `scripts/<x>.sh` when present,
-  else run inline, so they work globally, in a harness project, or in a bare repo; `/writing-rules`
-  is pure reference. Claude installs into `.claude/skills` / `~/.claude/skills`; Codex into
+  `/new-feedback`, `/wayfinder`, `/autonomous-run`. Procedural skills prefer a project-local
+  `scripts/<x>.sh`; `/writing-rules` is pure reference and `/wayfinder` is the decision-to-spec workflow.
+  Claude installs into `.claude/skills` / `~/.claude/skills`; Codex into
   `.agents/skills` / `~/.agents/skills`; `both` creates independent copies. See [`skills/README.md`](../skills/README.md)
   and [`skills/RECOMMENDED.md`](../skills/RECOMMENDED.md).
 - **Feedback / self-improvement loop** — a `docs/feedback/` convention + `scripts/new-feedback.sh`
@@ -42,6 +42,10 @@ For the reasoning behind any of it, the cross-links point back to the doc that e
   deterministic guards behind the rules ([`15-safety-model.md`](15-safety-model.md) covers the posture).
 - **Profile-aware `verify.conf` presets** — setup drops a starter `.harness/verify.conf` matched to
   the chosen profile(s) (dev → build/test; docs → spell/links; data → row-count reconcile).
+- **Finite autonomous-run controller** — `software-dev` setup scaffolds
+  `scripts/autonomous-run.py` and its manifest template for bounded, local-only Claude/Codex
+  maker-checker runs. Other profiles do not receive this coding-first v1 machinery; Wayfinder
+  remains universal. See [`21-autonomous-runs.md`](21-autonomous-runs.md).
 - **CI workflow (shipped example)** — [`.github/workflows/verify.yml`](../.github/workflows/verify.yml)
   runs the same `scripts/verify.sh` on every push/PR (plus a Windows `setup.ps1` job), so "green on my
   laptop" and "green in CI" can't drift. Setup does **not** install it into your project — copy it as a
@@ -53,9 +57,9 @@ For the reasoning behind any of it, the cross-links point back to the doc that e
   and skip manually owned name conflicts with an actionable warning.
 - **rtk output compressor** — `setup.sh`/`setup.ps1 --with-rtk` (default-ON for `software-dev` /
   `devops-setup`; `--no-rtk` to skip) installs [`rtk`](https://github.com/rtk-ai/rtk) and runs its
-  own `rtk init -g` to wire a PreToolUse hook that compresses noisy CLI output 60–90% before it
-  reaches context. A binary + hook, not a plugin, and Claude-only: Codex-only installs never invoke
-  its Claude wiring. See [`../config/plugins.md`](../config/plugins.md).
+  initializer for every selected runtime. Claude gets transparent PreToolUse command rewriting;
+  Codex gets `AGENTS.md` + `RTK.md` command guidance because its hooks cannot replace tool input.
+  See [`../config/plugins.md`](../config/plugins.md).
 - **Org-policy variant** — `sudo setup.sh --org-policy` installs a managed `CLAUDE.md` at the OS
   policy path (applies to all users on a shared box) + a stricter, no-bypass settings profile.
   This is Claude-only; an `--org-policy` run with platform `codex` or `both` is rejected.

--- a/docs/13-platforms-and-tools.md
+++ b/docs/13-platforms-and-tools.md
@@ -52,7 +52,8 @@ are skipped with an actionable warning.
 | UI-design reminder | Claude edit/write tools | Recognizes `apply_patch` and affected UI paths |
 | Context-percentage nudge | Best-effort; depends on Claude status line | ❌ |
 | `PreCompact` handoff | Not introduced in this release | Not introduced in this release |
-| Claude marketplaces/plugins/status line/`rtk` wiring | ✅ when selected | Never invoked by Codex-only installs |
+| Claude marketplaces/plugins/status line | ✅ when selected | Never invoked by Codex-only installs |
+| `rtk` wiring | Transparent hook + instructions | Instruction-level command guidance |
 | Organization policy | ✅ | Out of scope; rejected with an explanation |
 
 The keyword hook and written handoff procedure are the dependable cross-runtime mechanisms. Codex
@@ -62,8 +63,8 @@ approve them before relying on automatic invocation.
 ## Local, web, and other surfaces
 
 - **Claude Code locally** gets native rules, plugins, skills, hooks, MCP, and helper scripts.
-- **Codex locally** gets native rules, skills, hooks, MCP, and helper scripts without Claude-only
-  marketplaces, status line, or `rtk` setup.
+- **Codex locally** gets native rules, skills, hooks, MCP, helper scripts, and its own `rtk`
+  instruction setup, without Claude-only marketplaces or status line.
 - **claude.ai Projects / Cowork** can use `--export-instructions` for a paste-ready rules blob;
   local hooks, skills, and scripts do not travel into a prompt field.
 - **Gemini CLI** remains an instruction-file compatibility target through `--also-gemini-md`.

--- a/docs/14-project-tracker-guide.md
+++ b/docs/14-project-tracker-guide.md
@@ -28,6 +28,19 @@ historical record. This guide makes that concrete without assuming a specific to
 - **Branch from the item** when the tool supports it, so the branch ↔ item ↔ PR links itself and
   status transitions automatically.
 
+## Decision tickets and implementation tickets
+
+A decision ticket answers one question that blocks a safe plan. Its deliverable is a recorded
+answer and rationale, not code, copy, configuration, or another slice of the destination. For
+foggy multi-session work, `/wayfinder` or `$wayfinder` keeps the decision map in a repository spec
+under `docs/specs/`; see [`20-wayfinding-spec-flow.md`](20-wayfinding-spec-flow.md).
+
+The decision item closes only after the operator accepts the terminal spec. Implementation then
+starts from new, separately scoped tickets linked back to that spec. Never reuse the decision
+ticket as an implementation ticket: doing so hides the acceptance boundary and leaves later agents
+unable to tell which choices are settled. The write-consent policy applies to every create, update,
+comment, and close; ask-first mode produces paste-ready drafts for the operator.
+
 ## Mapping to common tools
 
 | Concept | Linear | GitHub | Jira | No tracker |

--- a/docs/18-influences.md
+++ b/docs/18-influences.md
@@ -93,7 +93,8 @@ and **LLM-as-judge** for foundation-model apps; a grounding text for the evidenc
 harness leans on (the `code-review` + `codex` review gates are this idea in practice).
 → [AI Engineering](https://www.oreilly.com/library/view/ai-engineering/9781098166298/)
 
-**Matt Pocock — *writing-for-agents*** (MIT, 2026) — the source for the `writing-rules` skill. This
+**Matt Pocock — *writing-for-agents* and *wayfinder*** (MIT, 2026) — the source for the
+`writing-rules` skill and the decision-map concepts in `wayfinder`. This
 harness's entire product is prose an agent reads, and this is the reference for writing it. Its
 central idea is the **two loads**: *context load*, what always-loaded material costs the agent's
 window every turn, versus *cognitive load*, what it costs the human to remember which document
@@ -109,6 +110,11 @@ told to "streamline" optimises for length because length is what it can see. The
 behavioural. Applying it to `core/60` found two adjacent bullets stating one meaning, and the merge
 paid for the new pointer.
 → [mattpocock/skills](https://github.com/mattpocock/skills) · [the reference](https://github.com/mattpocock/skills/blob/main/skills/productivity/writing-for-agents/SKILL.md)
+
+His `wayfinder` contributes destination, frontier, fog, and decision-index concepts for work too
+large or uncertain to plan in one pass. Agentsmith adapts those concepts to a repository-native
+terminal spec and retains its own external-write consent and decision/implementation ticket split.
+→ [the upstream skill](https://github.com/mattpocock/skills/blob/main/skills/engineering/wayfinder/SKILL.md)
 
 **Cobus Greyling — *Loop Engineering*** (MIT, 2026) — the source for `profiles/autonomous-loops.md`.
 Its framing draws the line this harness sits on: **`Harness = single session setup` / `Loop = harness

--- a/docs/19-glossary.md
+++ b/docs/19-glossary.md
@@ -59,6 +59,17 @@ an expert developer, most of the friction here is words — clear that, and the 
   harness treats naming it and being allowed to write to it as two different consents.
   → [`14-project-tracker-guide.md`](14-project-tracker-guide.md)
 
+## Wayfinding
+
+- **Wayfinder** — the dynamic workflow that turns a destination with an unclear route into an
+  operator-accepted repository spec. → [`20-wayfinding-spec-flow.md`](20-wayfinding-spec-flow.md)
+- **Decision ticket / implementation ticket** — the first resolves a question and records its
+  rationale; the second delivers one scoped part of an accepted spec. They are never the same item.
+- **Frontier / fog** — the frontier is the set of sharp, unblocked decisions available now; fog is
+  in-scope uncertainty that cannot yet be phrased as a precise decision.
+- **Terminal spec** — a spec with no unresolved choice an implementer must make. It remains a draft
+  until the operator explicitly accepts it.
+
 ## Verification
 
 - **Evidence** — an artifact a check produced (failing→passing test, wire response, rendered
@@ -75,6 +86,9 @@ an expert developer, most of the friction here is words — clear that, and the 
 
 ## Loops (unattended work)
 
+- **Autonomous run** — one finite, accepted implementation ticket executed by a local controller:
+  fresh maker → deterministic verifier → fresh checker → accept, retry, or escalate. Its v1
+  authority ends at local commits. → [`21-autonomous-runs.md`](21-autonomous-runs.md)
 - **Loop** — a harness plus a schedule, durable state, and a verification chain; work that lands
   with no human watching. → [`05-operating-modes.md`](05-operating-modes.md), `profiles/autonomous-loops.md`
 - **Maker / checker** — the mandatory split: the agent that did the work never judges it; a

--- a/docs/20-wayfinding-spec-flow.md
+++ b/docs/20-wayfinding-spec-flow.md
@@ -1,0 +1,38 @@
+# Wayfinding — from a foggy idea to an accepted spec
+
+Use Wayfinder when you know the destination but cannot yet write a decision-complete plan. It keeps
+planning work auditable without turning the tracker into a premature implementation backlog.
+
+Invoke `/wayfinder` in Claude Code or `$wayfinder` in Codex. The skill creates a living draft under
+`docs/specs/` from [`templates/wayfinder-spec.md`](../templates/wayfinder-spec.md). Repository storage
+makes the reasoning available to both runtimes and future sessions; the tracker remains the record
+of who owns each decision.
+
+## The flow
+
+1. **Chart:** define the destination and non-goals; map sharp decisions and their dependencies;
+   leave unshaped, in-scope uncertainty as fog.
+2. **Advance:** resolve one frontier decision per session. Record the detail once in its ticket or
+   durable artifact and keep only its linked gist in the decision index.
+3. **Terminal draft:** clear every blocking decision and either resolve or explicitly defer
+   non-blocking fog. Split the resulting work into independent implementation-ticket drafts.
+4. **Accept:** the operator explicitly accepts the spec. Only then does its status become
+   `accepted`, with `accepted_by` and `accepted_at` recorded; the decision ticket can close and
+   implementation becomes eligible to start.
+5. **Implement separately:** each build or delivery unit gets its own implementation ticket. The
+   accepted spec is its contract, not its ticket identity.
+
+Acceptance is a decision, not a formatting convention: an agent cannot accept its own draft.
+Likewise, a Linear connection is not consent. With the default ask-first policy, Wayfinder leaves
+paste-ready decision tickets, implementation tickets, and closing comments for the operator to
+post. See [`14-project-tracker-guide.md`](14-project-tracker-guide.md).
+
+## What terminal means
+
+An accepted spec has no unresolved question that an implementer must answer. Its evidence names
+the observable end state, its decisions link to their rationale, and each implementation ticket can
+be executed without inheriting hidden choices from the decision phase. Explicit deferrals are
+allowed only when they do not block the destination and name where the deferred work will live.
+
+Wayfinder is work-type-neutral: a destination can be code, a campaign, a research conclusion, or a
+document. It plans; the active work profile still defines what implementation and verification mean.

--- a/docs/21-autonomous-runs.md
+++ b/docs/21-autonomous-runs.md
@@ -1,0 +1,78 @@
+# Finite autonomous runs
+
+An autonomous run is the missing middle between an attended session and a recurring loop. It is a
+finite, approved implementation ticket that can run for hours without a person watching every
+turn. A loop watches forever; a run stops at one accepted local result or one explicit escalation.
+
+## The contract before the controller
+
+Planning and execution meet at two artifacts:
+
+1. an accepted Wayfinder terminal spec under `docs/specs/`; and
+2. a separate implementation ticket whose scope is one executable unit from that spec.
+
+The agent may write a draft spec, but it cannot accept its own spec. Starting the controller is a
+separate human action. If Linear writes are not authorized, the ticket remains a paste-ready draft
+until the operator posts it; naming Linear never grants the run a connector.
+
+Copy `templates/autonomous-run.json` through the controller's `prepare` command. The manifest pins
+the spec hash, ticket, base ref, maker/checker runtime and model, path boundary, verifier, attempt
+cap, wall-clock budget, and git/external-write policy. It must be reviewed and committed before
+`start` will accept it.
+
+## What runs overnight
+
+`scripts/autonomous-run.py start <manifest>` creates a sibling git worktree on an
+`agentsmith/<run-id>` branch. Each attempt is a fresh maker process. The maker must leave atomic
+local commits and a clean tree, then emit a schema-shaped receipt. The controller independently
+checks the commit, receipt, changed and ignored paths, fast-forward history, refs, config, hooks,
+existing Git objects, and other worktrees' administration. It then creates a disposable detached
+worktree at that exact commit: the deterministic verifier and fresh checker run there, never in
+the maker's retained worktree.
+
+The role map is data, not policy. Claude/Fable planning → Codex making → Claude checking and Claude
+making → Codex checking use the same protocol. Planning is normally attended; the overnight run
+begins only after the spec and implementation ticket are accepted.
+
+The v1 boundary is deliberately narrow:
+
+- local coding work only;
+- native Claude/Codex headless CLIs, no orchestration framework;
+- sandboxed workspace writes and no runtime connectors;
+- local commits, no push/PR/merge/history rewrite;
+- no Linear or other external-system writes;
+- maximum three attempts, then escalation;
+- one immutable wall-clock deadline across stop/resume;
+- no automatic context-percentage rollover.
+
+Codex receives the manifest objective and remaining native goal token budget. Claude receives only
+the remaining run-wide USD allowance. The controller accumulates usage reported by both CLIs and
+its persisted state remains authoritative, so resume cannot reset time or reported spend. Codex's
+CLI has no controller-enforced hard token switch; its native goal is the in-runtime cap, and the
+controller stops after reported usage crosses the manifest ceiling. Calibrate that limit in an
+attended run before treating it as a precise cost control.
+
+Claude receives a fail-closed sandbox configuration with no allowed network domains. The verifier
+runs with a credential-free environment, no network, no access to other home-directory file data,
+and no writes outside the disposable worktree. Read-only Git metadata remains visible so Git-based
+checks work. macOS uses the built-in sandbox; Linux requires `bubblewrap`. On any other host—or
+Linux without `bwrap`—verification exits closed instead of silently running unrestricted.
+Both roles start fresh; their receipts, not conversational memory, are the handoff.
+
+## Operations and recovery
+
+The controller and manifest template are scaffolded only for `software-dev` projects in v1; the
+Wayfinder spec flow remains available to every work type.
+
+`status <id>` reads controller state from the repository's git-common directory. `stop <id>` sends
+the active child a termination signal and retains the branch/worktree. `resume <id>` works only
+when the manifest and accepted spec hashes still match and the worktree is clean. A changed
+contract requires a new run ID rather than silently moving the goalposts. Paused time still counts
+against the original deadline.
+
+An accepted run prints the branch, commit, worktree, and evidence for human review. An escalated
+run prints the exact boundary that stopped it. Nothing leaves the machine until the operator
+separately authorizes the relevant external action.
+
+Before relying on this unattended, run one report-only fixture, observe one complete maker/checker
+cycle, and test `stop`. Autonomy is earned using the same ladder as the autonomous-loops profile.

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,8 @@ is a harness" to "make it your team's own," with the glossary as the appendix:
 | [`17-troubleshooting.md`](17-troubleshooting.md) | Symptom → cause → fix, for when it's behaving oddly at runtime. |
 | [`18-influences.md`](18-influences.md) | Full credits — who said each idea first, plus complementary work. |
 | [`19-glossary.md`](19-glossary.md) | Every harness term, one line each, with pointers. The appendix. |
+| [`20-wayfinding-spec-flow.md`](20-wayfinding-spec-flow.md) | Turn a foggy effort into an accepted terminal spec without collapsing decision and implementation tickets. |
+| [`21-autonomous-runs.md`](21-autonomous-runs.md) | Run one accepted coding ticket overnight through a local maker/checker controller. |
 | [`feedback/README.md`](feedback/README.md) | The post-incident log: how lessons become system changes. |
 | [`research/`](research/) | Source research the docs above were distilled from. |
 

--- a/docs/research/handoff-rollover-orchestration.md
+++ b/docs/research/handoff-rollover-orchestration.md
@@ -1,4 +1,10 @@
-# Research: automatic handoff rollover orchestration
+# Research: automatic handoff rollover orchestration (partially superseded)
+
+> **Superseded finding:** current Codex releases now document fresh thread creation and durable
+> goals, and both first-class runtimes expose stable headless execution. The no-go below remains
+> correct for *percentage-triggered transparent rollover*, but no longer blocks finite role-to-role
+> orchestration. Agentsmith now uses explicit, schema-validated role receipts instead; see
+> [`../21-autonomous-runs.md`](../21-autonomous-runs.md). This source note is retained under R9.
 
 > Decision note, verified 2026-08-25 against the shipped hooks and the locally installed
 > `codex-cli 0.149.0`. Keep this source material under `docs/research/` (R9); obsolete material
@@ -18,6 +24,8 @@ against undocumented runtime internals.
 | 1 | [Claude Code hooks reference](https://code.claude.com/docs/en/hooks) and [guide](https://code.claude.com/docs/en/hooks-guide) | 2026-08-25 | primary/vendor |
 | 2 | `hooks/context-budget-nudge.sh`, `hooks/handoff-on-keyword.sh`, `config/statusline-command.sh`, and `scripts/handoff.sh` in this repository | 2026-08-25 | primary/local |
 | 3 | Local `codex-cli 0.149.0` help for `queue`, `fork`, and experimental `app-server` | 2026-08-25 | primary/runtime |
+| 4 | [Codex non-interactive mode](https://learn.chatgpt.com/docs/non-interactive-mode), [goals](https://learn.chatgpt.com/use-cases/follow-goals), and [App Server](https://learn.chatgpt.com/docs/app-server) | 2026-08-25 | primary/vendor |
+| 5 | Local Claude Code 2.1.245 help for headless JSON output, structured schemas, budgets, sessions, and worktrees | 2026-08-25 | primary/runtime |
 
 ## Current trigger availability
 
@@ -72,7 +80,7 @@ Build a small, opt-in prototype for a runtime only when all of these are true:
 
 ## Conclusion / recommendation
 
-**No-go for an automatic rollover orchestrator today.** Keep the 30%-used Claude nudge as a
+**No-go for an automatic percentage-triggered rollover orchestrator.** Keep the 30%-used Claude nudge as a
 best-effort enforced cue and the keyword hook as the cross-runtime path. Do not build on Codex's
 experimental `app-server` or infer context consumption from internal/runtime files. Revisit with a
 bounded prototype when at least one runtime exposes both a stable context-usage event and a
@@ -84,4 +92,5 @@ able to prove the two facts that matter: *handoff completed* and *successor is f
 - Whether future Claude or Codex releases add a stable early-context event.
 - Whether a future Codex session-creation API documents blank-context rather than fork semantics.
 - Cross-platform process supervision and UI presentation; these matter only after the two primary
-  API gates above pass.
+  API gates above pass. Finite autonomous runs do not require this trigger: each declared role is
+  a fresh headless process and advances only after a validated durable receipt.

--- a/docs/research/wayfinder-adaptation.md
+++ b/docs/research/wayfinder-adaptation.md
@@ -1,0 +1,37 @@
+# Research: adapting Wayfinder for Agentsmith
+
+> Source assessment captured 2026-08-25. Keep under `docs/research/`; archive rather than delete
+> if superseded (R9).
+
+## Source inspected
+
+- Matt Pocock's [`skills` repository](https://github.com/mattpocock/skills), commit
+  `6654f6b60cd9d5be8b54c6fafe44346dabeb3b76`.
+- The upstream
+  [`wayfinder` skill](https://github.com/mattpocock/skills/blob/6654f6b60cd9d5be8b54c6fafe44346dabeb3b76/skills/engineering/wayfinder/SKILL.md)
+  and [maintainer guide](https://github.com/mattpocock/skills/blob/6654f6b60cd9d5be8b54c6fafe44346dabeb3b76/docs/engineering/wayfinder.md).
+
+## Decision
+
+**Adapt, do not adopt wholesale.** Keep destination, decision map, frontier, fog, linked decision
+index, and one-decision-per-session. Package them as one dynamic skill so the universal static
+surface does not grow.
+
+Agentsmith deliberately changes the terminal seam:
+
+- the repository owns the complete cross-runtime spec;
+- the operator alone changes a draft to accepted;
+- decision tickets resolve questions, while separate implementation tickets deliver the result;
+- tracker availability never grants write consent; and
+- the active work profile defines verification for coding and non-coding destinations.
+
+## Gaps that prevented direct adoption
+
+Upstream ships no Linear consent recipe, treats structural completion as sufficient without
+Agentsmith's independent evaluation requirement, permits notes that could be interpreted as
+self-authorizing execution, and routes downstream conversion mainly toward software tests and
+vertical code slices. Those assumptions do not transfer safely to a universal coding/non-coding
+harness.
+
+The adapted behavior is implemented in `skills/wayfinder/SKILL.md`; its terminal artifact is
+`templates/wayfinder-spec.md`, and `scripts/test-wayfinder-spec.sh` guards the boundary.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,0 +1,8 @@
+# Specs
+
+Wayfinder keeps living decision maps and terminal specs here. Start from
+[`templates/wayfinder-spec.md`](../../templates/wayfinder-spec.md); initial status is `draft`, and
+only explicit operator acceptance advances it to `accepted` and fills `accepted_by` / `accepted_at`.
+
+The spec records decisions. Implementation proceeds through new, separately scoped tracker items;
+the active tracker-write consent policy governs creating, commenting on, or closing those items.

--- a/scripts/autonomous-run.py
+++ b/scripts/autonomous-run.py
@@ -1,0 +1,887 @@
+#!/usr/bin/env python3
+"""Finite, local-only maker/checker orchestration for Agentsmith.
+
+The controller deliberately has no tracker, push, PR, merge, or deployment adapter.  Its
+authority ends at a local worktree and local commits; a human decides what leaves the machine.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import hashlib
+import json
+import os
+import re
+import signal
+import shutil
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = 1
+RECEIPT_SCHEMA = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "status": {"type": "string", "enum": ["completed", "accepted", "rejected", "blocked"]},
+        "summary": {"type": "string"},
+        "commit": {"type": "string"},
+        "changed_paths": {"type": "array", "items": {"type": "string"}},
+        "evidence": {"type": "array", "items": {"type": "string"}},
+        "unresolved": {"type": "array", "items": {"type": "string"}},
+        "next_state": {"type": "string"},
+    },
+    "required": ["status", "summary", "commit", "changed_paths", "evidence", "unresolved", "next_state"],
+}
+
+
+class RunError(RuntimeError):
+    pass
+
+
+class RunInterrupted(RunError):
+    pass
+
+
+def now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def run(cmd: list[str] | str, cwd: Path, *, timeout: int | None = None,
+        env: dict[str, str] | None = None, shell: bool = False) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=cwd, text=True, capture_output=True, timeout=timeout,
+                          env=env, shell=shell, check=False)
+
+
+def git(repo: Path, *args: str, check: bool = True) -> str:
+    result = run(["git", *args], repo)
+    if check and result.returncode:
+        raise RunError(result.stderr.strip() or result.stdout.strip() or f"git {' '.join(args)} failed")
+    return result.stdout.strip()
+
+
+def repo_root(path: Path) -> Path:
+    result = run(["git", "rev-parse", "--show-toplevel"], path)
+    if result.returncode:
+        raise RunError("autonomous runs require a git repository")
+    return Path(result.stdout.strip()).resolve()
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RunError(f"cannot read JSON {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise RunError(f"{path} must contain a JSON object")
+    return value
+
+
+def write_json(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp = path.with_suffix(path.suffix + ".tmp")
+    temp.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n")
+    temp.replace(path)
+
+
+def state_root(repo: Path) -> Path:
+    common = git(repo, "rev-parse", "--git-common-dir")
+    common_path = Path(common)
+    if not common_path.is_absolute():
+        common_path = (repo / common_path).resolve()
+    return common_path / "agentsmith-runs"
+
+
+def state_path(repo: Path, run_id: str) -> Path:
+    return state_root(repo) / run_id / "state.json"
+
+
+def event(state: dict[str, Any], kind: str, **fields: Any) -> None:
+    path = Path(state["state_path"]).parent / "events.jsonl"
+    record = {"at": now(), "event": kind, **fields}
+    with path.open("a") as handle:
+        handle.write(json.dumps(record, sort_keys=True) + "\n")
+
+
+def save_state(state: dict[str, Any], kind: str | None = None, **fields: Any) -> None:
+    state["updated_at"] = now()
+    write_json(Path(state["state_path"]), state)
+    if kind:
+        event(state, kind, **fields)
+
+
+def frontmatter(text: str) -> dict[str, str]:
+    if not text.startswith("---\n"):
+        raise RunError("spec must begin with YAML-style frontmatter")
+    end = text.find("\n---\n", 4)
+    if end < 0:
+        raise RunError("spec frontmatter is not closed")
+    values: dict[str, str] = {}
+    for raw in text[4:end].splitlines():
+        if not raw.strip() or raw.lstrip().startswith("#") or ":" not in raw:
+            continue
+        key, value = raw.split(":", 1)
+        values[key.strip()] = value.strip().strip('"\'')
+    return values
+
+
+def validate_manifest(manifest: dict[str, Any], repo: Path) -> tuple[Path, str]:
+    required = ["schema_version", "run_id", "spec_path", "implementation_ticket", "base_ref",
+                "roles", "scope", "verify", "limits", "git", "external_writes"]
+    missing = [key for key in required if key not in manifest]
+    if missing:
+        raise RunError(f"manifest missing: {', '.join(missing)}")
+    if manifest["schema_version"] != SCHEMA_VERSION:
+        raise RunError(f"unsupported schema_version {manifest['schema_version']}")
+    run_id = str(manifest["run_id"])
+    if not run_id or any(ch not in "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_" for ch in run_id):
+        raise RunError("run_id may contain only letters, digits, '-' and '_'")
+    if not str(manifest["implementation_ticket"]).strip():
+        raise RunError("implementation_ticket is required; a decision ticket is not executable work")
+    if manifest["external_writes"] is not False:
+        raise RunError("v1 requires external_writes=false")
+    git_policy = manifest["git"]
+    expected = {"local_commits": True, "push": False, "merge": False, "history_rewrite": False}
+    if any(git_policy.get(k) != v for k, v in expected.items()):
+        raise RunError("git policy must allow local commits only and forbid push/merge/history rewrite")
+    for role in ("maker", "checker"):
+        config = manifest["roles"].get(role, {})
+        if config.get("runtime") not in {"claude", "codex"}:
+            raise RunError(f"roles.{role}.runtime must be claude or codex")
+    limits = manifest["limits"]
+    if not 1 <= int(limits.get("max_attempts", 0)) <= 3:
+        raise RunError("limits.max_attempts must be between 1 and 3")
+    if int(limits.get("wall_minutes", 0)) <= 0:
+        raise RunError("limits.wall_minutes must be positive")
+    spec_rel = Path(str(manifest["spec_path"]))
+    if spec_rel.is_absolute() or ".." in spec_rel.parts or spec_rel.parts[:2] != ("docs", "specs"):
+        raise RunError("spec_path must be a repository-relative path under docs/specs/")
+    shown = git(repo, "show", f"{manifest['base_ref']}:{spec_rel.as_posix()}", check=False)
+    if not shown:
+        raise RunError("accepted spec must be committed at base_ref")
+    meta = frontmatter(shown)
+    if meta.get("status") != "accepted":
+        raise RunError("spec status must be accepted; agents may only author draft specs")
+    if not meta.get("accepted_by") or not meta.get("accepted_at"):
+        raise RunError("accepted spec requires accepted_by and accepted_at")
+    if not meta.get("decision_ticket"):
+        raise RunError("accepted spec requires a decision_ticket reference")
+    if str(manifest["implementation_ticket"]) == meta.get("decision_ticket"):
+        raise RunError("implementation_ticket must be separate from decision_ticket")
+    digest = hashlib.sha256(shown.encode()).hexdigest()
+    return spec_rel, digest
+
+
+def prepare(args: argparse.Namespace) -> int:
+    repo = repo_root(Path.cwd())
+    if args.template:
+        source = Path(args.template).resolve()
+    else:
+        source = repo / "templates/autonomous-run.json"
+        if not source.exists():
+            source = repo / ".harness/templates/autonomous-run.json"
+    manifest = load_json(source)
+    manifest["run_id"] = args.run_id
+    manifest["spec_path"] = args.spec
+    manifest["implementation_ticket"] = args.ticket
+    if args.maker:
+        manifest["roles"]["maker"]["runtime"] = args.maker
+    if args.checker:
+        manifest["roles"]["checker"]["runtime"] = args.checker
+    output = Path(args.output or f".harness/runs/{args.run_id}.json")
+    output = output if output.is_absolute() else repo / output
+    if output.exists() and not args.force:
+        raise RunError(f"refusing to overwrite {output}; pass --force deliberately")
+    write_json(output, manifest)
+    print(f"prepared {output.relative_to(repo) if output.is_relative_to(repo) else output}")
+    print("review and commit the manifest, then invoke 'start' explicitly to authorize execution")
+    return 0
+
+
+def clean(repo: Path) -> bool:
+    return not git(repo, "status", "--porcelain")
+
+
+def load_run(repo: Path, run_id: str) -> dict[str, Any]:
+    path = state_path(repo, run_id)
+    if not path.exists():
+        raise RunError(f"no run state for {run_id}")
+    return load_json(path)
+
+
+def remaining_seconds(state: dict[str, Any], manifest: dict[str, Any]) -> int:
+    return max(0, int(float(state["deadline_epoch"]) - time.time()))
+
+
+def changed_paths(worktree: Path, base: str, head: str = "HEAD") -> list[str]:
+    output = git(worktree, "diff", "--name-only", f"{base}..{head}")
+    return [line for line in output.splitlines() if line]
+
+
+def file_digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest() if path.is_file() else "missing"
+
+
+def resolved_git_path(repo: Path, argument: str) -> Path:
+    raw = Path(git(repo, "rev-parse", argument))
+    return raw.resolve() if raw.is_absolute() else (repo / raw).resolve()
+
+
+def git_metadata(repo: Path) -> dict[str, Any]:
+    common = resolved_git_path(repo, "--git-common-dir")
+    active = resolved_git_path(repo, "--git-dir")
+    active_rel = active.relative_to(common) if active.is_relative_to(common) else None
+    hooks: list[tuple[str, str]] = []
+    hooks_dir = common / "hooks"
+    if hooks_dir.is_dir():
+        for path in sorted(item for item in hooks_dir.rglob("*") if item.is_file()):
+            hooks.append((str(path.relative_to(hooks_dir)), file_digest(path)))
+    protected: list[tuple[str, str]] = []
+    objects: list[tuple[str, str]] = []
+    branch_ref = git(repo, "symbolic-ref", "-q", "HEAD", check=False)
+    branch_log = Path("logs") / branch_ref if branch_ref else None
+    for path in sorted(item for item in common.rglob("*") if item.is_file()):
+        rel = path.relative_to(common)
+        if rel.parts[0] == "agentsmith-runs":
+            continue
+        if rel.parts[0] == "objects":
+            objects.append((rel.as_posix(), file_digest(path)))
+            continue
+        if rel.parts[0] == "refs" or (branch_log and rel == branch_log):
+            continue
+        if active_rel and (rel == active_rel or active_rel in rel.parents):
+            continue
+        protected.append((rel.as_posix(), file_digest(path)))
+    refs = git(repo, "for-each-ref", "--format=%(refname) %(objectname)").splitlines()
+    return {
+        "refs": refs,
+        "config": file_digest(common / "config"),
+        "config_worktree": file_digest(common / "config.worktree"),
+        "hooks": hooks,
+        "protected_files": protected,
+        "existing_objects": objects,
+    }
+
+
+def ignored_paths(worktree: Path) -> set[str]:
+    output = git(worktree, "ls-files", "--others", "--ignored", "--exclude-standard", "-z")
+    return {path for path in output.split("\0") if path}
+
+
+def validate_git_transition(worktree: Path, before: dict[str, Any], after: dict[str, Any],
+                            branch: str, old_head: str, new_head: str) -> None:
+    expected_ref = f"refs/heads/{branch} {new_head}"
+    before_other = [line for line in before["refs"] if not line.startswith(f"refs/heads/{branch} ")]
+    after_other = [line for line in after["refs"] if not line.startswith(f"refs/heads/{branch} ")]
+    if before_other != after_other or expected_ref not in after["refs"]:
+        raise RunError("runtime changed Git refs outside the active run branch")
+    for key in ("config", "config_worktree", "hooks", "protected_files"):
+        if before[key] != after[key]:
+            raise RunError(f"runtime changed protected Git metadata: {key}")
+    after_objects = dict(after["existing_objects"])
+    altered_objects = [path for path, digest in before["existing_objects"]
+                       if after_objects.get(path) != digest]
+    if altered_objects:
+        raise RunError("runtime altered existing Git objects")
+    before_object_paths = {path for path, _ in before["existing_objects"]}
+    new_objects = set(after_objects) - before_object_paths
+    invalid_objects = sorted(path for path in new_objects
+                             if not re.fullmatch(r"objects/[0-9a-f]{2}/[0-9a-f]{38}", path))
+    if invalid_objects:
+        raise RunError(f"runtime created non-object files in Git's object store: {', '.join(invalid_objects)}")
+    ancestor = run(["git", "merge-base", "--is-ancestor", old_head, new_head], worktree)
+    if ancestor.returncode:
+        raise RunError("maker history is not a fast-forward from the previous attempt")
+
+
+def validate_git_unchanged(before: dict[str, Any], after: dict[str, Any], actor: str) -> None:
+    for key in ("refs", "config", "config_worktree", "hooks", "protected_files", "existing_objects"):
+        if before[key] != after[key]:
+            raise RunError(f"{actor} changed protected Git metadata: {key}")
+
+
+def sandboxed_verify(command: str, cwd: Path, timeout: int, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    """Run the human-approved verifier with no network and no writes outside its worktree."""
+    common = resolved_git_path(cwd, "--git-common-dir")
+    if sys.platform == "darwin" and Path("/usr/bin/sandbox-exec").exists():
+        escaped = str(cwd).replace('"', '\\"')
+        escaped_common = str(common).replace('"', '\\"')
+        home = str(Path.home()).replace('"', '\\"')
+        profile = "\n".join([
+            "(version 1)",
+            "(allow default)",
+            "(deny network*)",
+            "(deny file-write*)",
+            f'(deny file-read-data (require-all (subpath "{home}") '
+            f'(require-not (subpath "{escaped}")) (require-not (subpath "{escaped_common}"))))',
+            f'(allow file-write* (subpath "{escaped}"))',
+            '(allow file-write* (subpath "/tmp") (subpath "/private/tmp"))',
+            '(allow file-write* (literal "/dev/null") (literal "/dev/dtracehelper"))',
+        ])
+        return run(["/usr/bin/sandbox-exec", "-p", profile, "/bin/bash", "-c", command],
+                   cwd, timeout=timeout, env=env)
+    if sys.platform.startswith("linux") and shutil.which("bwrap"):
+        home = Path.home().resolve()
+        args = ["bwrap", "--unshare-net", "--die-with-parent", "--ro-bind", "/", "/",
+                "--tmpfs", str(home)]
+        directories: set[Path] = set()
+        for target in (cwd.resolve(), common):
+            if target.is_relative_to(home):
+                current = home
+                for part in target.relative_to(home).parts:
+                    current /= part
+                    directories.add(current)
+        for directory in sorted(directories, key=lambda item: len(item.parts)):
+            args += ["--dir", str(directory)]
+        args += ["--bind", str(cwd), str(cwd), "--ro-bind", str(common), str(common),
+                 "--tmpfs", "/tmp", "--dev", "/dev", "--proc", "/proc",
+                 "--chdir", str(cwd), "/bin/bash", "-c", command]
+        return run(args,
+                   cwd, timeout=timeout, env=env)
+    return subprocess.CompletedProcess([], 126, "", "no supported fail-closed verifier sandbox (macOS sandbox-exec or Linux bubblewrap)")
+
+
+def path_allowed(path: str, manifest: dict[str, Any]) -> bool:
+    scope = manifest["scope"]
+    denied = scope.get("denied_paths", [])
+    allowed = scope.get("allowed_paths", [])
+    if any(fnmatch.fnmatch(path, pattern) or path == pattern.rstrip("/**") for pattern in denied):
+        return False
+    return bool(allowed) and any(fnmatch.fnmatch(path, pattern) or path == pattern.rstrip("/**") for pattern in allowed)
+
+
+def receipt_from(value: Any) -> dict[str, Any] | None:
+    if isinstance(value, dict):
+        if set(RECEIPT_SCHEMA["required"]).issubset(value):
+            return value
+        for key in ("structured_output", "result", "output", "message", "content", "item"):
+            if key in value:
+                found = receipt_from(value[key])
+                if found:
+                    return found
+        for child in value.values():
+            found = receipt_from(child)
+            if found:
+                return found
+    elif isinstance(value, list):
+        for child in reversed(value):
+            found = receipt_from(child)
+            if found:
+                return found
+    elif isinstance(value, str):
+        try:
+            return receipt_from(json.loads(value))
+        except json.JSONDecodeError:
+            return None
+    return None
+
+
+def parse_receipt(path: Path, stdout: str) -> dict[str, Any]:
+    candidates: list[Any] = []
+    if path.exists():
+        try:
+            candidates.append(json.loads(path.read_text()))
+        except json.JSONDecodeError:
+            pass
+    try:
+        candidates.append(json.loads(stdout))
+    except json.JSONDecodeError:
+        for line in stdout.splitlines():
+            try:
+                candidates.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    for value in reversed(candidates):
+        found = receipt_from(value)
+        if found:
+            if found.get("status") not in {"completed", "accepted", "rejected", "blocked"}:
+                continue
+            if not all(isinstance(found.get(key), str) for key in ("summary", "commit", "next_state")):
+                continue
+            if not all(isinstance(found.get(key), list) and
+                       all(isinstance(item, str) for item in found[key])
+                       for key in ("changed_paths", "evidence", "unresolved")):
+                continue
+            if set(found) != set(RECEIPT_SCHEMA["required"]):
+                continue
+            return found
+    raise RunError("runtime emitted no schema-valid receipt")
+
+
+def runtime_env() -> dict[str, str]:
+    env = os.environ.copy()
+    for key in list(env):
+        upper = key.upper()
+        if any(token in upper for token in
+               ("TOKEN", "SECRET", "PASSWORD", "PASSWD", "API_KEY", "PRIVATE_KEY",
+                "CREDENTIAL", "AUTH", "COOKIE", "SESSION", "LINEAR_", "SLACK_")):
+            env.pop(key, None)
+    env["GIT_TERMINAL_PROMPT"] = "0"
+    env["GIT_ASKPASS"] = "/usr/bin/false"
+    env.pop("SSH_AUTH_SOCK", None)
+    return env
+
+
+def verifier_env() -> dict[str, str]:
+    allowed = ("PATH", "LANG", "LC_ALL", "LC_CTYPE", "TERM", "TMPDIR", "SHELL")
+    env = {key: os.environ[key] for key in allowed if key in os.environ}
+    env.update({"HOME": "/tmp/agentsmith-verifier-home", "CI": "1",
+                "GIT_TERMINAL_PROMPT": "0", "GIT_ASKPASS": "/usr/bin/false"})
+    return env
+
+
+def usage_metrics(stdout: str) -> tuple[float, int]:
+    """Extract conservative per-invocation usage totals from Claude/Codex JSON output."""
+    values: list[Any] = []
+    try:
+        values.append(json.loads(stdout))
+    except json.JSONDecodeError:
+        for line in stdout.splitlines():
+            try:
+                values.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    costs: list[float] = []
+    token_blocks: list[int] = []
+
+    def walk(value: Any) -> None:
+        if isinstance(value, dict):
+            cost = value.get("total_cost_usd")
+            if isinstance(cost, (int, float)):
+                costs.append(float(cost))
+            tokens = sum(int(value.get(key, 0)) for key in
+                         ("input_tokens", "output_tokens", "cached_input_tokens", "reasoning_tokens")
+                         if isinstance(value.get(key, 0), (int, float)))
+            if tokens:
+                token_blocks.append(tokens)
+            for child in value.values():
+                walk(child)
+        elif isinstance(value, list):
+            for child in value:
+                walk(child)
+
+    for value in values:
+        walk(value)
+    return (max(costs, default=0.0), max(token_blocks, default=0))
+
+
+def launch_role(state: dict[str, Any], manifest: dict[str, Any], role: str, prompt: str,
+                *, role_worktree: Path | None = None) -> dict[str, Any]:
+    worktree = role_worktree or Path(state["worktree"])
+    role_cfg = manifest["roles"][role]
+    runtime = role_cfg["runtime"]
+    run_dir = Path(state["state_path"]).parent
+    stop_file = run_dir / "STOP"
+    if stop_file.exists():
+        raise RunInterrupted("stopped by operator")
+    receipt_path = run_dir / f"attempt-{state['attempt']}-{role}-receipt.json"
+    schema_path = run_dir / "receipt-schema.json"
+    write_json(schema_path, RECEIPT_SCHEMA)
+    timeout = remaining_seconds(state, manifest)
+    if timeout <= 0:
+        raise RunError("wall-clock budget exhausted")
+    env = runtime_env()
+    common_git = str(state_root(Path(state["repo"])).parent)
+    if runtime == "codex":
+        token_budget = int(manifest["limits"].get("codex_goal_tokens", 0))
+        if token_budget and int(state.get("codex_tokens_used", 0)) >= token_budget:
+            raise RunError("Codex run-wide token budget exhausted")
+        executable = os.environ.get("AGENTSMITH_CODEX_BIN", "codex")
+        cmd = [executable, "exec", "--json", "--sandbox", "workspace-write"]
+        if role == "maker":
+            cmd += ["--add-dir", common_git]
+        cmd += ["--disable", "hooks", "-c", "mcp_servers={}",
+               "-c", "sandbox_workspace_write.network_access=false", "-c", "approval_policy=never",
+               "--output-schema", str(schema_path), "-o", str(receipt_path)]
+        if role_cfg.get("model"):
+            cmd += ["--model", str(role_cfg["model"])]
+        if role_cfg.get("effort"):
+            cmd += ["-c", f'model_reasoning_effort="{role_cfg["effort"]}"']
+        cmd += [prompt]
+    else:
+        executable = os.environ.get("AGENTSMITH_CLAUDE_BIN", "claude")
+        settings_path = run_dir / "claude-sandbox.json"
+        settings = {
+            "sandbox": {
+                "enabled": True,
+                "failIfUnavailable": True,
+                "autoAllowBashIfSandboxed": True,
+                "allowUnsandboxedCommands": False,
+                "filesystem": {
+                    "allowWrite": [common_git] if role == "maker" else [],
+                    "denyRead": [str(Path.home())],
+                    "allowRead": [str(worktree), common_git],
+                },
+                "network": {"allowedDomains": [], "deniedDomains": ["*"]},
+            },
+            "permissions": {
+                "deny": ["WebFetch", "WebSearch", "mcp__*"]
+                + (["Edit", "Write", "NotebookEdit"] if role == "checker" else [])
+            },
+            "enableAllProjectMcpServers": False,
+        }
+        write_json(settings_path, settings)
+        cmd = [executable, "-p", "--output-format", "json", "--permission-mode", "dontAsk",
+               "--setting-sources", "",
+               "--strict-mcp-config", "--mcp-config", '{"mcpServers":{}}', "--settings", str(settings_path),
+               "--json-schema", json.dumps(RECEIPT_SCHEMA)]
+        if role_cfg.get("model"):
+            cmd += ["--model", str(role_cfg["model"])]
+        if role_cfg.get("effort"):
+            cmd += ["--effort", str(role_cfg["effort"])]
+        budget = float(manifest["limits"].get("claude_max_usd", 0))
+        remaining_budget = budget - float(state.get("claude_cost_usd", 0.0))
+        if budget and remaining_budget <= 0:
+            raise RunError("Claude run-wide USD budget exhausted")
+        if remaining_budget > 0:
+            cmd += ["--max-budget-usd", str(remaining_budget)]
+        cmd += [prompt]
+    event(state, "role_started", role=role, runtime=runtime, attempt=state["attempt"])
+    process = subprocess.Popen(cmd, cwd=worktree, text=True, stdout=subprocess.PIPE,
+                               stderr=subprocess.PIPE, env=env)
+    if stop_file.exists():
+        process.terminate()
+        process.wait(timeout=10)
+        raise RunInterrupted("stopped by operator")
+    state["active_pid"] = process.pid
+    save_state(state)
+    try:
+        stdout, stderr = process.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        process.terminate()
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            process.kill()
+        raise RunError(f"{role} exceeded wall-clock budget")
+    finally:
+        persisted = load_json(Path(state["state_path"]))
+        if persisted.get("status") == "interrupted":
+            state.update(persisted)
+        state["active_pid"] = None
+        save_state(state)
+    (run_dir / f"attempt-{state['attempt']}-{role}.stdout").write_text(stdout)
+    (run_dir / f"attempt-{state['attempt']}-{role}.stderr").write_text(stderr)
+    cost, tokens = usage_metrics(stdout)
+    if runtime == "claude":
+        state["claude_cost_usd"] = float(state.get("claude_cost_usd", 0.0)) + cost
+        tokens = 0
+    else:
+        state["codex_tokens_used"] = int(state.get("codex_tokens_used", 0)) + tokens
+        cost = 0.0
+    save_state(state, "usage_recorded", role=role, runtime=runtime, cost_usd=cost, tokens=tokens)
+    max_cost = float(manifest["limits"].get("claude_max_usd", 0))
+    if max_cost and state["claude_cost_usd"] > max_cost:
+        raise RunError("Claude run-wide USD budget exceeded")
+    max_tokens = int(manifest["limits"].get("codex_goal_tokens", 0))
+    if max_tokens and state["codex_tokens_used"] > max_tokens:
+        raise RunError("Codex run-wide token budget exceeded")
+    if process.returncode:
+        if state.get("status") == "interrupted" or stop_file.exists():
+            raise RunInterrupted("stopped by operator")
+        raise RunError(f"{runtime} {role} exited {process.returncode}: {stderr[-500:].strip()}")
+    receipt = parse_receipt(receipt_path, stdout)
+    write_json(receipt_path, receipt)
+    event(state, "role_completed", role=role, status=receipt["status"], attempt=state["attempt"])
+    return receipt
+
+
+def role_prompt(state: dict[str, Any], manifest: dict[str, Any], role: str,
+                prior: dict[str, Any] | None = None, verify_output: str = "") -> str:
+    spec = manifest["spec_path"]
+    scope = manifest["scope"]
+    base = state["base_head"]
+    common = f"""Run {state['run_id']} for implementation ticket {manifest['implementation_ticket']}.
+Read the accepted terminal spec at {spec}. This ticket is separate from its decision ticket.
+Allowed paths: {json.dumps(scope['allowed_paths'])}. Denied paths: {json.dumps(scope['denied_paths'])}.
+No network, connectors, tracker writes, push, PR, merge, deployment, production action, or history rewrite.
+Return only the requested JSON receipt. Never claim evidence you did not produce.
+"""
+    if role == "maker":
+        feedback = f"\nThe prior checker rejected the attempt:\n{json.dumps(prior, indent=2)}\n" if prior else ""
+        goal_budget = int(manifest["limits"].get("codex_goal_tokens", 0)) - int(state.get("codex_tokens_used", 0))
+        goal = (f"If your runtime exposes the native goal tool, create a goal for this exact ticket with token budget "
+                f"{goal_budget}; the manifest remains authoritative.\n") if (
+                    manifest["roles"]["maker"]["runtime"] == "codex" and goal_budget > 0) else ""
+        return common + goal + f"""Implement the smallest complete change, run {manifest['verify']['command']},
+and make atomic local commits only. Leave the worktree clean. HEAD must advance beyond {base}.
+Use status completed or blocked; do not mark your own work accepted.{feedback}"""
+    return common + f"""You are the independent checker and default to REJECT. Do not edit files or commit.
+Inspect the committed diff from {base} to HEAD, rerun the real verification command yourself
+({manifest['verify']['command']}), and try to falsify the acceptance criteria. Controller verification output:
+{verify_output[-6000:]}
+Use status accepted, rejected, or blocked."""
+
+
+def execute(state: dict[str, Any], manifest: dict[str, Any]) -> int:
+    worktree = Path(state["worktree"])
+    max_attempts = int(manifest["limits"]["max_attempts"])
+    prior = state.get("last_checker_receipt")
+    while state["attempt"] < max_attempts:
+        if (Path(state["state_path"]).parent / "STOP").exists():
+            raise RunInterrupted("stopped by operator")
+        if remaining_seconds(state, manifest) <= 0:
+            raise RunError("wall-clock budget exhausted")
+        state["attempt"] += 1
+        state["status"] = "making"
+        save_state(state, "attempt_started", attempt=state["attempt"])
+        before_head = git(worktree, "rev-parse", "HEAD")
+        before_meta = git_metadata(worktree)
+        before_ignored = ignored_paths(worktree)
+        maker_error: Exception | None = None
+        maker: dict[str, Any] | None = None
+        try:
+            maker = launch_role(state, manifest, "maker", role_prompt(state, manifest, "maker", prior))
+        except Exception as exc:
+            maker_error = exc
+        after_head = git(worktree, "rev-parse", "HEAD")
+        validate_git_transition(worktree, before_meta, git_metadata(worktree), state["branch"],
+                                before_head, after_head)
+        if maker_error:
+            raise maker_error
+        assert maker is not None
+        if maker["status"] == "blocked":
+            raise RunError(f"maker blocked: {maker['summary']}")
+        if after_head == before_head:
+            raise RunError("maker completed without creating a local commit")
+        if not clean(worktree):
+            raise RunError("maker left the worktree dirty")
+        paths = changed_paths(worktree, state["base_head"])
+        bad = [path for path in paths if not path_allowed(path, manifest)]
+        if bad:
+            raise RunError(f"maker changed paths outside scope: {', '.join(bad)}")
+        ignored_added = sorted(ignored_paths(worktree) - before_ignored)
+        ignored_bad = [path for path in ignored_added if not path_allowed(path, manifest)]
+        if ignored_bad:
+            raise RunError(f"maker created ignored paths outside scope: {', '.join(ignored_bad)}")
+        if maker["commit"] != after_head or sorted(maker["changed_paths"]) != sorted(paths):
+            raise RunError("maker receipt does not match the committed Git state")
+        state["status"] = "checking"
+        save_state(state)
+        checker_head = git(worktree, "rev-parse", "HEAD")
+        checker_worktree = worktree.with_name(f"{worktree.name}-check-{state['attempt']}")
+        if checker_worktree.exists():
+            raise RunError(f"refusing to overwrite checker worktree {checker_worktree}")
+        added = run(["git", "worktree", "add", "--detach", str(checker_worktree), checker_head],
+                    Path(state["repo"]))
+        if added.returncode:
+            raise RunError(added.stderr.strip() or "checker worktree creation failed")
+        try:
+            verify = sandboxed_verify(manifest["verify"]["command"], checker_worktree,
+                                      remaining_seconds(state, manifest), verifier_env())
+            verify_output = f"exit={verify.returncode}\nSTDOUT:\n{verify.stdout}\nSTDERR:\n{verify.stderr}"
+            verify_path = Path(state["state_path"]).parent / f"attempt-{state['attempt']}-verify.txt"
+            verify_path.write_text(verify_output)
+            checker_status = git(checker_worktree, "status", "--porcelain")
+            if checker_status:
+                raise RunError("verifier modified tracked state")
+            checker_ignored = ignored_paths(checker_worktree)
+            checker_meta = git_metadata(checker_worktree)
+            checker_error: Exception | None = None
+            checker: dict[str, Any] | None = None
+            try:
+                checker = launch_role(state, manifest, "checker",
+                                      role_prompt(state, manifest, "checker", verify_output=verify_output),
+                                      role_worktree=checker_worktree)
+            except Exception as exc:
+                checker_error = exc
+            validate_git_unchanged(checker_meta, git_metadata(checker_worktree), "checker")
+            if (git(checker_worktree, "rev-parse", "HEAD") != checker_head or
+                    git(checker_worktree, "status", "--porcelain") != checker_status or
+                    ignored_paths(checker_worktree) != checker_ignored):
+                raise RunError("checker modified its disposable worktree")
+            if checker_error:
+                raise checker_error
+            assert checker is not None
+            if checker["commit"] != checker_head or sorted(checker["changed_paths"]) != sorted(paths):
+                raise RunError("checker receipt does not match the committed Git state")
+        finally:
+            removed = run(["git", "worktree", "remove", "--force", str(checker_worktree)],
+                          Path(state["repo"]))
+            if removed.returncode:
+                event(state, "checker_worktree_cleanup_failed", path=str(checker_worktree),
+                      error=removed.stderr.strip())
+                raise RunError(f"could not remove disposable checker worktree: {removed.stderr.strip()}")
+        if verify.returncode == 0 and checker["status"] == "accepted":
+            state["status"] = "accepted"
+            state["accepted_commit"] = checker_head
+            state["last_checker_receipt"] = checker
+            save_state(state, "run_accepted", commit=checker_head)
+            print(f"accepted locally: {state['branch']} at {checker_head}")
+            print(f"worktree retained for human review: {worktree}")
+            print("nothing was pushed, merged, or written to an external system")
+            return 0
+        prior = checker
+        state["last_checker_receipt"] = checker
+        state["status"] = "retrying"
+        save_state(state, "attempt_rejected", attempt=state["attempt"], verify_exit=verify.returncode)
+    state["status"] = "escalated"
+    state["reason"] = f"attempt cap reached ({max_attempts})"
+    save_state(state, "run_escalated", reason=state["reason"])
+    print(state["reason"], file=sys.stderr)
+    return 2
+
+
+def start(args: argparse.Namespace) -> int:
+    repo = repo_root(Path.cwd())
+    manifest_path = Path(args.manifest).resolve()
+    manifest = load_json(manifest_path)
+    spec_rel, spec_hash = validate_manifest(manifest, repo)
+    if not clean(repo):
+        raise RunError("base worktree must be clean before an autonomous run starts")
+    try:
+        manifest_rel = manifest_path.relative_to(repo)
+    except ValueError as exc:
+        raise RunError("run manifest must live inside the repository") from exc
+    tracked = run(["git", "ls-files", "--error-unmatch", str(manifest_rel)], repo)
+    if tracked.returncode:
+        raise RunError("run manifest must be committed before start")
+    name = str(manifest["run_id"])
+    path = state_path(repo, name)
+    if path.exists():
+        raise RunError(f"run {name} already exists; use resume or choose another run_id")
+    base_head = git(repo, "rev-parse", str(manifest["base_ref"]))
+    if not git(repo, "config", "user.name", check=False) or not git(repo, "config", "user.email", check=False):
+        raise RunError("git user.name and user.email must be configured before local commits")
+    branch = f"agentsmith/{name}"
+    default_worktree = repo.parent / f"{repo.name}-{name}"
+    worktree = Path(manifest.get("worktree_path") or default_worktree).resolve()
+    if worktree.exists() or git(repo, "show-ref", "--verify", f"refs/heads/{branch}", check=False):
+        raise RunError(f"refusing to overwrite existing branch/worktree for {name}")
+    created = run(["git", "worktree", "add", "-b", branch, str(worktree), base_head], repo)
+    if created.returncode:
+        raise RunError(created.stderr.strip() or "git worktree creation failed")
+    state = {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": name,
+        "status": "prepared",
+        "attempt": 0,
+        "repo": str(repo),
+        "worktree": str(worktree),
+        "branch": branch,
+        "base_head": base_head,
+        "spec_path": spec_rel.as_posix(),
+        "spec_sha256": spec_hash,
+        "manifest_path": str(manifest_path),
+        "manifest_sha256": hashlib.sha256(manifest_path.read_bytes()).hexdigest(),
+        "started_at": now(),
+        "started_epoch": time.time(),
+        "deadline_epoch": time.time() + int(manifest["limits"]["wall_minutes"]) * 60,
+        "claude_cost_usd": 0.0,
+        "codex_tokens_used": 0,
+        "active_pid": None,
+        "state_path": str(path),
+    }
+    save_state(state, "run_started", branch=branch, worktree=str(worktree))
+    try:
+        return execute(state, manifest)
+    except RunInterrupted:
+        state.update(load_json(Path(state["state_path"])))
+        print(f"interrupted: {name}; use resume when ready", file=sys.stderr)
+        return 130
+    except (RunError, subprocess.TimeoutExpired) as exc:
+        state["status"] = "escalated"
+        state["reason"] = str(exc)
+        save_state(state, "run_escalated", reason=str(exc))
+        print(f"escalated: {exc}", file=sys.stderr)
+        return 2
+
+
+def status_cmd(args: argparse.Namespace) -> int:
+    repo = repo_root(Path.cwd())
+    state = load_run(repo, args.run_id)
+    keys = ["run_id", "status", "attempt", "active_pid", "branch", "worktree", "base_head",
+            "accepted_commit", "deadline_epoch", "claude_cost_usd", "codex_tokens_used",
+            "reason", "updated_at"]
+    print(json.dumps({key: state.get(key) for key in keys if state.get(key) is not None}, indent=2))
+    return 0
+
+
+def stop(args: argparse.Namespace) -> int:
+    repo = repo_root(Path.cwd())
+    state = load_run(repo, args.run_id)
+    (Path(state["state_path"]).parent / "STOP").touch()
+    pid = state.get("active_pid")
+    if pid:
+        try:
+            os.kill(int(pid), signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+    state["status"] = "interrupted"
+    state["reason"] = "stopped by operator"
+    save_state(state, "run_interrupted", reason=state["reason"])
+    print(f"stopped {args.run_id}; local worktree retained")
+    return 0
+
+
+def resume(args: argparse.Namespace) -> int:
+    repo = repo_root(Path.cwd())
+    state = load_run(repo, args.run_id)
+    if state["status"] == "accepted":
+        raise RunError("accepted runs do not resume")
+    manifest_path = Path(state["manifest_path"])
+    manifest = load_json(manifest_path)
+    if hashlib.sha256(manifest_path.read_bytes()).hexdigest() != state["manifest_sha256"]:
+        raise RunError("manifest changed since start; create a new run for a changed contract")
+    spec_text = git(repo, "show", f"{state['base_head']}:{state['spec_path']}")
+    if hashlib.sha256(spec_text.encode()).hexdigest() != state["spec_sha256"]:
+        raise RunError("spec changed since start; create a new run for a changed contract")
+    if not clean(Path(state["worktree"])):
+        raise RunError("cannot resume a dirty worktree")
+    (Path(state["state_path"]).parent / "STOP").unlink(missing_ok=True)
+    state["status"] = "resuming"
+    state["reason"] = None
+    save_state(state, "run_resumed")
+    try:
+        return execute(state, manifest)
+    except RunInterrupted:
+        state.update(load_json(Path(state["state_path"])))
+        print(f"interrupted: {args.run_id}; use resume when ready", file=sys.stderr)
+        return 130
+    except RunError as exc:
+        state["status"] = "escalated"
+        state["reason"] = str(exc)
+        save_state(state, "run_escalated", reason=str(exc))
+        print(f"escalated: {exc}", file=sys.stderr)
+        return 2
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description="Finite local Claude/Codex maker-checker runs")
+    sub = result.add_subparsers(dest="command", required=True)
+    prep = sub.add_parser("prepare", help="create a non-executing run manifest")
+    prep.add_argument("--run-id", required=True)
+    prep.add_argument("--spec", required=True)
+    prep.add_argument("--ticket", required=True)
+    prep.add_argument("--maker", choices=["claude", "codex"])
+    prep.add_argument("--checker", choices=["claude", "codex"])
+    prep.add_argument("--template")
+    prep.add_argument("--output")
+    prep.add_argument("--force", action="store_true")
+    prep.set_defaults(func=prepare)
+    begin = sub.add_parser("start", help="explicitly authorize and run a committed manifest")
+    begin.add_argument("manifest")
+    begin.set_defaults(func=start)
+    for name, func in (("status", status_cmd), ("stop", stop), ("resume", resume)):
+        item = sub.add_parser(name)
+        item.add_argument("run_id")
+        item.set_defaults(func=func)
+    return result
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        return int(args.func(args))
+    except RunError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test-autonomous-run.sh
+++ b/scripts/test-autonomous-run.sh
@@ -132,6 +132,25 @@ PY
     ;;
 esac
 
+if [ "$(uname -s)" = Linux ]; then
+  if python3 - "$ROOT/scripts/autonomous-run.py" "$ROOT" <<'PY'
+from pathlib import Path
+import sys
+namespace = {'__name__': 'agentsmith_sandbox_probe', '__file__': sys.argv[1]}
+exec(compile(Path(sys.argv[1]).read_text(), sys.argv[1], 'exec'), namespace)
+result = namespace['sandboxed_verify'](
+    'exit 0', Path(sys.argv[2]), 15, namespace['verifier_env']())
+raise SystemExit(result.returncode)
+PY
+  then
+    ok 'Linux verifier sandbox is operational'
+  else
+    ok 'Linux host forbids the verifier sandbox, so autonomous execution fails closed'
+    printf 'autonomous-run: %d passed, %d failed (state machine covered on macOS/Linux with an operational sandbox)\n' "$pass" "$fail"
+    exit 0
+  fi
+fi
+
 if [ "$(uname -s)" = Darwin ] && [[ "$ROOT" = "$HOME/"* ]] &&
    [ "$(git -C "$ROOT" rev-parse --git-dir)" != "$(git -C "$ROOT" rev-parse --git-common-dir)" ]; then
   if python3 - "$ROOT/scripts/autonomous-run.py" "$ROOT" "$HOME/.gitconfig" <<'PY'

--- a/scripts/test-autonomous-run.sh
+++ b/scripts/test-autonomous-run.sh
@@ -113,6 +113,25 @@ invoke() {
     python3 "$repo/../fake/controller.py" "$@"
 }
 
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*)
+    if python3 - "$ROOT/scripts/autonomous-run.py" "$ROOT" <<'PY'
+from pathlib import Path
+import sys
+namespace = {'__name__': 'agentsmith_sandbox_probe', '__file__': sys.argv[1]}
+exec(compile(Path(sys.argv[1]).read_text(), sys.argv[1], 'exec'), namespace)
+result = namespace['sandboxed_verify'](
+    'exit 0', Path(sys.argv[2]), 15, namespace['verifier_env']())
+raise SystemExit(0 if result.returncode == 126 else 1)
+PY
+    then ok 'unsupported Windows verifier fails closed instead of running unrestricted'
+    else bad 'unsupported Windows verifier did not fail closed'; fi
+    printf 'autonomous-run: %d passed, %d failed (state machine covered on macOS/Linux)\n' "$pass" "$fail"
+    [ "$fail" -eq 0 ]
+    exit
+    ;;
+esac
+
 if [ "$(uname -s)" = Darwin ] && [[ "$ROOT" = "$HOME/"* ]] &&
    [ "$(git -C "$ROOT" rev-parse --git-dir)" != "$(git -C "$ROOT" rev-parse --git-common-dir)" ]; then
   if python3 - "$ROOT/scripts/autonomous-run.py" "$ROOT" "$HOME/.gitconfig" <<'PY'

--- a/scripts/test-autonomous-run.sh
+++ b/scripts/test-autonomous-run.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+# Deterministic controller tests: fake runtimes exercise the state machine without API calls.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+pass=0; fail=0
+ok()  { printf '  \033[32m✓\033[0m %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  \033[31m✗\033[0m %s\n' "$1"; fail=$((fail+1)); }
+assert() { local label="$1"; shift; if "$@"; then ok "$label"; else bad "$label"; fi; }
+
+make_fake() {
+  local path="$1"
+  mkdir -p "$path/bin"
+  cp "$ROOT/scripts/autonomous-run.py" "$path/controller.py"
+  chmod +x "$path/controller.py"
+  cp "$ROOT/templates/autonomous-run.json" "$path/template.json"
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'set -euo pipefail' \
+    'prompt="${!#}"' \
+    'receipt=""' \
+    'args=("$@")' \
+    'for ((i=0; i<${#args[@]}; i++)); do' \
+    '  if [ "${args[$i]}" = "-o" ]; then receipt="${args[$((i+1))]}"; fi' \
+    'done' \
+    'emit() {' \
+    '  local payload="$1"' \
+    '  if [ -n "$receipt" ]; then printf "%s\n" "$payload" > "$receipt"' \
+    '  else printf "{\"type\":\"result\",\"total_cost_usd\":0.25,\"structured_output\":%s}\n" "$payload"; fi' \
+    '}' \
+    'if [ "${FAKE_MODE:-accept}" = malformed ]; then emit "{}"; exit 0; fi' \
+    'if [[ "$prompt" == *"independent checker"* ]]; then' \
+    '  if [ "${FAKE_MODE:-accept}" = mutate-checker ]; then printf bad > src/checker.txt; fi' \
+    '  if [ "${FAKE_MODE:-accept}" = checker-ref ]; then git branch checker-escape; fi' \
+    '  count_file="${FAKE_COUNTER:-/tmp/agentsmith-fake-counter}"' \
+    '  count=0; [ -f "$count_file" ] && count="$(<"$count_file")"' \
+    '  count=$((count+1)); printf "%s" "$count" > "$count_file"' \
+    '  status=accepted' \
+    '  if [ "${FAKE_MODE:-accept}" = reject-once ] && [ "$count" -eq 1 ]; then status=rejected; fi' \
+    '  if [ "${FAKE_MODE:-accept}" = always-reject ]; then status=rejected; fi' \
+    '  emit "{\"status\":\"$status\",\"summary\":\"checker $status\",\"commit\":\"$(git rev-parse HEAD)\",\"changed_paths\":[\"src/change.txt\"],\"evidence\":[\"fake check\"],\"unresolved\":[],\"next_state\":\"$status\"}"' \
+    'else' \
+    '  if [ "${FAKE_MODE:-accept}" = slow ]; then sleep 20; fi' \
+    '  mkdir -p src' \
+    '  n=0; [ -f src/change.txt ] && n="$(<src/change.txt)"' \
+    '  printf "%s\n" "$((n+1))" > src/change.txt' \
+    '  changed="src/change.txt"' \
+    '  if [ "${FAKE_MODE:-accept}" = out-of-scope ]; then printf x > forbidden.txt; changed="forbidden.txt"; fi' \
+    '  if [ "${FAKE_MODE:-accept}" = ignored-outside ]; then printf x > ignored.tmp; fi' \
+    '  git add src/change.txt forbidden.txt 2>/dev/null || git add src/change.txt' \
+    '  if [ "${FAKE_MODE:-accept}" = amend-history ]; then git commit --amend --no-edit >/dev/null' \
+    '  else git commit -m "test(run): fake maker checkpoint" >/dev/null; fi' \
+    '  if [ "${FAKE_MODE:-accept}" = extra-ref ]; then git branch escaped-ref; fi' \
+    '  if [ "${FAKE_MODE:-accept}" = config-mutation ]; then git config --local agentsmith.escape true; fi' \
+    '  if [ "${FAKE_MODE:-accept}" = hook-mutation ]; then mkdir -p "$(git rev-parse --git-common-dir)/hooks"; printf bad > "$(git rev-parse --git-common-dir)/hooks/escaped"; fi' \
+    '  if [ "${FAKE_MODE:-accept}" = object-mutation ]; then object="$(git rev-parse HEAD^)"; object_path="$(git rev-parse --git-common-dir)/objects/${object:0:2}/${object:2}"; chmod u+w "$object_path"; printf bad > "$object_path"; fi' \
+    '  if [ "${FAKE_MODE:-accept}" = object-admin ]; then mkdir -p "$(git rev-parse --git-common-dir)/objects/info"; printf /tmp/escape > "$(git rev-parse --git-common-dir)/objects/info/alternates"; fi' \
+    '  if [ "${FAKE_MODE:-accept}" = other-index ]; then printf bad >> "$(git rev-parse --git-common-dir)/index"; fi' \
+    '  emit "{\"status\":\"completed\",\"summary\":\"fake maker\",\"commit\":\"$(git rev-parse HEAD)\",\"changed_paths\":[\"$changed\"],\"evidence\":[\"fake maker evidence\"],\"unresolved\":[],\"next_state\":\"checking\"}"' \
+    'fi' \
+    'if [ -n "$receipt" ]; then printf "%s\n" "{\"type\":\"turn.completed\",\"usage\":{\"input_tokens\":7,\"output_tokens\":3}}"; fi' > "$path/bin/fake-agent"
+  chmod +x "$path/bin/fake-agent"
+}
+
+new_repo() {
+  local name="$1" d
+  d="$TMP/$name/repo"
+  mkdir -p "$d/docs/specs" "$d/.harness/runs"
+  git -C "$d" init -q
+  git -C "$d" config user.name 'Harness Test'
+  git -C "$d" config user.email 'user@example.com'
+  printf '%s\n' \
+    'ignored.tmp' \
+    '---' \
+    'status: accepted' \
+    'decision_ticket: DEC-1' \
+    'accepted_by: Test Operator' \
+    'accepted_at: 2026-08-25' \
+    '---' \
+    '# Spec' \
+    '## Destination' \
+    'Create the bounded fixture.' > "$d/docs/specs/test.md"
+  sed -n '1p' "$d/docs/specs/test.md" > "$d/.gitignore"
+  sed '1d' "$d/docs/specs/test.md" > "$d/docs/specs/test.md.tmp"
+  mv "$d/docs/specs/test.md.tmp" "$d/docs/specs/test.md"
+  git -C "$d" add . && git -C "$d" commit -qm 'test: fixture'
+  printf '%s' "$d"
+}
+
+manifest() {
+  local repo="$1" id="$2"
+  python3 - "$repo" "$id" "$ROOT/templates/autonomous-run.json" <<'PY'
+import json, pathlib, sys
+repo, run_id, template = pathlib.Path(sys.argv[1]), sys.argv[2], pathlib.Path(sys.argv[3])
+value = json.loads(template.read_text())
+value.update(run_id=run_id, spec_path='docs/specs/test.md', implementation_ticket='IMP-1')
+value['scope']['allowed_paths'] = ['src/**']
+value['verify']['command'] = 'git rev-parse HEAD >/dev/null && test -f src/change.txt'
+value['limits'].update(max_attempts=3, wall_minutes=2)
+path = repo / '.harness' / 'runs' / f'{run_id}.json'
+path.write_text(json.dumps(value, indent=2) + '\n')
+PY
+  git -C "$repo" add . && git -C "$repo" commit -qm 'test: add run contract'
+}
+
+invoke() {
+  local repo="$1" mode="$2"; shift 2
+  FAKE_MODE="$mode" FAKE_COUNTER="$repo/../counter" \
+    AGENTSMITH_CODEX_BIN="$repo/../fake/bin/fake-agent" \
+    AGENTSMITH_CLAUDE_BIN="$repo/../fake/bin/fake-agent" \
+    python3 "$repo/../fake/controller.py" "$@"
+}
+
+if [ "$(uname -s)" = Darwin ] && [[ "$ROOT" = "$HOME/"* ]] &&
+   [ "$(git -C "$ROOT" rev-parse --git-dir)" != "$(git -C "$ROOT" rev-parse --git-common-dir)" ]; then
+  if python3 - "$ROOT/scripts/autonomous-run.py" "$ROOT" "$HOME/.gitconfig" <<'PY'
+from pathlib import Path
+import shlex
+import sys
+namespace = {'__name__': 'agentsmith_sandbox_probe', '__file__': sys.argv[1]}
+exec(compile(Path(sys.argv[1]).read_text(), sys.argv[1], 'exec'), namespace)
+private_probe = Path(sys.argv[3])
+private_check = f" && test ! -r {shlex.quote(str(private_probe))}" if private_probe.is_file() else ""
+result = namespace['sandboxed_verify'](
+    'git rev-parse HEAD >/dev/null' + private_check,
+    Path(sys.argv[2]), 15, namespace['verifier_env']())
+raise SystemExit(result.returncode)
+PY
+  then ok 'macOS verifier traverses linked Git metadata but not other HOME data'
+  else bad 'macOS verifier HOME boundary is incorrect'; fi
+fi
+
+echo 'autonomous-run — contract and successful handoff'
+repo="$(new_repo success)"; make_fake "$repo/../fake"; manifest "$repo" success
+if (cd "$repo" && invoke "$repo" accept start .harness/runs/success.json >../out 2>../err); then
+  ok 'maker → verifier → fresh checker accepts a local branch'
+else
+  bad 'successful fake run exited non-zero'
+  sed -n '1,120p' "$repo/../err" 2>/dev/null || true
+fi
+assert 'accepted run says no external action occurred' grep -q 'nothing was pushed' "$repo/../out"
+assert 'status reads durable accepted state' bash -c "cd '$repo' && python3 '$repo/../fake/controller.py' status success | grep -q '\"status\": \"accepted\"'"
+assert 'run branch exists only locally' git -C "$repo" show-ref --verify --quiet refs/heads/agentsmith/success
+assert 'runtime usage is accumulated across the run' python3 - "$repo/.git/agentsmith-runs/success/state.json" <<'PY'
+import json, sys
+s = json.load(open(sys.argv[1]))
+assert s['codex_tokens_used'] == 10
+assert s['claude_cost_usd'] == 0.25
+PY
+
+echo 'autonomous-run — rejection and bounded retry'
+repo="$(new_repo retry)"; make_fake "$repo/../fake"; manifest "$repo" retry
+if (cd "$repo" && invoke "$repo" reject-once start .harness/runs/retry.json >../out 2>../err); then
+  ok 'checker rejection is handed to a fresh maker attempt'
+else bad 'reject-once run did not recover'; fi
+assert 'retry state persists attempt count' bash -c "cd '$repo' && python3 '$repo/../fake/controller.py' status retry | grep -q '\"attempt\": 2'"
+
+echo 'autonomous-run — fail-closed gates'
+repo="$(new_repo scope)"; make_fake "$repo/../fake"; manifest "$repo" scope
+if (cd "$repo" && invoke "$repo" out-of-scope start .harness/runs/scope.json >../out 2>../err); then
+  bad 'out-of-scope maker change was accepted'
+else ok 'out-of-scope maker change escalates'; fi
+assert 'scope escalation names the unexpected path' grep -q 'outside scope: forbidden.txt' "$repo/../err"
+
+repo="$(new_repo mutate)"; make_fake "$repo/../fake"; manifest "$repo" mutate
+if (cd "$repo" && invoke "$repo" mutate-checker start .harness/runs/mutate.json >../out 2>../err); then
+  bad 'mutating checker was accepted'
+else ok 'checker mutation escalates'; fi
+assert 'checker mutation is explicit' grep -q 'checker modified its disposable worktree' "$repo/../err"
+
+repo="$(new_repo refs)"; make_fake "$repo/../fake"; manifest "$repo" refs
+if (cd "$repo" && invoke "$repo" extra-ref start .harness/runs/refs.json >../out 2>../err); then
+  bad 'maker-created side ref was accepted'
+else ok 'maker cannot mutate refs outside its run branch'; fi
+assert 'ref mutation is explicit' grep -q 'Git refs outside the active run branch' "$repo/../err"
+
+repo="$(new_repo config)"; make_fake "$repo/../fake"; manifest "$repo" config
+if (cd "$repo" && invoke "$repo" config-mutation start .harness/runs/config.json >../out 2>../err); then
+  bad 'maker Git config mutation was accepted'
+else ok 'maker cannot mutate repository config'; fi
+assert 'config mutation is explicit' grep -q 'protected Git metadata: config' "$repo/../err"
+
+repo="$(new_repo hooks)"; make_fake "$repo/../fake"; manifest "$repo" hooks
+if (cd "$repo" && invoke "$repo" hook-mutation start .harness/runs/hooks.json >../out 2>../err); then
+  bad 'maker Git hook mutation was accepted'
+else ok 'maker cannot mutate repository hooks'; fi
+assert 'hook mutation is explicit' grep -q 'protected Git metadata: hooks' "$repo/../err"
+
+repo="$(new_repo objects)"; make_fake "$repo/../fake"; manifest "$repo" objects
+if (cd "$repo" && invoke "$repo" object-mutation start .harness/runs/objects.json >../out 2>../err); then
+  bad 'maker existing-object corruption was accepted'
+else ok 'maker cannot alter existing Git objects'; fi
+if grep -q 'altered existing Git objects' "$repo/../err"; then
+  ok 'object corruption is explicit'
+else
+  sed -n '1,8p' "$repo/../err"
+  bad 'object corruption is explicit'
+fi
+
+repo="$(new_repo object-admin)"; make_fake "$repo/../fake"; manifest "$repo" object-admin
+if (cd "$repo" && invoke "$repo" object-admin start .harness/runs/object-admin.json >../out 2>../err); then
+  bad 'maker object-store administration file was accepted'
+else ok 'maker cannot add object-store administration files'; fi
+assert 'object-store administration escape is explicit' grep -q 'non-object files in Git' "$repo/../err"
+
+repo="$(new_repo other-index)"; make_fake "$repo/../fake"; manifest "$repo" other-index
+if (cd "$repo" && invoke "$repo" other-index start .harness/runs/other-index.json >../out 2>../err); then
+  bad 'maker main-worktree index mutation was accepted'
+else ok 'maker cannot alter another worktree index'; fi
+assert 'other-worktree mutation is explicit' grep -q 'protected Git metadata: protected_files' "$repo/../err"
+
+repo="$(new_repo rewrite)"; make_fake "$repo/../fake"; manifest "$repo" rewrite
+if (cd "$repo" && invoke "$repo" amend-history start .harness/runs/rewrite.json >../out 2>../err); then
+  bad 'maker history rewrite was accepted'
+else ok 'maker history rewrite is rejected'; fi
+assert 'history rewrite is explicit' grep -q 'not a fast-forward' "$repo/../err"
+
+repo="$(new_repo ignored)"; make_fake "$repo/../fake"; manifest "$repo" ignored
+if (cd "$repo" && invoke "$repo" ignored-outside start .harness/runs/ignored.json >../out 2>../err); then
+  bad 'ignored out-of-scope artifact was accepted'
+else ok 'ignored files remain inside declared scope'; fi
+assert 'ignored path escape is explicit' grep -q 'ignored paths outside scope: ignored.tmp' "$repo/../err"
+
+repo="$(new_repo checker-ref)"; make_fake "$repo/../fake"; manifest "$repo" checker-ref
+if (cd "$repo" && invoke "$repo" checker-ref start .harness/runs/checker-ref.json >../out 2>../err); then
+  bad 'checker-created ref was accepted'
+else ok 'checker cannot mutate shared Git refs'; fi
+assert 'checker ref mutation is explicit' grep -q 'checker changed protected Git metadata: refs' "$repo/../err"
+
+repo="$(new_repo verifier-escape)"; make_fake "$repo/../fake"; manifest "$repo" verifier-escape
+python3 - "$repo/.harness/runs/verifier-escape.json" <<'PY'
+import json, pathlib, sys
+p = pathlib.Path(sys.argv[1]); v = json.loads(p.read_text())
+v['verify']['command'] = 'printf escaped > ../escaped'
+p.write_text(json.dumps(v) + '\n')
+PY
+git -C "$repo" add . && git -C "$repo" commit -qm 'test: hostile verifier contract'
+if (cd "$repo" && AWS_SECRET_ACCESS_KEY=do-not-expose invoke "$repo" accept start .harness/runs/verifier-escape.json >../out 2>../err); then
+  bad 'escaping verifier was accepted'
+else ok 'verifier cannot write outside its disposable worktree'; fi
+assert 'verifier escape created no sibling artifact' test ! -e "$repo/../escaped"
+
+repo="$(new_repo draft)"; make_fake "$repo/../fake"; manifest "$repo" draft
+sed -i.bak 's/status: accepted/status: draft/' "$repo/docs/specs/test.md" && rm "$repo/docs/specs/test.md.bak"
+git -C "$repo" add . && git -C "$repo" commit -qm 'test: draft gate'
+if (cd "$repo" && invoke "$repo" accept start .harness/runs/draft.json >../out 2>../err); then
+  bad 'draft spec started implementation'
+else ok 'draft spec cannot start implementation'; fi
+assert 'draft rejection explains the human gate' grep -q 'spec status must be accepted' "$repo/../err"
+
+repo="$(new_repo malformed)"; make_fake "$repo/../fake"; manifest "$repo" malformed
+if (cd "$repo" && invoke "$repo" malformed start .harness/runs/malformed.json >../out 2>../err); then
+  bad 'malformed runtime receipt was accepted'
+else ok 'malformed runtime receipt escalates'; fi
+assert 'malformed receipt failure is explicit' grep -q 'no schema-valid receipt' "$repo/../err"
+
+repo="$(new_repo capped)"; make_fake "$repo/../fake"; manifest "$repo" capped
+if (cd "$repo" && invoke "$repo" always-reject start .harness/runs/capped.json >../out 2>../err); then
+  bad 'run exceeded its rejection cap'
+else ok 'three checker rejections escalate'; fi
+assert 'attempt cap is persisted and reported' grep -q 'attempt cap reached (3)' "$repo/../err"
+
+echo 'autonomous-run — operator stop and clean resume'
+repo="$(new_repo stopped)"; make_fake "$repo/../fake"; manifest "$repo" stopped
+(
+  cd "$repo" || exit 1
+  invoke "$repo" slow start .harness/runs/stopped.json >../out 2>../err
+) & runner=$!
+for _ in {1..50}; do
+  sleep 0.1
+  if (cd "$repo" && python3 "$repo/../fake/controller.py" status stopped 2>/dev/null | grep -Eq '"active_pid": [1-9]'); then break; fi
+done
+(cd "$repo" && python3 "$repo/../fake/controller.py" stop stopped >/dev/null 2>&1)
+wait "$runner" 2>/dev/null || true
+assert 'stop leaves durable interrupted state' bash -c "cd '$repo' && python3 '$repo/../fake/controller.py' status stopped | grep -q '\"status\": \"interrupted\"'"
+deadline_before="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["deadline_epoch"])' "$repo/.git/agentsmith-runs/stopped/state.json")"
+if (cd "$repo" && invoke "$repo" accept resume stopped >../resume-out 2>../resume-err); then
+  ok 'interrupted clean run resumes from durable state'
+else bad 'interrupted run did not resume'; fi
+deadline_after="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["deadline_epoch"])' "$repo/.git/agentsmith-runs/stopped/state.json")"
+assert 'resume preserves the original wall-clock deadline' test "$deadline_before" = "$deadline_after"
+
+repo="$(new_repo same-ticket)"; make_fake "$repo/../fake"; manifest "$repo" same-ticket
+python3 - "$repo/.harness/runs/same-ticket.json" <<'PY'
+import json, pathlib, sys
+p = pathlib.Path(sys.argv[1]); v = json.loads(p.read_text()); v['implementation_ticket'] = 'DEC-1'; p.write_text(json.dumps(v)+'\n')
+PY
+git -C "$repo" add . && git -C "$repo" commit -qm 'test: invalid ticket seam'
+if (cd "$repo" && invoke "$repo" accept start .harness/runs/same-ticket.json >../out 2>../err); then
+  bad 'decision ticket was reused for implementation'
+else ok 'decision and implementation tickets must differ'; fi
+
+echo
+printf 'autonomous-run: %d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/scripts/test-platform-install.ps1
+++ b/scripts/test-platform-install.ps1
@@ -73,6 +73,39 @@ try {
   $orgFailure = Run-SetupExpectFailure @('--platform','codex','--org-policy')
   Assert-True ($orgFailure.Contains('organization-policy installation is not supported')) 'Codex org-policy rejection is unclear'
 
+  # RTK is default-on for code profiles and uses the selected account-specific CODEX_HOME.
+  $fakeBin = Join-Path $sandbox 'fake bin'
+  New-Item -ItemType Directory -Force -Path $fakeBin | Out-Null
+  $fakeRtk = Join-Path $fakeBin 'rtk.ps1'
+  [IO.File]::WriteAllText($fakeRtk, @'
+if ($args[0] -eq '--version') { Write-Output 'rtk fake'; exit 0 }
+Add-Content -LiteralPath $env:AGENTSMITH_RTK_CALL_LOG -Value ("{0}|{1}" -f $env:CODEX_HOME, ($args -join ' '))
+exit 0
+'@, [Text.UTF8Encoding]::new($false))
+  $oldPath = $env:PATH
+  $rtkLog = Join-Path $sandbox 'rtk calls.log'
+  $env:PATH = "$fakeBin$([IO.Path]::PathSeparator)$oldPath"
+  $env:AGENTSMITH_RTK_CALL_LOG = $rtkLog
+  $rtkProject = Join-Path $sandbox 'rtk codex project'
+  New-Item -ItemType Directory -Force -Path $rtkProject | Out-Null
+  $rtkOutput = Run-Setup @('--platform','codex','--profile','software-dev','--target',$rtkProject)
+  Assert-True ((Get-Content $rtkLog -Raw).Contains("$codex|init -g --codex")) 'Codex code profile did not initialize RTK with CODEX_HOME'
+  Assert-True (-not $rtkOutput.Contains('Claude-specific wiring')) 'Codex RTK still emitted the obsolete Claude-only warning'
+  Remove-Item $rtkLog -Force
+  Run-Setup @('--platform','codex','--profile','software-dev','--target',$rtkProject,'--no-rtk') | Out-Null
+  Assert-True (-not (Test-Path $rtkLog)) '--no-rtk did not suppress the code-profile default'
+
+  $rtkRules = Join-Path $codex 'AGENTS.md'
+  Set-Content $rtkRules '@RTK.md' -Encoding utf8
+  $rtkDoctorMissing = Run-Setup @('--platform','codex','--doctor')
+  Assert-True ($rtkDoctorMissing.Contains("Codex RTK import is dangling: $(Join-Path $codex 'RTK.md')")) 'doctor did not report a dangling Codex RTK import'
+  Set-Content (Join-Path $codex 'RTK.md') '# generated RTK instructions' -Encoding utf8
+  $rtkDoctorHealthy = Run-Setup @('--platform','codex','--doctor')
+  Assert-True ($rtkDoctorHealthy.Contains('Codex RTK instructions wired')) 'doctor did not recognize healthy Codex RTK wiring'
+  Remove-Item $rtkRules,(Join-Path $codex 'RTK.md') -Force
+  $env:PATH = $oldPath
+  Remove-Item Env:AGENTSMITH_RTK_CALL_LOG -ErrorAction SilentlyContinue
+
   # Seed foreign configuration and an existing skill; Agentsmith must preserve both.
   Set-Content (Join-Path $codex 'config.toml') "# keep user comment`nmodel = `"gpt-test`"`n`n[features]`nkeep_me = true`n" -Encoding utf8
   Set-Content (Join-Path $codex 'hooks.json') '{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"foreign-user-hook"}]}],"Stop":[{"hooks":[{"type":"command","command":"foreign-stop-hook"}]}]}}' -Encoding utf8

--- a/scripts/test-platform-install.ps1
+++ b/scripts/test-platform-install.ps1
@@ -119,6 +119,8 @@ exit 0
   Assert-True (-not (Test-Path (Join-Path $project '.claude'))) 'Codex-only run created .claude'
   Assert-True (-not (Test-Path (Join-Path $fixtureHome '.claude'))) 'Codex-only run touched the Claude user home'
   Assert-True (Test-Path (Join-Path $project '.agents/skills/existing/SKILL.md')) 'existing Codex skill was removed'
+  Assert-True (-not (Test-Path (Join-Path $project 'scripts/autonomous-run.py'))) 'non-code profile installed autonomous controller'
+  Assert-True (-not (Test-Path (Join-Path $project '.harness/templates/autonomous-run.json'))) 'non-code profile installed autonomous manifest template'
   Assert-Contains (Join-Path $codex 'config.toml') '# keep user comment'
   Assert-Contains (Join-Path $codex 'config.toml') 'approval_policy = "on-request"'
   Assert-Contains (Join-Path $codex 'config.toml') 'sandbox_mode = "workspace-write"'
@@ -130,6 +132,12 @@ exit 0
   Assert-True ((Get-HookCommandCount (Join-Path $codex 'hooks.json') 'Stop' 'foreign-stop-hook') -eq 1) 'foreign Codex Stop hook was lost'
   Assert-Toml (Join-Path $codex 'config.toml')
   Assert-Toml (Join-Path $project '.codex/config.toml')
+
+  $softwareProject = Join-Path $fixtureHome 'autonomous-software'
+  New-Item -ItemType Directory -Force -Path $softwareProject | Out-Null
+  Run-Setup @('--platform','codex','--profile','software-dev','--no-rtk','--target',$softwareProject) | Out-Null
+  Assert-True (Test-Path (Join-Path $softwareProject 'scripts/autonomous-run.py')) 'software-dev missing autonomous controller'
+  Assert-True (Test-Path (Join-Path $softwareProject '.harness/templates/autonomous-run.json')) 'software-dev missing autonomous manifest template'
 
   # Re-run: update safety, union MCP selections, keep hook entries duplicate-free, and create backups.
   Set-Content (Join-Path $codex 'hooks/handoff-on-keyword.sh') '# stale Codex handoff hook' -Encoding utf8

--- a/scripts/test-platform-install.sh
+++ b/scripts/test-platform-install.sh
@@ -104,6 +104,8 @@ assert "Codex-only invokes no Claude/rtk command" test ! -e "$c/calls"
 assert "CODEX_HOME with spaces receives config" test -f "$c/Orca Account/codex home/config.toml"
 assert "Codex project skills preserve an existing skill" test -d "$c/project/.agents/skills/existing"
 assert "Codex project skills install bundled skills" test -f "$c/project/.agents/skills/handoff/SKILL.md"
+assert "non-code profile omits autonomous controller" test ! -e "$c/project/scripts/autonomous-run.py"
+assert "non-code profile omits autonomous manifest template" test ! -e "$c/project/.harness/templates/autonomous-run.json"
 assert "Codex-only creates no Claude home" test ! -e "$c/home/.claude"
 assert "Codex handoff hook installed" test -x "$c/Orca Account/codex home/hooks/handoff-on-keyword.sh"
 assert "Codex UI hook installed" test -x "$c/Orca Account/codex home/hooks/ui-design-reminder.sh"
@@ -126,6 +128,11 @@ assert project['mcp_servers']['playwright']['command'] == 'manual'
 assert project['mcp_servers']['context7']['command'] == 'npx'
 PY
 assert "cautious mapping and TOML parse exactly" test $? -eq 0
+
+software_case="$(new_case autonomous-software)"
+run "$software_case" --platform codex --profile software-dev --no-rtk --target "$software_case/project"
+assert "software-dev scaffolds autonomous controller" test -x "$software_case/project/scripts/autonomous-run.py"
+assert "software-dev scaffolds autonomous manifest template" test -f "$software_case/project/.harness/templates/autonomous-run.json"
 
 # Re-run adds a new managed server, retains the prior selection, and does not duplicate hooks/tables.
 printf '%s\n' '# stale Codex handoff hook' > "$c/Orca Account/codex home/hooks/handoff-on-keyword.sh"

--- a/scripts/test-platform-install.sh
+++ b/scripts/test-platform-install.sh
@@ -51,6 +51,44 @@ for p in claude codex both; do
   assert "$p global dry-run writes no home files" test -z "$(find "$c/home" "$c/Orca Account/codex home" -mindepth 1 -print -quit)"
 done
 
+echo "platform-install — RTK runtime wiring and doctor diagnostics"
+make_fake_rtk() {
+  local bin="$1"
+  mkdir -p "$bin"
+  printf '%s\n' '#!/usr/bin/env bash' \
+    'if [ "${1:-}" = "--version" ]; then echo "rtk fake"; exit 0; fi' \
+    'printf "%s|%s\n" "${CODEX_HOME:-}" "$*" >> "$AGENTSMITH_RTK_CALL_LOG"' \
+    > "$bin/rtk"
+  chmod +x "$bin/rtk"
+}
+
+c="$(new_case rtk-codex-default)"; make_fake_rtk "$c/bin"
+AGENTSMITH_RTK_CALL_LOG="$c/calls" PATH="$c/bin:$PATH" HOME="$c/home" CODEX_HOME="$c/Orca Account/codex home" \
+  bash "$ROOT/setup.sh" --platform codex --profile software-dev --target "$c/project" >"$c/out" 2>&1
+assert "Codex code profile enables RTK by default" grep -Fxq "$c/Orca Account/codex home|init -g --codex" "$c/calls"
+assert "Codex RTK wiring preserves CODEX_HOME paths with spaces" grep -Fq "$c/Orca Account/codex home|" "$c/calls"
+assert "Codex RTK no longer emits a Claude-only warning" sh -c "! grep -q 'Claude-specific wiring.*ignored' '$c/out'"
+
+c="$(new_case rtk-both)"; make_fake_rtk "$c/bin"
+AGENTSMITH_RTK_CALL_LOG="$c/calls" PATH="$c/bin:$PATH" HOME="$c/home" CODEX_HOME="$c/Orca Account/codex home" \
+  bash "$ROOT/setup.sh" --platform both --profile general-admin --with-rtk --target "$c/project" >"$c/out" 2>&1
+assert "both-mode initializes Claude RTK" grep -Fq '|init -g --auto-patch' "$c/calls"
+assert "both-mode initializes Codex RTK" grep -Fxq "$c/Orca Account/codex home|init -g --codex" "$c/calls"
+assert "both-mode initializes RTK exactly once per runtime" test "$(wc -l < "$c/calls" | tr -d ' ')" -eq 2
+
+c="$(new_case rtk-opt-out)"; make_fake_rtk "$c/bin"
+AGENTSMITH_RTK_CALL_LOG="$c/calls" PATH="$c/bin:$PATH" HOME="$c/home" CODEX_HOME="$c/Orca Account/codex home" \
+  bash "$ROOT/setup.sh" --platform codex --profile software-dev --no-rtk --target "$c/project" >"$c/out" 2>&1
+assert "--no-rtk suppresses default Codex RTK initialization" test ! -e "$c/calls"
+
+c="$(new_case rtk-doctor)"
+printf '%s\n' '@RTK.md' > "$c/Orca Account/codex home/AGENTS.md"
+HOME="$c/home" CODEX_HOME="$c/Orca Account/codex home" bash "$ROOT/setup.sh" --platform codex --doctor > "$c/doctor-missing" 2>&1
+assert "doctor reports a dangling Codex RTK import" grep -Fq "Codex RTK import is dangling: $c/Orca Account/codex home/RTK.md" "$c/doctor-missing"
+printf '%s\n' '# generated RTK instructions' > "$c/Orca Account/codex home/RTK.md"
+HOME="$c/home" CODEX_HOME="$c/Orca Account/codex home" bash "$ROOT/setup.sh" --platform codex --doctor > "$c/doctor-healthy" 2>&1
+assert "doctor recognizes healthy Codex RTK wiring" grep -Fq 'Codex RTK instructions wired' "$c/doctor-healthy"
+
 echo "platform-install — Codex config, MCP, skills, hooks, and re-runs"
 c="$(new_case codex-full)"
 mkdir -p "$c/bin" "$c/project/.codex" "$c/project/.agents/skills/existing" "$c/Orca Account/codex home"

--- a/scripts/test-wayfinder-spec.sh
+++ b/scripts/test-wayfinder-spec.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Regression guard for the Wayfinder spec boundary: stable structure, explicit acceptance, and
+# tracker consent. This is intentionally structural; prose alone cannot prevent decision and
+# implementation tickets from collapsing back into one item.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SKILL="$ROOT_DIR/skills/wayfinder/SKILL.md"
+TEMPLATE="$ROOT_DIR/templates/wayfinder-spec.md"
+CATALOG="$ROOT_DIR/skills/README.md"
+RECOMMENDED="$ROOT_DIR/skills/RECOMMENDED.md"
+
+pass=0; fail=0
+ok()  { printf '  \033[32m✓\033[0m %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  \033[31m✗\033[0m %s\n' "$1"; fail=$((fail+1)); }
+has() { grep -qF "$2" "$1" 2>/dev/null; }
+
+for f in "$SKILL" "$TEMPLATE"; do
+  [ -s "$f" ] && ok "$(basename "$f"): exists" || bad "$(basename "$f"): missing or empty"
+done
+
+required_sections=(
+  '## Destination'
+  '## Non-goals'
+  '## Decision map'
+  '### Frontier'
+  '### Blocked'
+  '### Fog'
+  '## Decision index'
+  '## Explicit deferrals'
+  '## Acceptance and evidence'
+  '## Decision-ticket drafts'
+  '## Implementation-ticket drafts'
+)
+for heading in "${required_sections[@]}"; do
+  has "$TEMPLATE" "$heading" \
+    && ok "template: carries $heading" \
+    || bad "template: missing $heading"
+done
+previous=0; ordered=true
+for heading in "${required_sections[@]}"; do
+  line="$(grep -nF "$heading" "$TEMPLATE" 2>/dev/null | head -1 | cut -d: -f1)"
+  if [ -z "$line" ] || [ "$line" -le "$previous" ]; then ordered=false; break; fi
+  previous="$line"
+done
+$ordered \
+  && ok 'template: sections preserve the decision-to-implementation sequence' \
+  || bad 'template: required sections are out of order'
+
+has "$TEMPLATE" 'status: draft' \
+  && ok 'template: initial status is draft' \
+  || bad 'template: draft status missing'
+if [ "$(head -1 "$TEMPLATE")" = '---' ] && [ "$(grep -c '^---$' "$TEMPLATE")" -ge 2 ]; then
+  ok 'template: controller-readable frontmatter is present'
+else
+  bad 'template: YAML-style frontmatter missing'
+fi
+for field in 'decision_ticket:' 'accepted_by:' 'accepted_at:'; do
+  has "$TEMPLATE" "$field" \
+    && ok "template: frontmatter carries $field" \
+    || bad "template: frontmatter missing $field"
+done
+if grep -qE '^status:[[:space:]]*accepted[[:space:]]*$' "$TEMPLATE"; then
+  bad 'template: pre-accepts an agent-produced spec'
+else
+  ok 'template: cannot start accepted'
+fi
+
+for phrase in \
+  'Only an explicit operator' \
+  'acceptance may change `status` to `accepted`' \
+  'separately tracked implementation ticket' \
+  'when writes are unauthorized' \
+  'A connected or named tracker grants no write permission' \
+  'Resolve one decision per session'; do
+  has "$SKILL" "$phrase" \
+    && ok "skill: guarded — $phrase" \
+    || bad "skill: missing guard — $phrase"
+done
+
+if has "$TEMPLATE" '## Decision-ticket drafts' && has "$TEMPLATE" '## Implementation-ticket drafts'; then
+  ok 'template: decision and implementation tickets are separate artifacts'
+else
+  bad 'template: ticket phases collapsed together'
+fi
+
+# The pack count excludes example-skill, which is explicitly a starter scaffold.
+bundled_count="$(find "$ROOT_DIR/skills" -mindepth 2 -maxdepth 2 -name SKILL.md ! -path '*/example-skill/*' | wc -l | tr -d ' ')"
+if [ "$bundled_count" = 9 ]; then
+  ok 'catalog: nine bundled non-example skills exist'
+else
+  bad "catalog: expected 9 bundled non-example skills, found $bundled_count"
+fi
+has "$CATALOG" 'Nine small skills ship in this repo.' \
+  && ok 'catalog: documented count is nine' \
+  || bad 'catalog: bundled count drifted'
+has "$RECOMMENDED" '**wayfinder**' \
+  && ok 'recommendations: Wayfinder is indexed' \
+  || bad 'recommendations: Wayfinder missing from bundled index'
+for skill_file in "$ROOT_DIR"/skills/*/SKILL.md; do
+  skill_name="$(basename "$(dirname "$skill_file")")"
+  [ "$skill_name" = example-skill ] && continue
+  if has "$CATALOG" "**$skill_name**" && has "$RECOMMENDED" "**$skill_name**"; then
+    ok "catalog: $skill_name appears in both indexes"
+  else
+    bad "catalog: $skill_name is missing from an index"
+  fi
+done
+has "$RECOMMENDED" '<!-- MAP autonomous-loops | packs: - | skills: using-git-worktrees,verify,wayfinder,autonomous-run -->' \
+  && ok 'recommendations: autonomous-loops map includes Wayfinder' \
+  || bad 'recommendations: autonomous-loops machine-readable map drifted'
+
+echo
+printf 'wayfinder-spec: %d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/setup.ps1
+++ b/setup.ps1
@@ -46,7 +46,8 @@
 #    ./setup.ps1 --with-rtk | --no-rtk   # rtk CLI-output compressor (default: ON for software-dev/devops-setup)
 #    ./setup.ps1 --with-mcp playwright,context7 ...   # add named MCP server(s) to native project config
 #    ./setup.ps1 --with-skills ...      # install the bundled skill pack (handoff, verify, harness-doctor,
-#                                       #   new-research, new-feedback, harness-help); project mode →
+#                                       #   new-research, new-feedback, harness-help, writing-rules,
+#                                       #   wayfinder, autonomous-run); project mode →
 #                                       #   native .claude/skills and/or .agents/skills destinations
 #    ./setup.ps1 --with-hooks ...       # install git guardrails (secret-scan+protect-main+conventional)
 #    ./setup.ps1 --update-plugins       # update installed plugins to latest, then exit
@@ -1750,7 +1751,8 @@ if ($o.AlsoGemini) { Assemble-To (Join-Path $o.Target 'GEMINI.md') $includeCore 
 if ($o.DryRun) {
   Write-Host ''
   Say "DRY RUN — nothing was written. A real run would ALSO scaffold into $($o.Target):"
-  Write-Host '    + scripts/        verify.sh, handoff.sh, new-research.sh, new-feedback.sh, secret-scan.sh, install-git-hooks.sh, lint-leanness.sh'
+  Write-Host '    + scripts/        verify.sh, handoff/research/feedback helpers, git guards'
+  if (Autonomous-ToolsWanted) { Write-Host '    + autonomous      autonomous-run.py + run manifest template (software-dev)' }
   Write-Host '    + hooks/git/      managed git hooks (secret-scan, protect-main, conventional-commits)'
   Write-Host '    + .harness/       verify.conf (+ .example), templates/, handoffs/'
   Write-Host '    + .planning/      progress-log.md'
@@ -1779,6 +1781,7 @@ function Cpa ($src, $dst) { if (-not (Test-Path $dst)) { Copy-Item $src $dst -Fo
 foreach ($s in @('verify.sh','new-research.sh','new-feedback.sh','handoff.sh','secret-scan.sh','install-git-hooks.sh','lint-leanness.sh')) {
   Cpa (Join-Path $HarnessDir "scripts/$s") (Join-Path $o.Target "scripts/$s")
 }
+if (Autonomous-ToolsWanted) { Cpa (Join-Path $HarnessDir 'scripts/autonomous-run.py') (Join-Path $o.Target 'scripts/autonomous-run.py') }
 Cpa (Join-Path $HarnessDir 'docs/feedback/README.md') (Join-Path $o.Target 'docs/feedback/README.md')
 Get-ChildItem (Join-Path $HarnessDir 'hooks/git') -Filter *.sh | ForEach-Object { Cpa $_.FullName (Join-Path $o.Target "hooks/git/$($_.Name)") }
 Cpa (Join-Path $HarnessDir '.harness/verify.conf.example') (Join-Path $o.Target '.harness/verify.conf.example')
@@ -1788,6 +1791,7 @@ else { Build-VerifyConf $verifyConf; Ok "added .harness/verify.conf (preset for:
 Cpa (Join-Path $HarnessDir 'templates/progress-log.md') (Join-Path $o.Target '.planning/progress-log.md')
 if (Has-Claude) { Cpa (Join-Path $HarnessDir "config/settings.local.$($o.Safety).json.example") (Join-Path $o.Target '.claude/settings.local.json.example') }
 Get-ChildItem (Join-Path $HarnessDir 'templates') -Filter *.md | ForEach-Object { Copy-Item $_.FullName (Join-Path $o.Target ".harness/templates/$($_.Name)") -Force }
+if (Autonomous-ToolsWanted) { Cpa (Join-Path $HarnessDir 'templates/autonomous-run.json') (Join-Path $o.Target '.harness/templates/autonomous-run.json') }
 Ok 'templates in .harness/templates/'
 # First-steps card: fill placeholders, write-if-absent (don't clobber a user-edited card)
 $firstSteps = Join-Path $o.Target 'FIRST-STEPS.md'

--- a/setup.ps1
+++ b/setup.ps1
@@ -159,6 +159,23 @@ function Platform-RulesLabel {
   return 'CLAUDE.md + AGENTS.md'
 }
 
+function Report-RtkHealth ([string]$RuntimeLabel, [string]$RulesPath, [string]$RuntimeDir) {
+  $import = $null
+  if (Test-Path $RulesPath) {
+    $import = Get-Content $RulesPath | Where-Object { $_ -match '^@.*RTK\.md\s*$' } | Select-Object -First 1
+  }
+  if ($import) {
+    $target = $import.Substring(1).TrimEnd("`r")
+    if (-not [IO.Path]::IsPathRooted($target)) { $target = Join-Path $RuntimeDir $target }
+    if (Test-Path $target -PathType Leaf) { Ok "$RuntimeLabel RTK instructions wired" }
+    else { Warn "$RuntimeLabel RTK import is dangling: $target — re-run with --with-rtk" }
+  } elseif (Test-Path (Join-Path $RuntimeDir 'RTK.md') -PathType Leaf) {
+    Warn "$RuntimeLabel RTK.md is present but not imported by $(Split-Path $RulesPath -Leaf) — re-run with --with-rtk"
+  } else {
+    Warn "$RuntimeLabel RTK.md missing — re-run with --with-rtk"
+  }
+}
+
 # ---- profile auto-detect + uninstall (used by --profile auto, the wizard, --uninstall) -----
 function Test-Has ([string]$dir, [string[]]$globs) {  # $true if any glob matches an entry in $dir
   foreach ($g in $globs) {
@@ -258,7 +275,6 @@ if ($o.OrgPolicy -and (Has-Codex)) {
 }
 if (-not (Has-Claude)) {
   if ($o.WithPlugins) { Warn '--with-plugins is Claude-only and was ignored for --platform codex.' }
-  if ($o.WithRtk -eq 'true') { Warn '--with-rtk is Claude-specific wiring and was ignored for --platform codex.' }
 }
 
 # Resolve --profile auto by inspecting the target project (before validation).
@@ -549,7 +565,11 @@ function Rtk-Wanted {  # install rtk? explicit flag wins; else auto = only for c
   return $false
 }
 
-function Install-Rtk {  # install the rtk binary (per-OS), then let rtk wire its own Claude Code hook
+function Autonomous-ToolsWanted {
+  return $ProfileArr -contains 'software-dev'
+}
+
+function Install-Rtk {  # install rtk once, then initialize each selected runtime independently
   if (Have-Cmd rtk) {
     Ok "rtk already installed ($(try { rtk --version } catch { 'present' }))"
   } else {
@@ -581,11 +601,24 @@ function Install-Rtk {  # install the rtk binary (per-OS), then let rtk wire its
       Warn 'rtk: no supported installer found — install by hand: https://github.com/rtk-ai/rtk#installation'; return
     }
   }
-  if (-not (Have-Cmd rtk)) { Warn 'rtk not on PATH after install — open a new shell, then run: rtk init -g --auto-patch'; return }
+  if (-not (Have-Cmd rtk)) { Warn 'rtk not on PATH after install — open a new shell, then re-run setup with --with-rtk'; return }
   if (-not (Have-Cmd rg))  { Warn 'rtk: ripgrep (rg) not on PATH — some filters need it (winget install BurntSushi.ripgrep.MSVC)' }
-  rtk init -g --auto-patch *> $null
-  if ($LASTEXITCODE -eq 0) { Ok 'rtk wired into Claude Code (hook + RTK.md) — restart Claude Code to load it' }
-  else { Warn "rtk: 'rtk init -g --auto-patch' failed — run it by hand to wire the hook" }
+  if (Has-Claude) {
+    rtk init -g --auto-patch *> $null
+    if ($LASTEXITCODE -eq 0) { Ok 'rtk wired into Claude Code (hook + RTK.md) — restart Claude Code to load it' }
+    else { Warn 'rtk: Claude initialization failed — run: rtk init -g --auto-patch' }
+  }
+  if (Has-Codex) {
+    $previousCodexHome = $env:CODEX_HOME
+    try {
+      $env:CODEX_HOME = $CodexDir
+      rtk init -g --codex *> $null
+      if ($LASTEXITCODE -eq 0) { Ok 'rtk wired into Codex (AGENTS.md + RTK.md instructions)' }
+      else { Warn "rtk: Codex initialization failed — set CODEX_HOME to '$CodexDir' and run: rtk init -g --codex" }
+    } finally {
+      $env:CODEX_HOME = $previousCodexHome
+    }
+  }
 }
 
 function Install-ClaudeConfig {
@@ -651,8 +684,6 @@ function Install-ClaudeConfig {
     Say "  29 security skills available on demand — owasp-audit, threat-modeling, api-audit,"
     Say "  dependency-audit, prompt-injection, container-audit, cloud-audit, iam-audit, and more."
   }
-  # rtk — token-compressing CLI proxy (github.com/rtk-ai/rtk). Default-ON for code profiles; --no-rtk opts out.
-  if (Rtk-Wanted) { Install-Rtk }
 }
 
 function Install-CodexConfig {
@@ -663,6 +694,8 @@ function Install-CodexConfig {
 function Install-PlatformConfig {
   if (Has-Claude) { Install-ClaudeConfig }
   if (Has-Codex) { Install-CodexConfig }
+  # Default-ON for code profiles; initialize every selected runtime, not only Claude.
+  if (Rtk-Wanted) { Install-Rtk }
   Install-NativeSkills
   if ($o.WithHandoffHooks) {
     if (Has-Claude) { Install-ClaudeHandoffHooks }
@@ -1565,6 +1598,7 @@ if ($o.Doctor) {
     } else { Warn "no $settings" }
     $gmd = Join-Path $CcDir 'CLAUDE.md'
     if (Test-Path $gmd) { Ok "global Claude rules present ($(@(Get-Content $gmd).Count) lines)" } else { Warn 'no global Claude rules (per-project only)' }
+    Report-RtkHealth 'Claude' $gmd $CcDir
     $skills = Join-Path $CcDir 'skills'
     if (Test-Path $skills) { Ok "Claude skills: $(@(Get-ChildItem $skills -Directory).Count)" } else { Warn 'no Claude skills directory' }
     $kw = 'bash ~/.claude/hooks/handoff-on-keyword.sh'
@@ -1594,6 +1628,7 @@ if ($o.Doctor) {
     if (Test-Path $config) { if (Test-TomlFile $config) { Ok "Codex config valid: $config" } else { Warn "Codex config is not valid TOML: $config" } } else { Warn "no $config" }
     $gmd = Join-Path $CodexDir 'AGENTS.md'
     if (Test-Path $gmd) { Ok "global Codex rules present ($(@(Get-Content $gmd).Count) lines)" } else { Warn 'no global Codex rules (per-project only)' }
+    Report-RtkHealth 'Codex' $gmd $CodexDir
     $skills = Join-Path $HOME '.agents/skills'
     if (Test-Path $skills) { Ok "Codex skills: $(@(Get-ChildItem $skills -Directory).Count)" } else { Warn 'no Codex skills directory' }
     $codexHookScript = Join-Path $CodexDir 'hooks/handoff-on-keyword.sh'

--- a/setup.sh
+++ b/setup.sh
@@ -185,6 +185,22 @@ doctor_script_state() {  # <label> <installed> <source>
   fi
 }
 
+doctor_rtk_state() {  # <runtime label> <global rules file> <runtime config dir>
+  local label="$1" rules="$2" runtime_dir="$3" import_line="" target=""
+  [ -f "$rules" ] && import_line="$(grep -E '^@.*RTK\.md[[:space:]]*$' "$rules" 2>/dev/null | head -n 1 || true)"
+  if [ -n "$import_line" ]; then
+    target="${import_line#@}"
+    target="${target%$'\r'}"
+    case "$target" in /*) ;; *) target="$runtime_dir/$target";; esac
+    if [ -f "$target" ]; then ok "$label RTK instructions wired"
+    else warn "$label RTK import is dangling: $target — re-run with --with-rtk"; fi
+  elif [ -f "$runtime_dir/RTK.md" ]; then
+    warn "$label RTK.md is present but not imported by $(basename "$rules") — re-run with --with-rtk"
+  else
+    warn "$label RTK.md missing — re-run with --with-rtk"
+  fi
+}
+
 # ---- profile auto-detect + uninstall (used by --profile auto, the wizard, --uninstall) -----
 _has() {  # <dir> <glob...> -> 0 if any glob matches an existing entry (glob-safe under set -e)
   local d="$1"; shift; local p f
@@ -675,7 +691,6 @@ $ALSO_AGENTS_MD && warn "--also-agents-md is deprecated and copies instructions 
 $DO_ORG_POLICY && has_codex && die "Codex organization-policy installation is not supported in this release. Use --platform claude --org-policy; Codex organization policy must be managed separately."
 if ! has_claude; then
   [ -z "$WITH_PLUGINS" ] || warn "--with-plugins is Claude-only and was ignored for --platform codex."
-  [ "$WITH_RTK" != true ] || warn "--with-rtk is Claude-specific wiring and was ignored for --platform codex."
 fi
 
 # ---- standalone actions ----------------------------------------------------
@@ -703,6 +718,7 @@ if $DO_DOCTOR; then
       ok "Claude global rules present ($(wc -l < "$CC_DIR/CLAUDE.md") lines)"
       [ -f "$HARNESS_DIR/scripts/lint-leanness.sh" ] && bash "$HARNESS_DIR/scripts/lint-leanness.sh" "$CC_DIR/CLAUDE.md" 2>/dev/null | sed 's/^/  /'
     else warn "no Claude global rules (per-project only)"; fi
+    doctor_rtk_state "Claude" "$CC_DIR/CLAUDE.md" "$CC_DIR"
     [ -d "$CC_DIR/skills" ] && ok "Claude skills: $(find "$CC_DIR/skills" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l | tr -d ' ')" || warn "no Claude skills directory"
     command -v claude >/dev/null 2>&1 && ok "'claude' CLI on PATH" || warn "'claude' CLI not on PATH"
   fi
@@ -715,6 +731,7 @@ if $DO_DOCTOR; then
       ok "Codex global rules present ($(wc -l < "$CODEX_DIR/AGENTS.md") lines)"
       [ -f "$HARNESS_DIR/scripts/lint-leanness.sh" ] && bash "$HARNESS_DIR/scripts/lint-leanness.sh" "$CODEX_DIR/AGENTS.md" 2>/dev/null | sed 's/^/  /'
     else warn "no Codex global rules (per-project only)"; fi
+    doctor_rtk_state "Codex" "$CODEX_DIR/AGENTS.md" "$CODEX_DIR"
     [ -d "$HOME/.agents/skills" ] && ok "Codex skills: $(find "$HOME/.agents/skills" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l | tr -d ' ')" || warn "no Codex global skills directory"
     [ -f "$CODEX_DIR/hooks.json" ] && ok "Codex hooks.json present (review trust with /hooks)" || warn "no Codex hooks.json"
     doctor_script_state "Codex keyword handoff hook" "$CODEX_DIR/hooks/handoff-on-keyword.sh" "$HARNESS_DIR/hooks/handoff-on-keyword.sh"
@@ -935,8 +952,6 @@ install_claude_config() {
     say "  29 security skills available on demand — owasp-audit, threat-modeling, api-audit,"
     say "  dependency-audit, prompt-injection, container-audit, cloud-audit, iam-audit, and more." ;;
   esac
-  # rtk — token-compressing CLI proxy (github.com/rtk-ai/rtk). Default-ON for code profiles; --no-rtk opts out.
-  rtk_wanted && install_rtk
   return 0   # never let a false trailing `&&` (both hooks/skills off) abort the caller under set -e
 }
 
@@ -1075,6 +1090,8 @@ install_codex_config() {
 install_platform_config() {
   has_claude && install_claude_config
   has_codex  && install_codex_config
+  # Default-ON for code profiles; initialize every selected runtime, not only Claude.
+  rtk_wanted && install_rtk
   install_native_skills
   $WITH_HANDOFF_HOOKS && install_handoff_hooks
   $WITH_UI_DESIGN_HOOK && install_ui_design_hook
@@ -1102,11 +1119,18 @@ install_rtk() {  # install the rtk binary (per-OS), then let rtk wire its own Cl
         || { warn "rtk: installer failed — install by hand: https://github.com/rtk-ai/rtk#installation"; return 0; }
     fi
   fi
-  command -v rtk >/dev/null 2>&1 || { warn "rtk installed but not on PATH — add \$HOME/.local/bin to PATH, then run: rtk init -g --auto-patch"; return 0; }
+  command -v rtk >/dev/null 2>&1 || { warn "rtk installed but not on PATH — add \$HOME/.local/bin to PATH, then re-run setup with --with-rtk"; return 0; }
   command -v rg  >/dev/null 2>&1 || warn "rtk: ripgrep (rg) not on PATH — some filters need it (install ripgrep via brew/apt/winget)"
-  # rtk writes its own PreToolUse hook + RTK.md + settings.json entry + @RTK.md import — idempotent, no prompt
-  if rtk init -g --auto-patch >/dev/null 2>&1; then ok "rtk wired into Claude Code (hook + RTK.md) — restart Claude Code to load it"
-  else warn "rtk: 'rtk init -g --auto-patch' failed — run it by hand to wire the hook"; fi
+  if has_claude; then
+    # Claude gets transparent PreToolUse rewriting plus RTK.md instructions.
+    if rtk init -g --auto-patch >/dev/null 2>&1; then ok "rtk wired into Claude Code (hook + RTK.md) — restart Claude Code to load it"
+    else warn "rtk: Claude initialization failed — run: rtk init -g --auto-patch"; fi
+  fi
+  if has_codex; then
+    # Codex has no updatedInput hook support; rtk installs instruction-level guidance instead.
+    if CODEX_HOME="$CODEX_DIR" rtk init -g --codex >/dev/null 2>&1; then ok "rtk wired into Codex (AGENTS.md + RTK.md instructions)"
+    else warn "rtk: Codex initialization failed — set CODEX_HOME to '$CODEX_DIR' and run: rtk init -g --codex"; fi
+  fi
   return 0
 }
 

--- a/setup.sh
+++ b/setup.sh
@@ -40,7 +40,8 @@
 #    ./setup.sh --with-rtk | --no-rtk   # rtk CLI-output compressor (default: ON for software-dev/devops-setup)
 #    ./setup.sh --with-mcp playwright,context7 ...   # add named MCP server(s) to native project config
 #    ./setup.sh --with-skills ...       # install the bundled skill pack (handoff, verify,
-#                                       #   harness-doctor, new-research, new-feedback, harness-help);
+#                                       #   harness-doctor, new-research, new-feedback, harness-help,
+#                                       #   writing-rules, wayfinder, autonomous-run);
 #                                       #   native .claude/skills and/or .agents/skills destinations
 #    ./setup.sh --with-hooks ...        # install git guardrails (secret-scan+protect-main+conventional) in --target
 #    ./setup.sh --update-plugins        # update installed plugins to latest, then exit
@@ -1107,7 +1108,15 @@ rtk_wanted() {  # install rtk? explicit flag wins; else auto = only for code pro
   return 1
 }
 
-install_rtk() {  # install the rtk binary (per-OS), then let rtk wire its own Claude Code hook
+autonomous_tools_wanted() {  # v1 is intentionally code-first; other profiles still get the spec skill
+  local p
+  for p in "${PROFILE_ARR[@]:-}"; do
+    [ "$p" = software-dev ] && return 0
+  done
+  return 1
+}
+
+install_rtk() {  # install rtk once, then initialize each selected runtime independently
   if command -v rtk >/dev/null 2>&1; then
     ok "rtk already installed ($(rtk --version 2>/dev/null || echo present))"
   else
@@ -1721,7 +1730,8 @@ $ALSO_GEMINI_MD && assemble_to "$TARGET/GEMINI.md" "$INCLUDE_CORE"
 if $DRY_RUN; then
   echo
   say "DRY RUN — nothing was written. A real run would ALSO scaffold into $TARGET:"
-  echo "    + scripts/        verify.sh, handoff.sh, new-research.sh, new-feedback.sh, secret-scan.sh, install-git-hooks.sh, lint-leanness.sh"
+  echo "    + scripts/        verify.sh, handoff/research/feedback helpers, git guards"
+  autonomous_tools_wanted && echo "    + autonomous      autonomous-run.py + run manifest template (software-dev)"
   echo "    + hooks/git/      managed git hooks (secret-scan, protect-main, conventional-commits)"
   echo "    + .harness/       verify.conf (+ .example), templates/, handoffs/"
   echo "    + .planning/      progress-log.md"
@@ -1758,7 +1768,9 @@ cpa "$HARNESS_DIR/scripts/handoff.sh"           "$TARGET/scripts/handoff.sh"
 cpa "$HARNESS_DIR/scripts/secret-scan.sh"       "$TARGET/scripts/secret-scan.sh"
 cpa "$HARNESS_DIR/scripts/install-git-hooks.sh" "$TARGET/scripts/install-git-hooks.sh"
 cpa "$HARNESS_DIR/scripts/lint-leanness.sh"     "$TARGET/scripts/lint-leanness.sh"
+autonomous_tools_wanted && cpa "$HARNESS_DIR/scripts/autonomous-run.py" "$TARGET/scripts/autonomous-run.py"
 chmod +x "$TARGET/scripts/"*.sh 2>/dev/null || true
+autonomous_tools_wanted && chmod +x "$TARGET/scripts/autonomous-run.py" 2>/dev/null || true
 cpa "$HARNESS_DIR/docs/feedback/README.md"      "$TARGET/docs/feedback/README.md"
 mkdir -p "$TARGET/hooks/git"
 for g in "$HARNESS_DIR"/hooks/git/*.sh; do cpa "$g" "$TARGET/hooks/git/$(basename "$g")"; done
@@ -1773,6 +1785,7 @@ fi
 cpa "$HARNESS_DIR/templates/progress-log.md"    "$TARGET/.planning/progress-log.md"
 has_claude && cpa "$HARNESS_DIR/config/settings.local.$SAFETY.json.example" "$TARGET/.claude/settings.local.json.example"
 mkdir -p "$TARGET/.harness/templates"; cp "$HARNESS_DIR"/templates/*.md "$TARGET/.harness/templates/" 2>/dev/null || true; ok "templates in .harness/templates/"
+autonomous_tools_wanted && cpa "$HARNESS_DIR/templates/autonomous-run.json" "$TARGET/.harness/templates/autonomous-run.json"
 write_first_steps "$TARGET/FIRST-STEPS.md"
 scaffold_design_system   # honors --design-system for a UI project (no-op on the default/backend path)
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -42,11 +42,9 @@ only when the skill needs them.
 
 ## The bundled skill pack
 
-Seven small skills ship in this repo. Six are **self-contained + script-aware**: each prefers a
-project-local `scripts/<x>.sh` when present (the fast path a harness-installed project already has),
-and otherwise runs a complete inline procedure — so they work installed globally, inside a harness
-project, or in a bare repo, with no dependency on a harness checkout. The seventh,
-**writing-rules**, is pure reference: no script, nothing to run, consulted while you write.
+Nine small skills ship in this repo. Procedural skills prefer a project-local `scripts/<x>.sh` when
+present and otherwise carry their fallback in the skill. **writing-rules** is pure reference;
+**wayfinder** is the repository-native decision-to-spec workflow.
 
 | Skill | Fires on | What it does |
 |---|---|---|
@@ -57,6 +55,8 @@ project, or in a bare repo, with no dependency on a harness checkout. The sevent
 | **new-research** | "start a research note" | Scaffolds a durable `docs/research/` source note (R9). |
 | **new-feedback** | "log a harness lesson" | Scaffolds a numbered `docs/feedback/` post-incident (System-Evolution loop). |
 | **writing-rules** | writing/reviewing a rule, gate, skill description, or agent prompt | The levers that decide whether a line changes behaviour or only costs tokens. |
+| **wayfinder** | a foggy effort whose destination is known but route is not | Builds a decision map and an operator-accepted spec before separate implementation tickets. |
+| **autonomous-run** | start/status/resume/stop a bounded local run from an accepted spec | Drives the finite maker/checker controller without granting external writes. |
 
 They're work-type-neutral and follow `core/` rules (verify before done, no secrets). See
 `RECOMMENDED.md` for the per-profile map.

--- a/skills/RECOMMENDED.md
+++ b/skills/RECOMMENDED.md
@@ -11,9 +11,9 @@ recommend packs and skills for the profile you pick. Edit the prose and the MAP 
 they're the single source of truth.
 
 ## Bundled with the harness (install with `--with-skills`)
-Seven small, work-type-neutral skills. Six prefer a project-local `scripts/<x>.sh` when present,
-else run an inline procedure, so they work globally, in a harness project, or in a bare repo; the
-seventh is pure reference:
+Nine small, work-type-neutral skills. Procedural skills prefer a project-local `scripts/<x>.sh`
+when present and otherwise carry their fallback in the skill; the rest are repository-native
+workflow/reference:
 - **handoff** — wrap up a session: durable note + paste-ready kickoff block.
 - **verify** — "is this shippable?" with evidence, never a bare "should pass".
 - **harness-doctor** — is this project's harness installed correctly and lean?
@@ -25,6 +25,11 @@ seventh is pure reference:
   most on a draft you already have. Adapted from Matt Pocock's
   [`writing-for-agents`](https://github.com/mattpocock/skills) (MIT) — install his upstream pack for
   the original plus its skill-frontmatter companion.
+- **wayfinder** — turn a foggy, multi-session effort into a repository-native decision map,
+  operator-accepted terminal spec, and separate implementation-ticket drafts. Adapted from Matt
+  Pocock's [`wayfinder`](https://github.com/mattpocock/skills) (MIT), with tracker consent retained.
+- **autonomous-run** — prepare/start/status/resume/stop a finite local maker/checker run from an
+  accepted spec, with durable receipts and no push, merge, or external writes.
 
 Project mode installs these into `<project>/.claude/skills/` (Claude),
 `<project>/.agents/skills/` (Codex), or both. Global mode uses `~/.claude/skills/`,
@@ -130,9 +135,12 @@ than working from memory. Match the skill to the engagement:
   to *refute* each one. Same job the `codex` two-AI gate does for a diff.
 
 ## autonomous-loops
-<!-- MAP autonomous-loops | packs: - | skills: using-git-worktrees,verify -->
+<!-- MAP autonomous-loops | packs: - | skills: using-git-worktrees,verify,wayfinder,autonomous-run -->
 - **using-git-worktrees** — one isolated worktree per fix attempt; discard it on reject.
 - **verify** — what the *checker* actually runs. The check must be one the maker can't fake.
+- **wayfinder** — require an accepted terminal spec before an autonomous run consumes its separate
+  implementation ticket.
+- **autonomous-run** — the bounded local controller interface once that spec is accepted.
 - Otherwise deliberately bare: use the active platform's scheduler (Claude `/loop` or `/schedule`,
   or an external scheduler) and its maker/checker subagent split. Resist bolting on a loop
   framework — the rules are the product (R10).

--- a/skills/autonomous-run/SKILL.md
+++ b/skills/autonomous-run/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: autonomous-run
+description: Prepare, start, inspect, resume, or stop a finite local overnight coding run after a human has accepted a Wayfinder terminal spec; coordinates a declared Claude/Codex maker and independent checker without pushing, merging, or writing to external systems.
+---
+
+# Autonomous run — bounded overnight execution
+
+This skill is for a **finite approved implementation**, not a recurring watcher. For recurring
+work use the autonomous-loops profile. For unresolved product or architecture decisions, run
+Wayfinder first.
+
+## Hard gate
+
+Do not begin implementation unless all of these are true:
+
+1. The terminal spec is committed under `docs/specs/` with `status: accepted`, `accepted_by`, and
+   `accepted_at`. An agent may author only `status: draft`.
+2. A separate implementation-ticket ID is named. The decision ticket is not executable work.
+3. The operator explicitly invokes or authorizes `start`. Producing or checking a spec never
+   self-authorizes implementation.
+
+Linear and every other external system still follow the installed write-consent rule. The v1
+controller has no external-write adapter at all.
+
+## Prepare the contract
+
+If `scripts/autonomous-run.py` exists, use it. Its installed template is
+`.harness/templates/autonomous-run.json` (the harness source checkout uses
+`templates/autonomous-run.json`):
+
+```text
+python3 scripts/autonomous-run.py prepare \
+  --run-id <short-id> \
+  --spec docs/specs/<name>.md \
+  --ticket <implementation-ticket> \
+  --maker codex --checker claude \
+  --template .harness/templates/autonomous-run.json
+```
+
+This only creates a manifest. Review its exact allowed/denied paths, verifier, models, attempt cap,
+wall-clock limit, and budgets. Commit it before execution; the controller refuses an uncommitted
+contract.
+
+## Start and supervise
+
+Only after explicit operator authorization:
+
+```text
+python3 scripts/autonomous-run.py start .harness/runs/<short-id>.json
+```
+
+The controller creates an isolated local branch/worktree, launches a fresh maker, validates its
+receipt, scope and Git transition, then creates a disposable detached worktree for the sandboxed
+deterministic verifier and a fresh checker. A rejection becomes the next maker's input. Three
+failed attempts, invalid state, denied scope, immutable-deadline or reported-budget exhaustion,
+Git metadata drift, or checker mutation escalates instead of widening authority. Verification
+fails closed unless macOS `sandbox-exec` or Linux `bubblewrap` is available.
+
+Use `status <id>`, `stop <id>`, or `resume <id>`. Stop/resume retains the worktree and audit state.
+An accepted run ends at a local commit for human review: never push, open a PR, merge, deploy,
+rewrite history, or write to Linear from this workflow.
+
+## Report
+
+Give the run ID, status, attempt count, branch/worktree, accepted commit or escalation reason, and
+the actual verification evidence. State explicitly that external actions were not taken.

--- a/skills/wayfinder/SKILL.md
+++ b/skills/wayfinder/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: wayfinder
+description: Wayfind a foggy, multi-session effort into an accepted repository spec and separate implementation-ticket drafts. Use when the destination is known but important decisions, dependencies, or scope are not yet clear enough to implement safely.
+---
+
+# Wayfinder
+
+Turn uncertainty into a decision-complete spec. The map plans the route; it does not execute the
+destination.
+
+## Invariants
+
+- **Destination:** the observable end state this effort is finding a route to.
+- **Decision map:** named questions and their dependency edges. A decision produces an answer, not
+  a slice of implementation.
+- **Frontier:** the sharp, unresolved, unblocked decisions that can be taken next.
+- **Fog:** in-scope uncertainty that cannot yet be phrased as a precise question. Fog graduates to
+  a decision only when the question is sharp.
+- **Decision index:** one context pointer and one-line rationale per resolved decision; the detail
+  lives in its ticket or linked research artifact.
+- **Non-goal:** a deliberate scope boundary. It never graduates from fog unless the destination is
+  explicitly redrawn.
+
+Resolve one decision per session. Parallel research may inform that decision, but does not silently
+resolve another one.
+
+## Chart
+
+1. Read the tracked item, existing plans/specs, and `docs/14-project-tracker-guide.md` when present.
+   Determine the active tracker-write policy before any tracker action.
+2. Name the destination and non-goals. Stop if the effort is already small and decision-complete;
+   use the ordinary plan flow instead.
+3. Create `docs/specs/<slug>.md` from `.harness/templates/wayfinder-spec.md` (or
+   `templates/wayfinder-spec.md` in the harness source checkout); reproduce that shape only when
+   neither is available. Initial status is always `draft`.
+4. Add every sharp question to the decision map, wire its blockers, and identify the frontier.
+   Keep unshaped uncertainty in Fog. Draft a decision ticket for each mapped decision.
+5. If tracker writes are unauthorized, put paste-ready ticket bodies in the spec and surface them
+   to the operator. A connected or named tracker grants no write permission.
+6. Stop after charting. The completed draft spec and ticket drafts are the evidence for this step.
+
+## Advance
+
+1. Load the spec at low resolution: destination, frontier, fog, non-goals, and decision index.
+2. Select one frontier decision. Research, prototype, or discuss only enough to answer its stated
+   question. Human-preference decisions require the human's actual answer.
+3. Record the answer and rationale once, in the decision's ticket draft or authorized tracker item.
+   Add only a linked gist to the Decision index.
+4. Recompute dependencies. Graduate newly sharp fog into decisions; move newly excluded work to
+   Non-goals or Explicit deferrals with a reason.
+5. Stop after one decision. Completion means its answer is recorded and the map reflects the new
+   frontier without duplicate rationale.
+
+## Terminal-spec gate
+
+A spec can be offered for acceptance only when:
+
+- the destination and non-goals are concrete;
+- no unresolved in-scope decision or blocking fog remains;
+- each resolved decision has a rationale and context pointer;
+- evidence/acceptance requirements cover the destination end to end; and
+- implementation-ticket drafts are separate, independently executable scopes.
+
+Present the spec as `draft` and ask the operator to accept or revise it. Only an explicit operator
+acceptance may change `status` to `accepted`; record that human in `accepted_by` and the acceptance
+time in `accepted_at`. An agent's own evaluation cannot accept it. Acceptance closes the decision
+item and unlocks planning/execution against the separate implementation tickets.
+Tracker consent still governs closing or creating items: when writes are unauthorized, provide the
+close comment and implementation-ticket bodies as paste-ready drafts.
+
+## Implementation boundary
+
+An implementation ticket names one deliverable, its scope, dependencies, and proof. It never
+inherits the decision ticket's identity. Wayfinder ends at the accepted spec and ticket drafts;
+start implementation only from a separately tracked implementation ticket and the operator's
+normal execution instruction.
+
+---
+*Adapted from Matt Pocock's
+[`wayfinder`](https://github.com/mattpocock/skills/blob/6654f6b60cd9d5be8b54c6fafe44346dabeb3b76/skills/engineering/wayfinder/SKILL.md)
+(MIT). Agentsmith keeps its decision-map concepts while making the terminal artifact repository-
+native and preserving tracker consent.*

--- a/templates/autonomous-run.json
+++ b/templates/autonomous-run.json
@@ -1,0 +1,52 @@
+{
+  "base_ref": "HEAD",
+  "external_writes": false,
+  "git": {
+    "history_rewrite": false,
+    "local_commits": true,
+    "merge": false,
+    "push": false
+  },
+  "implementation_ticket": "",
+  "limits": {
+    "claude_max_usd": 20,
+    "codex_goal_tokens": 200000,
+    "max_attempts": 3,
+    "wall_minutes": 480
+  },
+  "roles": {
+    "checker": {
+      "effort": "high",
+      "model": "",
+      "runtime": "claude"
+    },
+    "maker": {
+      "effort": "high",
+      "model": "",
+      "runtime": "codex"
+    }
+  },
+  "run_id": "",
+  "schema_version": 1,
+  "scope": {
+    "allowed_paths": [
+      "src/**",
+      "tests/**",
+      "docs/**"
+    ],
+    "denied_paths": [
+      ".env*",
+      ".git/**",
+      ".github/workflows/**",
+      "**/*secret*",
+      "**/*credential*",
+      "**/migrations/**",
+      "**/terraform/**",
+      "**/k8s/**"
+    ]
+  },
+  "spec_path": "",
+  "verify": {
+    "command": "./scripts/verify.sh"
+  }
+}

--- a/templates/wayfinder-spec.md
+++ b/templates/wayfinder-spec.md
@@ -1,0 +1,65 @@
+---
+status: draft
+decision_ticket: <tracker link/id or paste-ready draft name>
+accepted_by:
+accepted_at:
+---
+
+# Spec: <destination name>
+
+## Destination
+
+<The observable end state this effort is finding a route to.>
+
+## Non-goals
+
+- <A deliberate boundary; include why it is outside this destination.>
+
+## Decision map
+
+### Frontier
+
+- [ ] **<decision name>** — <sharp question>; blocked by: none
+
+### Blocked
+
+- [ ] **<decision name>** — <sharp question>; blocked by: <decision name>
+
+### Fog
+
+- <In-scope uncertainty that is not yet sharp enough to state as a decision.>
+
+## Decision index
+
+- [<resolved decision name>](<ticket or durable artifact>): <answer gist> — <one-line rationale>
+
+## Explicit deferrals
+
+- <Non-blocking uncertainty intentionally deferred, with reason and future owner/item.>
+
+## Acceptance and evidence
+
+- <End-to-end observable that proves the destination was reached.>
+
+## Decision-ticket drafts
+
+### <decision name>
+
+**Question:** <one decision this ticket resolves>
+
+**Blocked by:** <decision name or none>
+
+**Resolution:** <leave open until decided>
+
+## Implementation-ticket drafts
+
+> These are new work items created only after this spec is accepted. They do not reuse or reopen
+> the decision ticket.
+
+### <implementation ticket title>
+
+- **Outcome:** <one independently deliverable result>
+- **In scope:** <bounded work>
+- **Out of scope:** <boundary>
+- **Depends on:** <accepted decision or preceding implementation ticket>
+- **Acceptance/evidence:** <checks and observable result>


### PR DESCRIPTION
## Why

The harness needed a durable spec seam and bounded local orchestration before Claude and Codex could hand work to each other unattended. RTK was also intended to be the code-profile default for both runtimes, but Codex wiring was missing.

## What changed

- adapt Wayfinder into a repository-owned, human-accepted spec flow
- preserve Linear write consent and separate decision/implementation tickets
- add a finite local maker/checker controller with isolated verification, immutable budgets, retries, receipts, and stop/resume
- restore RTK default initialization for Claude and Codex code profiles
- scaffold autonomous machinery only for software-dev while keeping the spec skill universal

## Verification

- `bash scripts/verify.sh` — all 12 phases passed
- autonomous adversarial suite — 42/42
- platform installer suite — 110/110
- Wayfinder suite — 40/40
- independent adversarial review — accepted

PowerShell execution remains unverified locally because `pwsh` is unavailable. No live paid Claude/Codex autonomous run was performed; the controller suite uses deterministic fake runtimes.