### PR TITLE
feat(update): add staged stable release updater

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -28,11 +28,13 @@ jobs:
         with:
           python-version: '3.13'
       - name: Python core compiles
-        run: python -m py_compile agentsmith.py native_launcher.py evaluate.py config/statusline.py scripts/autonomous-run.py scripts/test-agent-conformance.py scripts/test-autonomous-state.py scripts/test-doctor.py scripts/test-evaluate.py scripts/test-secret-scan.py scripts/test-statusline.py scripts/test-tracker-consent.py compatibility/test_registry.py
+        run: python -m py_compile agentsmith.py native_launcher.py evaluate.py config/statusline.py scripts/autonomous-run.py scripts/test-agent-conformance.py scripts/test-autonomous-state.py scripts/test-doctor.py scripts/test-evaluate.py scripts/test-secret-scan.py scripts/test-statusline.py scripts/test-tracker-consent.py scripts/test-update.py compatibility/test_registry.py
       - name: Registry schema and contract
         run: python compatibility/test_registry.py
       - name: Strict cross-platform conformance
         run: python scripts/test-agent-conformance.py --strict
+      - name: Stable release updater
+        run: python scripts/test-update.py
       - name: Cross-platform scanner, consent, state ownership, doctor, and evaluation fixtures
         run: |
           python scripts/test-secret-scan.py

--- a/.harness/verify.conf
+++ b/.harness/verify.conf
@@ -11,8 +11,9 @@
 # CI runs the Python conformance/registry phases natively on all three operating systems and the
 # remaining POSIX guardrail phases on Ubuntu. This local file remains the superset release gate.
 
-python-core :: python3 -m py_compile agentsmith.py native_launcher.py evaluate.py config/statusline.py scripts/autonomous-run.py scripts/test-agent-conformance.py scripts/test-autonomous-state.py scripts/test-doctor.py scripts/test-evaluate.py scripts/test-secret-scan.py scripts/test-statusline.py scripts/test-tracker-consent.py compatibility/test_registry.py
+python-core :: python3 -m py_compile agentsmith.py native_launcher.py evaluate.py config/statusline.py scripts/autonomous-run.py scripts/test-agent-conformance.py scripts/test-autonomous-state.py scripts/test-doctor.py scripts/test-evaluate.py scripts/test-secret-scan.py scripts/test-statusline.py scripts/test-tracker-consent.py scripts/test-update.py compatibility/test_registry.py
 agent-conformance :: python3 scripts/test-agent-conformance.py --strict
+update :: python3 scripts/test-update.py
 registry :: python3 compatibility/test_registry.py
 doctor :: python3 scripts/test-doctor.py
 evaluation-runner :: python3 scripts/test-evaluate.py

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -74,7 +74,7 @@ Reruns recover omitted name, role, bio, and tracker values from existing managed
 ```
 
 - Skills are canonical under `.agents/skills`; Claude gets `.claude/skills` as an adapter.
-- MCP is managed only for supported native integrations.
+- MCP is project-scoped and managed only for supported native integrations.
 - Runtime and git hooks invoke Python directly and require no Bash or WSL.
 - Unsupported client capabilities remain unsupported; AgentSmith does not emulate them.
 
@@ -93,7 +93,7 @@ and a dependency-free helper under `~/.claude/`. Any explicit Claude status-line
 Codex needs no added setting: its built-in model/directory status line is already active when
 `tui.status_line` is absent, and an explicit Codex list (including `[]`) remains authoritative.
 
-## 5. Preview, inspect, and uninstall
+## 5. Preview, update, inspect, and uninstall
 
 ```bash
 ./setup.sh --agent all --profile software-dev --dry-run --target .
@@ -109,6 +109,46 @@ Doctor is read-only: it reports effective global/project/nested sources, managed
 fingerprints, combined and duplicate context, actual native safety, and current/stale owned
 capabilities. A duplicate-core warning recommends `--profile-only` but never rewrites a project;
 self-contained project instructions may be intentional for collaborators.
+
+Use the staged updater for an installed project:
+
+```bash
+agentsmith update check
+agentsmith update plan --target /path/to/project --save /tmp/agentsmith-update.json
+# Read the plan. Applying it is the explicit installation approval boundary.
+agentsmith update apply --plan /tmp/agentsmith-update.json
+agentsmith update rollback --receipt /path/printed/by/apply.json
+```
+
+For a global installation, replace `--target /path/to/project` with `--global`. Stable release tags
+from the official repository are the default. `--version v1.2.3` selects an exact stable tag, and
+`--from REMOTE` selects an explicit fork or local test remote. Planning checks that the tag,
+declared version, and Git commit agree. It records current fingerprints, preserved-content rules,
+migration warnings, and verification steps without changing the installation. It also stages the
+release in temporary directories and records the exact create/replace paths, hashes, and file modes.
+Planning uses the current trusted installer logic and treats candidate release files as data. The
+candidate release code does not run before `apply`.
+
+The first plan creates a local authentication key at `~/.agentsmith/update-integrity.key`; this does
+not change the installation. Plans and receipts are bound to that key and to the local account.
+`apply` refuses an edited plan, a moved tag, any file that changed after planning, or a staged result
+that differs from the authenticated proposal. It repeats the release installer against temporary copies,
+then backs up and atomically replaces only managed
+files. A failed apply or health check restores the pre-update bytes automatically. A successful
+apply writes its rollback receipt and backups under `~/.agentsmith`, outside tracked project files.
+Rollback also refuses when an updated file changed after apply, so it cannot overwrite later work.
+
+Weekly checks are opt-in and report-only:
+
+```bash
+agentsmith update configure --auto-check weekly
+agentsmith update configure --auto-check off
+```
+
+The check uses a short timeout and never blocks the requested command when offline. AgentSmith has
+no automatic apply mode. The deprecated `install --self-update` option is only for a clean harness
+Git checkout: it fast-forwards the current branch and lacks stable-release selection, staged plans,
+installation receipts, and rollback.
 
 Global native destinations are fixed, so `--global --target ...` is rejected:
 
@@ -171,6 +211,10 @@ Migration notes:
 - Shared skills live in `.agents/skills`; Claude's directory is an adapter.
 - Old shell helpers may remain in upgraded projects, but new hooks and skills use the Python CLI.
 - `--with-rtk` no longer adds proprietary instruction imports.
+- New installs record update choices and owned skill fingerprints in the existing
+  `.agentsmith/state.json`. Planning can reconstruct a pre-manifest install only when managed
+  markers and ownership state prove every required choice; otherwise it stops and asks for an
+  explicit reinstall rather than guessing safety or ownership.
 
 See [the compatibility contract](docs/22-compatibility-contract.md) and
 [the current registry](config/agents.json).

--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ instead of `--target` for the separate global scope. An explicit `--from` may se
 test remote; a moving development branch is never selected implicitly. The first plan creates a
 machine-local authentication key at `~/.agentsmith/update-integrity.key`. Plans and receipts are
 bound to that key, so an edited or copied document cannot silently authorize different changes.
+Staged updates retain an installation's `--assemble-only` choice, so they do not introduce native
+permission settings or status-line helpers that the original install intentionally omitted.
 
 `agentsmith update configure --auto-check weekly` opts into short, opportunistic checks at command
 startup. They report availability only and never block the requested command when offline.

--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ API-key-authenticated Codex sessions fail closed.
 `--with-skills` installs the canonical pack under `.agents/skills`. Claude additionally gets the
 `.claude/skills` adapter its runtime requires. Skills declare compatibility in frontmatter and do
 not infer runtime identity from their installation path.
+An existing same-name skill remains foreign and is neither overwritten nor added to AgentSmith's
+managed inventory; only an explicit `--force` replacement transfers ownership.
 
 `--with-mcp playwright,context7` manages project MCP only for clients with a supported native adapter.
 Foreign JSON/TOML content is preserved; manually owned Codex MCP names win over a managed copy.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ python3 agentsmith.py compatibility
 python3 agentsmith.py doctor --agent all --target /path/to/project
 python3 agentsmith.py evaluate --agent native --dry-run --claude-max-usd 10 --codex-max-tokens 100000
 
+agentsmith update check --json
+agentsmith update plan --target /path/to/project --save /tmp/agentsmith-update.json
+agentsmith update apply --plan /tmp/agentsmith-update.json
+
 ./setup.sh --agent all --profile auto --dry-run --target /path/to/project
 ./setup.sh --agent all --uninstall --target /path/to/project
 ```
@@ -98,6 +102,25 @@ combined/duplicate token estimates. It separately inspects actual safety, skills
 scanner commands, and installed runtime ownership. Duplicate full cores are warnings, not automatic
 rewrites; use the reported `--profile-only` recommendation only when a self-contained project copy
 is not required. Fixture evidence is never presented as a live-client claim.
+
+Updates select stable semantic-version tags from the official repository by default. `check` and
+`plan` do not change the installation. Planning stages the release in temporary directories and
+records the exact managed create/replace paths, hashes, and file modes. It uses the current trusted
+installer logic and treats candidate release files as data; candidate code does not run during
+planning. `apply --plan` is the approval boundary: it rechecks every planned fingerprint, runs the
+candidate installer in temporary directories, requires the exact staged set, writes
+managed changes atomically, runs strict health checks, and prints the path to a local rollback receipt. Use
+`agentsmith update rollback --receipt FILE` to restore the exact pre-update bytes. Pass `--global`
+instead of `--target` for the separate global scope. An explicit `--from` may select a fork or local
+test remote; a moving development branch is never selected implicitly. The first plan creates a
+machine-local authentication key at `~/.agentsmith/update-integrity.key`. Plans and receipts are
+bound to that key, so an edited or copied document cannot silently authorize different changes.
+
+`agentsmith update configure --auto-check weekly` opts into short, opportunistic checks at command
+startup. They report availability only and never block the requested command when offline.
+Automatic installation is not supported; use `--auto-check off` to disable the checks. The old
+`install --self-update` flag remains temporarily for clean Git checkouts only. It fast-forwards the
+current checkout and cannot provide release selection, installation fingerprints, or rollback.
 
 `agentsmith evaluate` runs nine behavioral scenarios for installed Claude Code and Codex clients.
 The default is a write-free dry run that resolves clients, commands, isolation, scenarios, and
@@ -117,7 +140,7 @@ API-key-authenticated Codex sessions fail closed.
 `.claude/skills` adapter its runtime requires. Skills declare compatibility in frontmatter and do
 not infer runtime identity from their installation path.
 
-`--with-mcp playwright,context7` manages MCP only for clients with a supported native adapter.
+`--with-mcp playwright,context7` manages project MCP only for clients with a supported native adapter.
 Foreign JSON/TOML content is preserved; manually owned Codex MCP names win over a managed copy.
 
 `--with-handoff-hooks`, `--with-ui-design-hook`, and `--with-hooks` install Python commands rather

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ machine-local authentication key at `~/.agentsmith/update-integrity.key`. Plans 
 bound to that key, so an edited or copied document cannot silently authorize different changes.
 Staged updates retain an installation's `--assemble-only` choice, so they do not introduce native
 permission settings or status-line helpers that the original install intentionally omitted.
+Selected project MCP configuration is fingerprinted and updated with the same approval and rollback
+boundary; MCP servers and settings that AgentSmith does not own remain intact.
 
 `agentsmith update configure --auto-check weekly` opts into short, opportunistic checks at command
 startup. They report availability only and never block the requested command when offline.

--- a/agentsmith.py
+++ b/agentsmith.py
@@ -1292,7 +1292,7 @@ def validate_installation_manifest(state: dict[str, Any]) -> dict[str, Any]:
     if unknown_state:
         raise CliError(f"Installation state has unknown field(s): {', '.join(unknown_state)}")
     if state.get("schema_version") != 1:
-        raise CliError("Installation state has no supported schema; rerun install with explicit choices before planning an update")
+        raise CliError("Installation state has an unsupported schema; rerun install with explicit choices before planning an update")
     installation = state.get("installation")
     if not isinstance(installation, dict):
         raise CliError("Installation state has no manifest; rerun install with explicit choices before planning an update")
@@ -1580,7 +1580,7 @@ def cmd_update_plan(args: argparse.Namespace) -> int:
     state = load_update_state(target)
     expected_scope = "global" if args.global_mode else "project"
     migration_warnings: list[str] = []
-    if state.get("schema_version") == 1 and isinstance(state.get("installation"), dict):
+    if "schema_version" in state or "installation" in state:
         installation = validate_installation_manifest(state)
     else:
         installation = reconstruct_pre_manifest_installation(target, expected_scope, state)

--- a/agentsmith.py
+++ b/agentsmith.py
@@ -9,18 +9,23 @@ file, so macOS, Linux, and native Windows exercise the same implementation.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import datetime as dt
 import hashlib
+import hmac
+import io
 import json
 import os
 from pathlib import Path
 import re
+import secrets
 import shlex
 import shutil
 import subprocess
 import sys
 import tempfile
 import textwrap
+import time
 import tomllib
 from typing import Any, Iterable
 import urllib.error
@@ -28,6 +33,7 @@ import urllib.request
 
 
 VERSION = "0.2.0"
+OFFICIAL_REMOTE = "https://github.com/PromptPartner/agentsmith.git"
 ROOT = Path(__file__).resolve().parent
 REGISTRY_PATH = ROOT / "config" / "agents.json"
 BEGIN = "<!-- BEGIN AGENTSMITH — universal agent harness (managed by agentsmith — edit core/profiles, not here) -->"
@@ -56,6 +62,14 @@ GROUPS = {
     "all": AGENT_IDS,
 }
 CODE_PROFILES = {"software-dev", "devops-setup"}
+RUNTIME_FILES = (
+    ".agentsmith/agentsmith.py",
+    ".agentsmith/agentsmith",
+    ".agentsmith/agentsmith.cmd",
+    ".agentsmith/config/agents.json",
+    ".agentsmith/evaluate.py",
+    ".agentsmith/native_launcher.py",
+)
 SECRET_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     ("PEM private key", re.compile(r"BEGIN [A-Z ]*PRIVATE KEY")),
     ("AWS access key id", re.compile(r"AKIA[0-9A-Z]{16}")),
@@ -164,7 +178,39 @@ def atomic_write(path: Path, content: str) -> None:
     with tempfile.NamedTemporaryFile("w", encoding="utf-8", newline="", dir=path.parent, delete=False) as handle:
         handle.write(content)
         temp = Path(handle.name)
-    temp.replace(path)
+    try:
+        replace_with_retry(temp, path)
+    except Exception:
+        temp.unlink(missing_ok=True)
+        raise
+
+
+def replace_with_retry(source: Path, destination: Path) -> None:
+    delays = (0.05, 0.1, 0.2)
+    for attempt in range(len(delays) + 1):
+        try:
+            source.replace(destination)
+            return
+        except PermissionError:
+            if attempt == len(delays):
+                raise
+            time.sleep(delays[attempt])
+
+
+def atomic_write_bytes(path: Path, content: bytes, mode: int | None = None) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile("wb", dir=path.parent, delete=False) as handle:
+        handle.write(content)
+        handle.flush()
+        os.fsync(handle.fileno())
+        temp = Path(handle.name)
+    if mode is not None:
+        temp.chmod(mode)
+    try:
+        replace_with_retry(temp, path)
+    except Exception:
+        temp.unlink(missing_ok=True)
+        raise
 
 
 def managed_markers(text: str) -> tuple[str, str] | None:
@@ -518,12 +564,148 @@ def load_state(target: Path) -> dict[str, Any]:
         return {}
 
 
+def load_update_state(target: Path) -> dict[str, Any]:
+    path = state_path(target)
+    if not path.exists():
+        return {}
+    try:
+        state = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise CliError(f"Cannot use malformed update state {path}: {exc}") from exc
+    if not isinstance(state, dict):
+        raise CliError(f"Cannot use non-object update state {path}")
+    return state
+
+
 def record_state(target: Path, key: str, value: Any, *, dry_run: bool) -> None:
     if dry_run:
         return
     state = load_state(target)
     state[key] = value
     path = state_path(target)
+    rendered = json.dumps(state, indent=2, ensure_ascii=False) + "\n"
+    if not path.exists() or path.read_text(encoding="utf-8") != rendered:
+        atomic_write(path, rendered)
+
+
+def source_release_identity() -> dict[str, str | None]:
+    """Describe this runtime without mistaking an installed project for the source checkout."""
+    identity: dict[str, str | None] = {"release": None, "commit": None}
+    if not shutil.which("git"):
+        return identity
+    probe = subprocess.run(
+        ["git", "-C", str(ROOT), "rev-parse", "--show-toplevel", "HEAD"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    lines = probe.stdout.splitlines()
+    if probe.returncode or len(lines) != 2:
+        return identity
+    try:
+        source_root = Path(lines[0]).resolve()
+    except OSError:
+        return identity
+    if source_root != ROOT.resolve():
+        return identity
+    unstaged = subprocess.run(["git", "-C", str(ROOT), "diff", "--quiet"], check=False)
+    staged = subprocess.run(["git", "-C", str(ROOT), "diff", "--cached", "--quiet"], check=False)
+    if unstaged.returncode or staged.returncode:
+        return identity
+    identity["commit"] = lines[1]
+    tag = subprocess.run(
+        ["git", "-C", str(ROOT), "describe", "--tags", "--exact-match", "--match", "v[0-9]*"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    candidate = tag.stdout.strip()
+    if tag.returncode == 0 and candidate == f"v{VERSION}":
+        identity["release"] = candidate
+    return identity
+
+
+def record_installation_manifest(
+    target: Path,
+    agents: list[str],
+    profiles: list[str],
+    args: argparse.Namespace,
+    recovery: dict[str, str],
+) -> None:
+    if args.dry_run:
+        return
+    manifest_root = home_dir() if args.global_mode else target
+    state = load_state(manifest_root)
+    prior_installation = state.get("installation", {})
+    source = source_release_identity()
+    if not source.get("commit") and isinstance(prior_installation, dict):
+        prior_source = prior_installation.get("source")
+        if isinstance(prior_source, dict):
+            source = {
+                "release": prior_source.get("release") if isinstance(prior_source.get("release"), str) else None,
+                "commit": prior_source.get("commit") if isinstance(prior_source.get("commit"), str) else None,
+            }
+    requested_mcp = csv(args.with_mcp)
+    available_mcp = json.loads((ROOT / "config" / "mcp.example.json").read_text(encoding="utf-8"))["mcpServers"]
+    prior_capabilities = prior_installation.get("capabilities", {}) if isinstance(prior_installation, dict) else {}
+    if not isinstance(prior_capabilities, dict):
+        prior_capabilities = {}
+    prior_mcp = prior_capabilities.get("mcp", [])
+    if not isinstance(prior_mcp, list):
+        prior_mcp = []
+    mcp_names = list(dict.fromkeys(
+        name for name in [*prior_mcp, *requested_mcp]
+        if isinstance(name, str) and name in available_mcp
+    ))
+    safety = {
+        agent_id: args.safety
+        for agent_id in agents
+        if agent_id in {"claude", "codex"}
+    }
+    state["schema_version"] = 1
+    managed_files: list[dict[str, str]] = []
+    managed_root = home_dir() if args.global_mode else target
+    for relative_root in (Path(".agents") / "skills", Path(".claude") / "skills"):
+        skill_root = managed_root / relative_root
+        if not skill_root.is_dir():
+            continue
+        for path in sorted(skill_root.rglob("*")):
+            if path.is_file():
+                managed_files.append({
+                    "root": "home" if args.global_mode else "target",
+                    "path": path.relative_to(managed_root).as_posix(),
+                    "sha256": file_sha256(path),
+                })
+    state["installation"] = {
+        "installed_version": VERSION,
+        "source": source,
+        "scope": "global" if args.global_mode else "project",
+        "agents": agents,
+        "profiles": profiles,
+        "include_core": not args.profile_only,
+        "safety": safety,
+        "operator": {
+            "name": args.operator_name or recovery.get("operator_name") or "the project lead",
+            "role": args.operator_role or recovery.get("operator_role") or "owner / decision-maker",
+            "bio": args.operator_bio or recovery.get("operator_bio") or (
+                "They decide direction and accept the risk; you are the technical co-pilot — proactive, "
+                "evidence-driven, and honest about trade-offs."
+            ),
+        },
+        "tracker": {
+            "name": args.tracker or recovery.get("tracker") or "your project's tracker (or a KNOWN-ISSUES.md at the repo root)",
+            "writes": args.tracker_writes or recovery.get("tracker_writes") or "ask",
+        },
+        "capabilities": {
+            "handoff_hooks": bool(args.with_handoff_hooks or prior_capabilities.get("handoff_hooks")),
+            "hooks": bool(args.with_hooks or prior_capabilities.get("hooks")),
+            "mcp": mcp_names,
+            "skills": bool(args.with_skills or prior_capabilities.get("skills")),
+            "ui_design_hook": bool(args.with_ui_design_hook or prior_capabilities.get("ui_design_hook")),
+        },
+        "managed_files": managed_files,
+    }
+    path = state_path(manifest_root)
     rendered = json.dumps(state, indent=2, ensure_ascii=False) + "\n"
     if not path.exists() or path.read_text(encoding="utf-8") != rendered:
         atomic_write(path, rendered)
@@ -704,7 +886,7 @@ def copy_runtime(target: Path, *, dry_run: bool) -> Path:
     destination = target / ".agentsmith" / "agentsmith.py"
     if not dry_run:
         destination.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(Path(__file__).resolve(), destination)
+        shutil.copy2(ROOT / "agentsmith.py", destination)
         registry_destination = destination.parent / "config" / "agents.json"
         registry_destination.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(REGISTRY_PATH, registry_destination)
@@ -847,6 +1029,7 @@ def install_claude_plugin_packs(agents: list[str], requested: str | None, *, dry
 
 
 def self_update(args: argparse.Namespace) -> int:
+    warn("install --self-update is deprecated and updates only a clean Git checkout; use 'agentsmith update' for installed scopes")
     if not shutil.which("git"):
         raise CliError("Self-update needs git on PATH")
     if subprocess.run(["git", "-C", str(ROOT), "diff", "--quiet"]).returncode or subprocess.run(
@@ -889,6 +1072,1190 @@ def self_update(args: argparse.Namespace) -> int:
     if not args.no_reassemble:
         reassemble_managed_targets(args)
     return 0
+
+
+def stable_release_tags(remote: str, *, timeout_seconds: int = 10) -> list[tuple[tuple[int, int, int], str]]:
+    """Return stable semantic-version tags advertised by a Git remote."""
+    if not shutil.which("git"):
+        raise CliError("Update checks need git on PATH")
+    git_env = {
+        **os.environ,
+        "GIT_TERMINAL_PROMPT": "0",
+        "GIT_ASKPASS": "/usr/bin/false" if os.name != "nt" else "",
+    }
+    try:
+        result = subprocess.run(
+            ["git", "ls-remote", "--tags", "--refs", "--", remote],
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=timeout_seconds,
+            env=git_env,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise CliError(f"Update check timed out after {timeout_seconds} seconds; no installation changes were made") from exc
+    except OSError as exc:
+        raise CliError(f"Update check could not start git: {exc}") from exc
+    if result.returncode:
+        detail = result.stderr.strip().splitlines()[-1] if result.stderr.strip() else "remote unavailable"
+        raise CliError(f"Update check failed ({detail}); no installation changes were made")
+    releases: list[tuple[tuple[int, int, int], str]] = []
+    for line in result.stdout.splitlines():
+        fields = line.split()
+        if len(fields) != 2:
+            continue
+        match = re.fullmatch(r"refs/tags/(v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*))", fields[1])
+        if match:
+            releases.append(((int(match.group(2)), int(match.group(3)), int(match.group(4))), match.group(1)))
+    return sorted(set(releases))
+
+
+def cmd_update_check(args: argparse.Namespace) -> int:
+    remote = args.update_from or OFFICIAL_REMOTE
+    releases = stable_release_tags(remote)
+    if not releases:
+        raise CliError(f"No stable semantic-version tags were found at {remote}")
+    latest_version, tag = releases[-1]
+    current_match = re.fullmatch(r"(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)", VERSION)
+    if not current_match:
+        raise CliError(f"Installed version {VERSION!r} is not a stable semantic version")
+    current_version = tuple(int(current_match.group(index)) for index in range(1, 4))
+    payload = {
+        "current_version": VERSION,
+        "latest_version": ".".join(str(part) for part in latest_version),
+        "tag": tag,
+        "update_available": latest_version > current_version,
+        "remote": remote,
+    }
+    if args.json:
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
+    elif payload["update_available"]:
+        say(f"Agentsmith {payload['latest_version']} is available ({tag}); run 'agentsmith update plan' to inspect it")
+    else:
+        ok(f"Agentsmith {VERSION} is the latest stable release")
+    return 0
+
+
+def resolve_stable_release(remote: str, requested_tag: str | None) -> dict[str, str]:
+    releases = stable_release_tags(remote)
+    if not releases:
+        raise CliError(f"No stable semantic-version tags were found at {remote}")
+    release_by_tag = {tag: version for version, tag in releases}
+    tag = requested_tag or releases[-1][1]
+    if tag not in release_by_tag:
+        raise CliError(f"Release {tag!r} is not an advertised stable semantic-version tag at {remote}")
+    version_tuple = release_by_tag[tag]
+    version = ".".join(str(part) for part in version_tuple)
+    git_env = {
+        **os.environ,
+        "GIT_TERMINAL_PROMPT": "0",
+        "GIT_ASKPASS": "/usr/bin/false" if os.name != "nt" else "",
+    }
+    with tempfile.TemporaryDirectory(prefix="agentsmith-release-") as temporary:
+        checkout = Path(temporary) / "checkout"
+        try:
+            cloned = subprocess.run(
+                ["git", "clone", "--quiet", "--no-checkout", "--single-branch", "--branch", tag, "--", remote, str(checkout)],
+                text=True,
+                capture_output=True,
+                check=False,
+                timeout=30,
+                env=git_env,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise CliError("Release checkout timed out; no installation changes were made") from exc
+        if cloned.returncode:
+            detail = cloned.stderr.strip().splitlines()[-1] if cloned.stderr.strip() else "clone failed"
+            raise CliError(f"Could not stage release {tag} ({detail}); no installation changes were made")
+        commit_result = subprocess.run(
+            ["git", "-C", str(checkout), "rev-parse", f"refs/tags/{tag}^{{commit}}"],
+            text=True,
+            capture_output=True,
+            check=False,
+            env=git_env,
+        )
+        commit = commit_result.stdout.strip()
+        if commit_result.returncode or not re.fullmatch(r"[0-9a-f]{40,64}", commit):
+            raise CliError(f"Release tag {tag} does not resolve to a valid Git commit")
+        tree = subprocess.run(
+            ["git", "-C", str(checkout), "ls-tree", "-r", commit],
+            text=True,
+            capture_output=True,
+            check=False,
+            env=git_env,
+        )
+        unsafe_entry = next(
+            (line for line in tree.stdout.splitlines() if line.startswith(("120000 ", "160000 "))),
+            None,
+        )
+        if tree.returncode or unsafe_entry:
+            raise CliError(f"Release {tag} contains an unsupported symbolic link or submodule")
+        checked_out = subprocess.run(
+            ["git", "-C", str(checkout), "checkout", "--quiet", "--detach", commit],
+            text=True,
+            capture_output=True,
+            check=False,
+            env=git_env,
+        )
+        if checked_out.returncode:
+            raise CliError(f"Release commit {commit[:12]} could not be checked out")
+        for candidate in checkout.rglob("*"):
+            if candidate.is_symlink():
+                raise CliError(f"Release {tag} contains a symbolic link, which staged updates do not accept: {candidate.relative_to(checkout)}")
+        runtime = checkout / "agentsmith.py"
+        try:
+            runtime_text = runtime.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise CliError(f"Release {tag} has no readable agentsmith.py runtime") from exc
+        declared = re.search(r'^VERSION = "([^"]+)"$', runtime_text, re.MULTILINE)
+        if not declared or declared.group(1) != version:
+            actual = declared.group(1) if declared else "missing"
+            raise CliError(f"Release {tag} declares version {actual!r}, expected {version!r}")
+    return {"tag": tag, "version": version, "commit": commit}
+
+
+def checkout_planned_release(remote: str, release: dict[str, str], destination: Path) -> Path:
+    resolved = resolve_stable_release(remote, release["tag"])
+    if resolved != release:
+        raise CliError("The selected release tag moved or changed after planning; create a new plan")
+    git_env = {
+        **os.environ,
+        "GIT_TERMINAL_PROMPT": "0",
+        "GIT_ASKPASS": "/usr/bin/false" if os.name != "nt" else "",
+    }
+    result = subprocess.run(
+        [
+            "git", "clone", "--quiet", "--no-checkout", "--single-branch", "--branch", release["tag"],
+            "--", remote, str(destination),
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+        env=git_env,
+    )
+    if result.returncode:
+        detail = result.stderr.strip().splitlines()[-1] if result.stderr.strip() else "clone failed"
+        raise CliError(f"Could not restage release {release['tag']} ({detail})")
+    checked_out = subprocess.run(
+        ["git", "-C", str(destination), "checkout", "--quiet", "--detach", release["commit"]],
+        text=True,
+        capture_output=True,
+        check=False,
+        env=git_env,
+    )
+    if checked_out.returncode:
+        raise CliError(f"Could not check out planned commit {release['commit'][:12]}")
+    return destination
+
+
+def validate_installation_manifest(state: dict[str, Any]) -> dict[str, Any]:
+    allowed_state = {
+        "schema_version", "installation", "gemini_context_added", "native_statuslines",
+        "native_safety", "claude_mcp_added", "skills_installed", "update_policy",
+    }
+    unknown_state = sorted(set(state) - allowed_state)
+    if unknown_state:
+        raise CliError(f"Installation state has unknown field(s): {', '.join(unknown_state)}")
+    if state.get("schema_version") != 1:
+        raise CliError("Installation state has no supported schema; rerun install with explicit choices before planning an update")
+    installation = state.get("installation")
+    if not isinstance(installation, dict):
+        raise CliError("Installation state has no manifest; rerun install with explicit choices before planning an update")
+    allowed_installation = {
+        "installed_version", "source", "scope", "agents", "profiles", "include_core",
+        "safety", "operator", "tracker", "capabilities", "managed_files",
+    }
+    unknown_installation = sorted(set(installation) - allowed_installation)
+    if unknown_installation:
+        raise CliError(f"Installation manifest has unknown field(s): {', '.join(unknown_installation)}")
+    required = allowed_installation
+    missing = sorted(required - set(installation))
+    if missing:
+        raise CliError(f"Installation manifest is missing field(s): {', '.join(missing)}")
+    return installation
+
+
+def reconstruct_pre_manifest_installation(target: Path, scope: str, state: dict[str, Any]) -> dict[str, Any]:
+    instruction_candidates = (
+        [home_dir() / ".claude" / "CLAUDE.md", codex_home() / "AGENTS.md"]
+        if scope == "global"
+        else [target / "AGENTS.md", target / "CLAUDE.md"]
+    )
+    managed_instructions = [
+        path for path in instruction_candidates
+        if path.is_file() and managed_markers(path.read_text(encoding="utf-8", errors="replace"))
+    ]
+    if not managed_instructions:
+        raise CliError("Pre-manifest install has no managed instruction markers; rerun install with explicit choices")
+    metadata_values: set[tuple[tuple[str, ...], bool]] = set()
+    for path in managed_instructions:
+        text = path.read_text(encoding="utf-8", errors="replace")
+        metadata = re.search(r"Generated\. Profiles: ([^.]+)\. core=(true|false)\.", text)
+        if not metadata:
+            raise CliError(f"Cannot infer profiles and core choice from {path}; rerun install explicitly")
+        profiles = () if metadata.group(1) == "none" else tuple(metadata.group(1).split(","))
+        metadata_values.add((profiles, metadata.group(2) == "true"))
+    if len(metadata_values) != 1:
+        raise CliError("Managed instruction copies disagree about profiles or core choice; rerun install explicitly")
+    profiles, include_core = next(iter(metadata_values))
+    home_state = load_state(home_dir().resolve())
+    native_safety = home_state.get("native_safety", {})
+    native_safety = native_safety if isinstance(native_safety, dict) else {}
+    agents: list[str] = []
+    if scope == "global":
+        if (home_dir() / ".claude" / "CLAUDE.md") in managed_instructions:
+            agents.append("claude")
+        if (codex_home() / "AGENTS.md") in managed_instructions:
+            agents.append("codex")
+    else:
+        claude_copy = target / "CLAUDE.md"
+        if claude_copy in managed_instructions:
+            agents.append("claude")
+        native_candidates = {key for key in native_safety if key in {"claude", "codex"}}
+        if native_candidates == {"codex"}:
+            agents.append("codex")
+        elif native_candidates - set(agents):
+            raise CliError("Pre-manifest native agent ownership is ambiguous; rerun install with explicit --agent choices")
+        adapters = {
+            "gemini-cli": target / ".gemini" / "settings.json",
+            "aider": target / ".aider.conf.yml",
+            "continue": target / ".continue" / "rules" / "agentsmith.md",
+            "goose": target / ".goosehints",
+        }
+        for agent_id, path in adapters.items():
+            if path.is_file():
+                agents.append(agent_id)
+    agents = list(dict.fromkeys(agents))
+    if not agents:
+        raise CliError("Pre-manifest agent selection cannot be inferred; rerun install with explicit --agent choices")
+    safety: dict[str, str] = {}
+    for agent_id in agents:
+        if agent_id not in {"claude", "codex"}:
+            continue
+        value = native_safety.get(agent_id)
+        if value not in {"cautious", "trusted"}:
+            raise CliError(f"Pre-manifest safety for {agent_id} cannot be inferred; rerun install with explicit --safety")
+        safety[agent_id] = value
+    recovery = recover_identity(managed_instructions)
+    runtime = target / ".agentsmith" / "agentsmith.py" if scope == "project" else Path(__file__).resolve()
+    installed_version = VERSION
+    if runtime.is_file():
+        declared = re.search(r'^VERSION = "([^"]+)"$', runtime.read_text(encoding="utf-8", errors="replace"), re.MULTILINE)
+        if declared:
+            installed_version = declared.group(1)
+    config_texts = []
+    for path in (home_dir() / ".claude" / "settings.json", codex_home() / "config.toml"):
+        if path.is_file():
+            config_texts.append(path.read_text(encoding="utf-8", errors="replace"))
+    combined_config = "\n".join(config_texts)
+    mcp_names = sorted(set(re.findall(r"(?m)^\[mcp_servers\.([A-Za-z0-9_-]+)\]\s*$", combined_config)))
+    skill_root = home_dir() if scope == "global" else target
+    skills = (skill_root / ".agents" / "skills").is_dir()
+    return {
+        "installed_version": installed_version,
+        "source": {"release": None, "commit": None},
+        "scope": scope,
+        "agents": agents,
+        "profiles": list(profiles),
+        "include_core": include_core,
+        "safety": safety,
+        "operator": {
+            "name": recovery.get("operator_name", "the project lead"),
+            "role": recovery.get("operator_role", "owner / decision-maker"),
+            "bio": recovery.get("operator_bio", (
+                "They decide direction and accept the risk; you are the technical co-pilot — proactive, "
+                "evidence-driven, and honest about trade-offs."
+            )),
+        },
+        "tracker": {
+            "name": recovery.get("tracker", "your project's tracker (or a KNOWN-ISSUES.md at the repo root)"),
+            "writes": recovery.get("tracker_writes", "ask"),
+        },
+        "capabilities": {
+            "handoff_hooks": "handoff-on-keyword" in combined_config,
+            "hooks": False,
+            "mcp": mcp_names,
+            "skills": skills,
+            "ui_design_hook": "ui-design-reminder" in combined_config,
+        },
+        "managed_files": [],
+    }
+
+
+def fingerprint_entry(root_name: str, root: Path, path: Path) -> dict[str, Any]:
+    relative = path.relative_to(root).as_posix()
+    return {
+        "root": root_name,
+        "path": relative,
+        "sha256": file_sha256(path) if path.is_file() else None,
+        "mode": path.stat().st_mode & 0o777 if path.is_file() else None,
+    }
+
+
+def safe_update_path(root: Path, relative: str | Path) -> Path:
+    """Return a contained updater path after rejecting every symbolic-link component."""
+    root = root.resolve()
+    relative_path = Path(relative)
+    if relative_path.is_absolute() or ".." in relative_path.parts or not relative_path.parts:
+        raise CliError(f"Update path escapes its declared root: {relative}")
+    candidate = root.joinpath(relative_path)
+    current = root
+    for part in relative_path.parts:
+        current = current / part
+        if current.is_symlink():
+            raise CliError(f"Update refused to follow symbolic link {current}")
+    try:
+        candidate.resolve(strict=False).relative_to(root)
+    except (OSError, ValueError) as exc:
+        raise CliError(f"Update path escapes its declared root: {candidate}") from exc
+    return candidate
+
+
+def installation_fingerprints(target: Path, installation: dict[str, Any]) -> tuple[dict[str, str], list[dict[str, Any]]]:
+    roots = {
+        "target": target,
+        "home": home_dir().resolve(),
+        "codex_home": codex_home().resolve(),
+    }
+    candidates: set[tuple[str, Path]] = set()
+
+    def add(root_name: str, relative: str) -> None:
+        root = roots[root_name]
+        path = safe_update_path(root, relative)
+        if path.is_dir():
+            for child in path.rglob("*"):
+                checked = safe_update_path(root, child.relative_to(root))
+                if checked.is_file():
+                    candidates.add((root_name, checked))
+        else:
+            candidates.add((root_name, path))
+
+    if installation["scope"] == "project":
+        for relative in (
+            "AGENTS.md", "CLAUDE.md", *RUNTIME_FILES, ".agentsmith/autonomous-run.py", ".agentsmith/state.json",
+            ".harness/templates", ".harness/verify.conf",
+        ):
+            add("target", relative)
+        adapters = {
+            "gemini-cli": ".gemini/settings.json",
+            "aider": ".aider.conf.yml",
+            "continue": ".continue/rules/agentsmith.md",
+            "goose": ".goosehints",
+        }
+        for agent_id in installation["agents"]:
+            if agent_id in adapters:
+                add("target", adapters[agent_id])
+        if installation["capabilities"].get("skills"):
+            add("target", ".agents/skills")
+            if "claude" in installation["agents"]:
+                add("target", ".claude/skills")
+    else:
+        if "claude" in installation["agents"]:
+            add("home", ".claude/CLAUDE.md")
+        if "codex" in installation["agents"]:
+            add("codex_home", "AGENTS.md")
+        if installation["capabilities"].get("skills"):
+            add("home", ".agents/skills")
+            if "claude" in installation["agents"]:
+                add("home", ".claude/skills")
+        if installation["capabilities"].get("handoff_hooks") or installation["capabilities"].get("ui_design_hook"):
+            for relative in RUNTIME_FILES:
+                add("home", relative)
+    add("home", ".agentsmith/state.json")
+    home_state = load_update_state(roots["home"])
+    native_statuslines = home_state.get("native_statuslines", {})
+    claude_statusline = native_statuslines.get("claude", {}) if isinstance(native_statuslines, dict) else {}
+    statusline_files = claude_statusline.get("files", {}) if isinstance(claude_statusline, dict) else {}
+    if isinstance(statusline_files, dict):
+        for raw_path in statusline_files:
+            if not isinstance(raw_path, str):
+                continue
+            try:
+                relative = Path(raw_path).relative_to(roots["home"]).as_posix()
+            except ValueError:
+                continue
+            if re.fullmatch(r"\.claude/agentsmith-statusline(?:-\d+)?\.(?:py|ps1)", relative):
+                add("home", relative)
+    if "claude" in installation["agents"]:
+        add("home", ".claude/settings.json")
+    if "codex" in installation["agents"]:
+        add("codex_home", "config.toml")
+        add("codex_home", "hooks.json")
+    entries = [fingerprint_entry(root_name, roots[root_name], path) for root_name, path in candidates]
+    entries.sort(key=lambda item: (item["root"], item["path"]))
+    return {name: str(path) for name, path in roots.items()}, entries
+
+
+def update_integrity_key(*, create: bool) -> bytes:
+    key_path = safe_update_path(home_dir().resolve(), ".agentsmith/update-integrity.key")
+    if key_path.exists():
+        if not key_path.is_file():
+            raise CliError(f"Update integrity key is not a regular file: {key_path}")
+        try:
+            key = key_path.read_bytes()
+        except OSError as exc:
+            raise CliError(f"Cannot read update integrity key {key_path}: {exc}") from exc
+        if len(key) != 32:
+            raise CliError(f"Update integrity key has an invalid length: {key_path}")
+        return key
+    if not create:
+        raise CliError(f"Update integrity key is missing: {key_path}; create a new plan on this machine")
+    key = secrets.token_bytes(32)
+    atomic_write_bytes(key_path, key, 0o600)
+    try:
+        key_path.chmod(0o600)
+    except OSError as exc:
+        raise CliError(f"Cannot secure update integrity key {key_path}: {exc}") from exc
+    return key
+
+
+def plan_integrity(payload: dict[str, Any], key: bytes) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return "hmac-sha256:" + hmac.new(key, canonical, hashlib.sha256).hexdigest()
+
+
+def cmd_update_plan(args: argparse.Namespace) -> int:
+    if args.global_mode == bool(args.target):
+        raise CliError("Update planning requires exactly one of --global or --target PATH")
+    target = home_dir().resolve() if args.global_mode else Path(args.target).expanduser().resolve()
+    safe_update_path(target, ".agentsmith/state.json")
+    state = load_update_state(target)
+    expected_scope = "global" if args.global_mode else "project"
+    migration_warnings: list[str] = []
+    if state.get("schema_version") == 1 and isinstance(state.get("installation"), dict):
+        installation = validate_installation_manifest(state)
+    else:
+        installation = reconstruct_pre_manifest_installation(target, expected_scope, state)
+        migration_warnings.append(
+            "Pre-manifest installation choices were reconstructed from managed markers and ownership state; "
+            "apply will persist schema version 1."
+        )
+    if installation["scope"] != expected_scope:
+        raise CliError(f"Installation manifest scope is {installation['scope']!r}, not {expected_scope!r}")
+    remote = args.update_from or OFFICIAL_REMOTE
+    release = resolve_stable_release(remote, args.version)
+    roots, fingerprints = installation_fingerprints(target, installation)
+    payload: dict[str, Any] = {
+        "schema_version": 1,
+        "created_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "scope": expected_scope,
+        "target": str(target),
+        "roots": roots,
+        "remote": remote,
+        "release": release,
+        "installation": installation,
+        "fingerprints": fingerprints,
+        "proposed_changes": [],
+        "preserved_foreign_content": [
+            "Content outside AgentSmith-managed markers and owned configuration remains in place.",
+            "Modified helpers, research, source material, and unowned configuration are not deletion targets.",
+        ],
+        "migration_warnings": migration_warnings,
+        "verification": [
+            "repeat the staged release installer with the recorded manifest choices",
+            "require the exact create/replace paths, hashes, and modes recorded in proposed_changes",
+            "run agentsmith doctor --strict for the selected install",
+            "compare post-update state and write a rollback receipt",
+        ],
+    }
+    with tempfile.TemporaryDirectory(prefix="agentsmith-plan-") as temporary:
+        _, proposed = stage_planned_update(payload, Path(temporary), execute_candidate=False)
+        payload["proposed_changes"] = proposed_change_manifest(payload, proposed)
+    payload["integrity"] = plan_integrity(payload, update_integrity_key(create=True))
+    rendered = json.dumps(payload, indent=2, ensure_ascii=False) + "\n"
+    if args.save:
+        destination = Path(args.save).expanduser().resolve()
+        atomic_write(destination, rendered)
+        ok(f"saved read-only installation plan for {release['tag']} to {destination}")
+    else:
+        print(rendered, end="")
+    return 0
+
+
+def load_update_document(path: Path, kind: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise CliError(f"Cannot read {kind} {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise CliError(f"{kind.capitalize()} must be a JSON object")
+    integrity = payload.get("integrity")
+    unsigned = {key: value for key, value in payload.items() if key != "integrity"}
+    expected_integrity = plan_integrity(unsigned, update_integrity_key(create=False))
+    if not isinstance(integrity, str) or not hmac.compare_digest(integrity, expected_integrity):
+        raise CliError(f"{kind.capitalize()} integrity check failed; do not apply an edited or partial file")
+    return payload
+
+
+def validated_plan(path: Path) -> dict[str, Any]:
+    plan = load_update_document(path, "plan")
+    allowed = {
+        "schema_version", "created_at", "scope", "target", "roots", "remote", "release",
+        "installation", "fingerprints", "proposed_changes", "preserved_foreign_content",
+        "migration_warnings", "verification", "integrity",
+    }
+    unknown = sorted(set(plan) - allowed)
+    missing = sorted(allowed - set(plan))
+    if unknown or missing:
+        detail = f"unknown: {', '.join(unknown)}" if unknown else f"missing: {', '.join(missing)}"
+        raise CliError(f"Plan fields are not supported ({detail})")
+    if plan["schema_version"] != 1 or plan["scope"] not in {"project", "global"}:
+        raise CliError("Plan schema or scope is not supported")
+    if not isinstance(plan["target"], str) or not isinstance(plan["remote"], str) or not plan["remote"]:
+        raise CliError("Plan target and remote must be non-empty strings")
+    expected_target = home_dir().resolve() if plan["scope"] == "global" else Path(plan["target"]).resolve()
+    expected_roots = {
+        "target": str(expected_target),
+        "home": str(home_dir().resolve()),
+        "codex_home": str(codex_home().resolve()),
+    }
+    if plan["roots"] != expected_roots or Path(plan["target"]).resolve() != expected_target:
+        raise CliError("Plan roots do not match the current target, HOME, and CODEX_HOME")
+    release = plan["release"]
+    if not isinstance(release, dict) or set(release) != {"tag", "version", "commit"}:
+        raise CliError("Plan release identity is malformed")
+    if not re.fullmatch(r"v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)", release.get("tag", "")):
+        raise CliError("Plan release tag is not a stable semantic version")
+    if release["tag"] != f"v{release.get('version')}" or not re.fullmatch(r"[0-9a-f]{40,64}", release.get("commit", "")):
+        raise CliError("Plan release version or commit is malformed")
+    installation = validate_installation_manifest({"schema_version": 1, "installation": plan["installation"]})
+    if installation["scope"] != plan["scope"]:
+        raise CliError("Plan scope and installation manifest disagree")
+    if not isinstance(plan["fingerprints"], list):
+        raise CliError("Plan fingerprints must be a list")
+    for item in plan["fingerprints"]:
+        if not isinstance(item, dict) or set(item) != {"root", "path", "sha256", "mode"}:
+            raise CliError("Plan contains a malformed fingerprint")
+        if item["root"] not in expected_roots or not isinstance(item["path"], str):
+            raise CliError("Plan fingerprint has an unknown root or path")
+        relative = Path(item["path"])
+        if relative.is_absolute() or ".." in relative.parts or not relative.parts:
+            raise CliError("Plan fingerprint path escapes its declared root")
+        safe_update_path(Path(expected_roots[item["root"]]), relative)
+        if item["sha256"] is not None and not re.fullmatch(r"[0-9a-f]{64}", item["sha256"]):
+            raise CliError("Plan fingerprint hash is malformed")
+        if item["mode"] is not None and (not isinstance(item["mode"], int) or not 0 <= item["mode"] <= 0o777):
+            raise CliError("Plan fingerprint mode is malformed")
+    if not isinstance(plan["proposed_changes"], list):
+        raise CliError("Plan proposed changes must be a list")
+    proposed_paths: set[tuple[str, str]] = set()
+    for item in plan["proposed_changes"]:
+        if not isinstance(item, dict) or set(item) != {
+            "root", "path", "operation", "before_sha256", "before_mode", "after_sha256", "after_mode"
+        }:
+            raise CliError("Plan contains a malformed proposed change")
+        if item["root"] not in expected_roots or item["operation"] not in {"create", "replace"}:
+            raise CliError("Plan proposed change has an unknown root or operation")
+        if not isinstance(item["path"], str) or not allowed_update_path(item["root"], item["path"], installation):
+            raise CliError("Plan proposed change is outside managed update surfaces")
+        safe_update_path(Path(expected_roots[item["root"]]), item["path"])
+        for name in ("before_sha256", "after_sha256"):
+            if item[name] is not None and not re.fullmatch(r"[0-9a-f]{64}", item[name]):
+                raise CliError("Plan proposed change hash is malformed")
+        for name in ("before_mode", "after_mode"):
+            if item[name] is not None and (not isinstance(item[name], int) or not 0 <= item[name] <= 0o777):
+                raise CliError("Plan proposed change mode is malformed")
+        if item["after_sha256"] is None or item["after_mode"] is None:
+            raise CliError("Plan proposed change has no staged result")
+        if item["operation"] == "create" and (item["before_sha256"] is not None or item["before_mode"] is not None):
+            raise CliError("Plan create operation has an existing-file baseline")
+        if item["operation"] == "replace" and (item["before_sha256"] is None or item["before_mode"] is None):
+            raise CliError("Plan replace operation has no existing-file baseline")
+        identity = (item["root"], item["path"])
+        if identity in proposed_paths:
+            raise CliError("Plan contains a duplicate proposed change")
+        proposed_paths.add(identity)
+    return plan
+
+
+def recheck_plan_fingerprints(plan: dict[str, Any]) -> None:
+    for item in plan["fingerprints"]:
+        path = safe_update_path(Path(plan["roots"][item["root"]]), item["path"])
+        actual = file_sha256(path) if path.is_file() else None
+        actual_mode = path.stat().st_mode & 0o777 if path.is_file() else None
+        if actual != item["sha256"] or actual_mode != item["mode"]:
+            raise CliError(f"Update refused: {item['root']}:{item['path']} changed after planning")
+
+
+def copy_plan_inputs_to_shadow(plan: dict[str, Any], shadow_roots: dict[str, Path]) -> None:
+    for item in plan["fingerprints"]:
+        if item["sha256"] is None:
+            continue
+        source = safe_update_path(Path(plan["roots"][item["root"]]), item["path"])
+        destination = safe_update_path(shadow_roots[item["root"]], item["path"])
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+
+
+def prepare_owned_skills(plan: dict[str, Any], shadow_roots: dict[str, Path]) -> set[tuple[str, str]]:
+    inventory = plan["installation"].get("managed_files", [])
+    grouped: dict[tuple[str, str], list[dict[str, str]]] = {}
+    for item in inventory:
+        if not isinstance(item, dict) or set(item) != {"root", "path", "sha256"}:
+            raise CliError("Installation managed-file inventory is malformed")
+        parts = Path(item["path"]).parts
+        if len(parts) < 4 or (parts[0], parts[1]) not in {(".agents", "skills"), (".claude", "skills")}:
+            continue
+        prefix = Path(*parts[:3]).as_posix()
+        grouped.setdefault((item["root"], prefix), []).append(item)
+    preserved: set[tuple[str, str]] = set()
+    for (root_name, prefix), items in grouped.items():
+        source_root = Path(plan["roots"][root_name])
+        actual_root = safe_update_path(source_root, prefix)
+        recorded = {item["path"]: item["sha256"] for item in items}
+        current: dict[str, str] = {}
+        if actual_root.is_dir():
+            for path in actual_root.rglob("*"):
+                relative = path.relative_to(source_root)
+                checked = safe_update_path(source_root, relative)
+                if checked.is_file():
+                    current[relative.as_posix()] = file_sha256(checked)
+        shadow_skill = safe_update_path(shadow_roots[root_name], prefix)
+        if current == recorded:
+            if shadow_skill.exists():
+                shutil.rmtree(shadow_skill)
+        else:
+            preserved.add((root_name, prefix))
+    return preserved
+
+
+def retain_customized_skill_baselines(
+    plan: dict[str, Any], shadow_roots: dict[str, Path], preserved: set[tuple[str, str]]
+) -> None:
+    if not preserved:
+        return
+    state_root = shadow_roots["home"] if plan["scope"] == "global" else shadow_roots["target"]
+    state = load_state(state_root)
+    installation = state.get("installation")
+    if not isinstance(installation, dict):
+        raise CliError("Staged installer did not write an installation manifest")
+    new_inventory = installation.get("managed_files", [])
+    kept_new = [
+        item for item in new_inventory
+        if not any(item.get("root") == root_name and item.get("path", "").startswith(prefix + "/") for root_name, prefix in preserved)
+    ]
+    prior = plan["installation"].get("managed_files", [])
+    kept_prior = [
+        item for item in prior
+        if any(item.get("root") == root_name and item.get("path", "").startswith(prefix + "/") for root_name, prefix in preserved)
+    ]
+    installation["managed_files"] = [*kept_new, *kept_prior]
+    atomic_write(state_path(state_root), json.dumps(state, indent=2, ensure_ascii=False) + "\n")
+
+
+def install_arguments_from_manifest(plan: dict[str, Any], shadow_target: Path) -> list[str]:
+    installation = plan["installation"]
+    arguments = ["install", "--agent", ",".join(installation["agents"])]
+    if plan["scope"] == "global":
+        arguments.append("--global")
+    else:
+        arguments += ["--target", str(shadow_target)]
+    for profile in installation["profiles"]:
+        arguments += ["--profile", profile]
+    if not installation["include_core"]:
+        arguments.append("--profile-only")
+    safety_values = set(installation["safety"].values())
+    if len(safety_values) > 1:
+        raise CliError("Update cannot reproduce mixed native safety settings; reinstall each scope explicitly")
+    if safety_values:
+        arguments += ["--safety", next(iter(safety_values))]
+    operator = installation["operator"]
+    arguments += ["--operator-name", operator["name"], "--operator-role", operator["role"], "--operator-bio", operator["bio"]]
+    tracker = installation["tracker"]
+    arguments += ["--tracker", tracker["name"], "--tracker-writes", tracker["writes"]]
+    capabilities = installation["capabilities"]
+    if capabilities.get("skills"):
+        arguments.append("--with-skills")
+    for name in capabilities.get("mcp", []):
+        arguments += ["--with-mcp", name]
+    if capabilities.get("handoff_hooks"):
+        arguments.append("--with-handoff-hooks")
+    if capabilities.get("ui_design_hook"):
+        arguments.append("--with-ui-design-hook")
+    if capabilities.get("hooks"):
+        arguments.append("--with-hooks")
+    return arguments
+
+
+def shadow_files(root: Path) -> dict[str, tuple[bytes, int]]:
+    result: dict[str, tuple[bytes, int]] = {}
+    for path in root.rglob("*"):
+        relative = path.relative_to(root)
+        checked = safe_update_path(root, relative)
+        if (
+            checked.is_file()
+            and ".git" not in relative.parts
+            and not re.search(r"\.bak\.\d{8}-\d{6}(?:\.\d+)?$", checked.name)
+        ):
+            result[relative.as_posix()] = (checked.read_bytes(), checked.stat().st_mode & 0o777)
+    return result
+
+
+def translate_shadow_paths(
+    content: bytes, shadow_roots: dict[str, Path], actual_roots: dict[str, str]
+) -> bytes:
+    try:
+        text = content.decode("utf-8")
+    except UnicodeDecodeError:
+        return content
+    replacements: set[tuple[str, str]] = set()
+    for root_name, shadow_root in shadow_roots.items():
+        actual = actual_roots[root_name]
+        for old, new in ((str(shadow_root), actual), (shadow_root.as_posix(), Path(actual).as_posix())):
+            replacements.add((old, new))
+            replacements.add((json.dumps(old, ensure_ascii=False)[1:-1], json.dumps(new, ensure_ascii=False)[1:-1]))
+    for old, new in sorted(replacements, key=lambda item: len(item[0]), reverse=True):
+        text = text.replace(old, new)
+    return text.encode("utf-8")
+
+
+def allowed_update_path(root_name: str, relative: str, installation: dict[str, Any]) -> bool:
+    path = Path(relative)
+    if ".." in path.parts or path.is_absolute():
+        return False
+    if root_name == "target":
+        exact = {
+            "AGENTS.md", "CLAUDE.md", ".harness/verify.conf", ".aider.conf.yml", ".goosehints",
+            ".gemini/settings.json", ".continue/rules/agentsmith.md",
+            *RUNTIME_FILES, ".agentsmith/autonomous-run.py", ".agentsmith/state.json",
+        }
+        prefixes = (".harness/templates/", ".agents/skills/", ".claude/skills/")
+        return relative in exact or relative.startswith(prefixes)
+    if root_name == "home":
+        return (
+            relative in {".agentsmith/state.json", *RUNTIME_FILES}
+            or relative in {".claude/CLAUDE.md", ".claude/settings.json"}
+            or bool(re.fullmatch(r"\.claude/agentsmith-statusline(?:-\d+)?\.(?:py|ps1)", relative))
+            or relative.startswith((".agents/skills/", ".claude/skills/"))
+        )
+    if root_name == "codex_home":
+        return relative in {"AGENTS.md", "config.toml", "hooks.json"}
+    return False
+
+
+def trusted_stage_install(
+    checkout: Path,
+    release_version: str,
+    arguments: list[str],
+    shadow_env: dict[str, str],
+) -> None:
+    """Run today's trusted installer logic against data files from a candidate release."""
+    global ROOT, REGISTRY_PATH, VERSION
+    prior_root, prior_registry, prior_version = ROOT, REGISTRY_PATH, VERSION
+    prior_environment = {name: os.environ.get(name) for name in shadow_env}
+    output, errors = io.StringIO(), io.StringIO()
+    try:
+        ROOT = checkout
+        REGISTRY_PATH = checkout / "config" / "agents.json"
+        VERSION = release_version
+        os.environ.update(shadow_env)
+        parsed = parser().parse_args(arguments)
+        with contextlib.redirect_stdout(output), contextlib.redirect_stderr(errors):
+            result = cmd_install(parsed)
+        if result:
+            raise CliError(f"Trusted staged installer returned {result}")
+    except Exception as exc:
+        detail = (output.getvalue() + errors.getvalue()).strip()[-1000:]
+        suffix = f"\n{detail}" if detail else ""
+        raise CliError(f"Trusted planning install failed before real files changed: {exc}{suffix}") from exc
+    finally:
+        ROOT, REGISTRY_PATH, VERSION = prior_root, prior_registry, prior_version
+        for name, value in prior_environment.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+
+def stage_planned_update(
+    plan: dict[str, Any], temporary_root: Path, *, execute_candidate: bool
+) -> tuple[Path, list[tuple[str, str, bytes, int]]]:
+    checkout = checkout_planned_release(plan["remote"], plan["release"], temporary_root / "release")
+    shadow_roots = {
+        "target": temporary_root / "target",
+        "home": temporary_root / "home",
+        "codex_home": temporary_root / "codex-home",
+    }
+    for root in shadow_roots.values():
+        root.mkdir(parents=True, exist_ok=True)
+    copy_plan_inputs_to_shadow(plan, shadow_roots)
+    preserved_skills = prepare_owned_skills(plan, shadow_roots)
+    shadow_env = {
+        "HOME": str(shadow_roots["home"]),
+        "USERPROFILE": str(shadow_roots["home"]),
+        "CODEX_HOME": str(shadow_roots["codex_home"]),
+        "GIT_TERMINAL_PROMPT": "0",
+    }
+    install_arguments = install_arguments_from_manifest(plan, shadow_roots["target"])
+    if execute_candidate:
+        candidate_env = {
+            name: os.environ[name]
+            for name in (
+                "PATH", "PATHEXT", "SYSTEMROOT", "WINDIR", "COMSPEC", "TEMP", "TMP", "TMPDIR",
+                "LANG", "LC_ALL", "PYTHONIOENCODING",
+            )
+            if name in os.environ
+        }
+        install = subprocess.run(
+            [sys.executable, str(checkout / "agentsmith.py"), *install_arguments],
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=120,
+            env={**candidate_env, **shadow_env},
+        )
+        if install.returncode:
+            detail = (install.stdout + install.stderr).strip()[-1000:]
+            raise CliError(f"Staged release install failed before real files changed:\n{detail}")
+    else:
+        trusted_stage_install(checkout, plan["release"]["version"], install_arguments, shadow_env)
+    retain_customized_skill_baselines(plan, shadow_roots, preserved_skills)
+    proposed: list[tuple[str, str, bytes, int]] = []
+    for root_name, shadow_root in shadow_roots.items():
+        for relative, (content, mode) in shadow_files(shadow_root).items():
+            if not allowed_update_path(root_name, relative, plan["installation"]):
+                raise CliError(f"Release attempted an update outside the managed surface: {root_name}:{relative}")
+            content = translate_shadow_paths(content, shadow_roots, plan["roots"])
+            actual = safe_update_path(Path(plan["roots"][root_name]), relative)
+            if actual.exists() and not actual.is_file():
+                raise CliError(f"Update refused to replace non-file path {actual}")
+            current = actual.read_bytes() if actual.is_file() else None
+            current_mode = actual.stat().st_mode & 0o777 if actual.is_file() else None
+            if current != content or current_mode != mode:
+                proposed.append((root_name, relative, content, mode))
+    proposed.sort(key=lambda item: (item[0], item[1]))
+    return checkout, proposed
+
+
+def proposed_change_manifest(
+    plan: dict[str, Any], proposed: list[tuple[str, str, bytes, int]]
+) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    for root_name, relative, content, mode in proposed:
+        actual = safe_update_path(Path(plan["roots"][root_name]), relative)
+        existed = actual.is_file()
+        before = actual.read_bytes() if existed else None
+        result.append({
+            "root": root_name,
+            "path": relative,
+            "operation": "replace" if existed else "create",
+            "before_sha256": hashlib.sha256(before).hexdigest() if before is not None else None,
+            "before_mode": actual.stat().st_mode & 0o777 if existed else None,
+            "after_sha256": hashlib.sha256(content).hexdigest(),
+            "after_mode": mode,
+        })
+    return result
+
+
+def validate_post_update_health(plan: dict[str, Any]) -> None:
+    installation = plan["installation"]
+    state_root = Path(plan["roots"]["home"] if plan["scope"] == "global" else plan["roots"]["target"])
+    installed = validate_installation_manifest(load_update_state(state_root))
+    for field in ("scope", "agents", "profiles", "include_core", "safety", "operator", "tracker", "capabilities"):
+        if installed.get(field) != installation.get(field):
+            raise CliError(f"Post-update health check failed: installation manifest changed {field}")
+    if installed.get("installed_version") != plan["release"]["version"]:
+        raise CliError("Post-update health check failed: installed runtime version does not match the release")
+    if installed.get("source") != {
+        "release": plan["release"]["tag"],
+        "commit": plan["release"]["commit"],
+    }:
+        raise CliError("Post-update health check failed: installed source identity does not match the release")
+
+    for item in plan["proposed_changes"]:
+        path = safe_update_path(Path(plan["roots"][item["root"]]), item["path"])
+        actual_hash = file_sha256(path) if path.is_file() else None
+        actual_mode = path.stat().st_mode & 0o777 if path.is_file() else None
+        if actual_hash != item["after_sha256"] or actual_mode != item["after_mode"]:
+            raise CliError(f"Post-update health check failed: {item['root']}:{item['path']} does not match the plan")
+
+    target = Path(plan["roots"]["target"])
+    instruction_paths: list[Path] = []
+    if plan["scope"] == "global":
+        if "claude" in installation["agents"]:
+            instruction_paths.append(Path(plan["roots"]["home"]) / ".claude" / "CLAUDE.md")
+        if "codex" in installation["agents"]:
+            instruction_paths.append(Path(plan["roots"]["codex_home"]) / "AGENTS.md")
+    else:
+        instruction_paths.append(target / "AGENTS.md")
+        if "claude" in installation["agents"]:
+            instruction_paths.append(target / "CLAUDE.md")
+    for path in instruction_paths:
+        if not path.is_file() or not managed_markers(path.read_text(encoding="utf-8", errors="replace")):
+            raise CliError(f"Post-update health check failed: managed instructions are missing or malformed in {path}")
+
+    capabilities = installation["capabilities"]
+    runtime_root = Path(plan["roots"]["home"]) if plan["scope"] == "global" else target
+    needs_runtime = plan["scope"] == "project" or capabilities.get("handoff_hooks") or capabilities.get("ui_design_hook")
+    runtime = runtime_root / ".agentsmith" / "agentsmith.py"
+    if needs_runtime:
+        for relative in RUNTIME_FILES:
+            if not safe_update_path(runtime_root, relative).is_file():
+                raise CliError(f"Post-update health check failed: managed runtime file is missing: {relative}")
+        declared = re.search(
+            r'^VERSION = "([^"]+)"$', runtime.read_text(encoding="utf-8", errors="replace"), re.MULTILINE
+        )
+        if not declared or declared.group(1) != plan["release"]["version"]:
+            raise CliError("Post-update health check failed: managed runtime did not reach the planned version")
+
+    if capabilities.get("skills"):
+        skill_root = Path(plan["roots"]["home"]) if plan["scope"] == "global" else target
+        required_roots = [skill_root / ".agents" / "skills"]
+        if "claude" in installation["agents"]:
+            required_roots.append(skill_root / ".claude" / "skills")
+        if any(not root.is_dir() or not any(root.rglob("SKILL.md")) for root in required_roots):
+            raise CliError("Post-update health check failed: a managed skill root is missing or empty")
+        inventory = installed.get("managed_files", [])
+        if not inventory or any(
+            not safe_update_path(Path(plan["roots"][item["root"]]), item["path"]).is_file()
+            for item in inventory
+        ):
+            raise CliError("Post-update health check failed: managed skill inventory is missing a file")
+
+    requested_mcp = set(capabilities.get("mcp", []))
+    if requested_mcp and plan["scope"] == "global":
+        raise CliError("Post-update health check failed: global MCP ownership is not supported")
+    if requested_mcp:
+        rows = {row["id"]: row for row in compatibility_rows(installation["agents"])}
+        for agent_id in installation["agents"]:
+            if agent_id not in {"claude", "codex"}:
+                continue
+            mcp = inspect_mcp(agent_id, rows[agent_id], target)
+            if not requested_mcp.issubset(set(mcp["managed_names"])):
+                raise CliError(f"Post-update health check failed: managed MCP is incomplete for {agent_id}")
+
+    if capabilities.get("handoff_hooks") or capabilities.get("ui_design_hook"):
+        for agent_id in set(installation["agents"]) & {"claude", "codex"}:
+            config = Path(plan["roots"]["home"]) / ".claude" / "settings.json" if agent_id == "claude" else Path(plan["roots"]["codex_home"]) / "hooks.json"
+            commands, parse_state = hook_commands(config)
+            if parse_state != "parsed":
+                raise CliError(f"Post-update health check failed: hook configuration is {parse_state} for {agent_id}")
+            if capabilities.get("handoff_hooks") and not any(
+                str(runtime) in command and "hook handoff-on-keyword" in command for command in commands
+            ):
+                raise CliError(f"Post-update health check failed: handoff hook is missing for {agent_id}")
+            if capabilities.get("ui_design_hook") and not any(
+                str(runtime) in command and "hook ui-design-reminder" in command for command in commands
+            ):
+                raise CliError(f"Post-update health check failed: UI design hook is missing for {agent_id}")
+
+    if capabilities.get("hooks"):
+        hook_dir = subprocess.run(
+            ["git", "-C", str(target), "rev-parse", "--git-path", "hooks"],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        if hook_dir.returncode:
+            raise CliError("Post-update health check failed: managed Git hook target is not a repository")
+        resolved = Path(hook_dir.stdout.strip())
+        if not resolved.is_absolute():
+            resolved = target / resolved
+        pre_commit = resolved / "pre-commit"
+        text = pre_commit.read_text(encoding="utf-8", errors="replace") if pre_commit.is_file() else ""
+        if str(runtime) not in text or "hook git-pre-commit" not in text:
+            raise CliError("Post-update health check failed: managed Git pre-commit hook is missing or stale")
+
+    for agent_id, expected_safety in installation["safety"].items():
+        if inspect_safety(agent_id)["state"] != expected_safety:
+            raise CliError(f"Post-update health check failed: native safety does not match the manifest for {agent_id}")
+
+
+def restore_changes(changes: list[dict[str, Any]], roots: dict[str, str], backup_root: Path) -> None:
+    for change in reversed(changes):
+        path = safe_update_path(Path(roots[change["root"]]), change["path"])
+        if change["existed"]:
+            backup_path = safe_update_path(backup_root, Path(change["root"]) / change["path"])
+            content = backup_path.read_bytes()
+            if hashlib.sha256(content).hexdigest() != change["before_sha256"]:
+                raise CliError(f"Rollback backup hash mismatch for {change['root']}:{change['path']}")
+            atomic_write_bytes(path, content, change["before_mode"])
+        elif path.exists():
+            if path.is_dir():
+                raise CliError(f"Rollback refused to remove unexpected directory {path}")
+            path.unlink()
+
+
+def cmd_update_apply(args: argparse.Namespace) -> int:
+    plan_path = Path(args.plan).expanduser().resolve()
+    plan = validated_plan(plan_path)
+    recheck_plan_fingerprints(plan)
+    update_home = home_dir().resolve()
+    receipt_root = safe_update_path(update_home, ".agentsmith/update-receipts")
+    update_id = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ-") + plan["integrity"][-12:]
+    backup_root = safe_update_path(update_home, Path(".agentsmith/update-backups") / update_id)
+    changes: list[dict[str, Any]] = []
+    with tempfile.TemporaryDirectory(prefix="agentsmith-apply-") as temporary:
+        temporary_root = Path(temporary)
+        checkout, proposed = stage_planned_update(plan, temporary_root, execute_candidate=True)
+        actual_proposal = proposed_change_manifest(plan, proposed)
+        if actual_proposal != plan["proposed_changes"]:
+            raise CliError("Update refused: staged managed changes do not match the authenticated plan")
+        try:
+            for root_name, relative, content, mode in proposed:
+                actual = safe_update_path(Path(plan["roots"][root_name]), relative)
+                existed = actual.is_file()
+                before_content = actual.read_bytes() if existed else b""
+                before_mode = actual.stat().st_mode & 0o777 if existed else None
+                if existed:
+                    backup_path = safe_update_path(backup_root, Path(root_name) / relative)
+                    backup_path.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(actual, backup_path)
+                atomic_write_bytes(actual, content, mode)
+                changes.append({
+                    "root": root_name,
+                    "path": relative,
+                    "existed": existed,
+                    "before_sha256": hashlib.sha256(before_content).hexdigest() if existed else None,
+                    "before_mode": before_mode,
+                    "after_sha256": hashlib.sha256(content).hexdigest(),
+                    "after_mode": mode,
+                })
+            validate_post_update_health(plan)
+            doctor_arguments = ["doctor", "--agent", ",".join(plan["installation"]["agents"]), "--strict"]
+            doctor_arguments += ["--target", plan["target"]]
+            doctor = subprocess.run(
+                [sys.executable, str(checkout / "agentsmith.py"), *doctor_arguments],
+                text=True,
+                capture_output=True,
+                check=False,
+                timeout=120,
+                env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
+            )
+            if doctor.returncode:
+                raise CliError(f"Post-update doctor failed:\n{(doctor.stdout + doctor.stderr).strip()[-1000:]}")
+        except Exception:
+            restore_changes(changes, plan["roots"], backup_root)
+            raise
+    receipt: dict[str, Any] = {
+        "schema_version": 1,
+        "created_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "scope": plan["scope"],
+        "plan_integrity": plan["integrity"],
+        "release": plan["release"],
+        "roots": plan["roots"],
+        "backup_root": str(backup_root),
+        "changes": changes,
+    }
+    receipt["integrity"] = plan_integrity(receipt, update_integrity_key(create=False))
+    receipt_path = receipt_root / f"{update_id}.json"
+    try:
+        receipt_root.mkdir(parents=True, exist_ok=True)
+        backup_root.mkdir(parents=True, exist_ok=True)
+        receipt_root.chmod(0o700)
+        backup_root.chmod(0o700)
+        atomic_write(receipt_path, json.dumps(receipt, indent=2, ensure_ascii=False) + "\n")
+    except Exception:
+        restore_changes(changes, plan["roots"], backup_root)
+        raise
+    ok(f"applied {plan['release']['tag']} after fingerprint and health checks")
+    say(f"rollback receipt: {receipt_path}")
+    return 0
+
+
+def cmd_update_rollback(args: argparse.Namespace) -> int:
+    receipt_path = Path(args.receipt).expanduser().resolve()
+    receipt = load_update_document(receipt_path, "receipt")
+    allowed = {
+        "schema_version", "created_at", "scope", "plan_integrity", "release", "roots",
+        "backup_root", "changes", "integrity",
+    }
+    if set(receipt) != allowed or receipt["schema_version"] != 1:
+        raise CliError("Rollback receipt has unsupported fields or schema")
+    update_home = home_dir().resolve()
+    expected_backup_parent = safe_update_path(update_home, ".agentsmith/update-backups")
+    raw_backup_root = Path(receipt["backup_root"])
+    try:
+        backup_relative = raw_backup_root.relative_to(update_home)
+    except ValueError as exc:
+        raise CliError("Rollback receipt points outside the local update-backup directory") from exc
+    backup_root = safe_update_path(update_home, backup_relative)
+    if backup_root.parent != expected_backup_parent:
+        raise CliError("Rollback receipt points outside the local update-backup directory")
+    if receipt["scope"] not in {"project", "global"}:
+        raise CliError("Rollback receipt scope is invalid")
+    expected_home = str(home_dir().resolve())
+    expected_codex = str(codex_home().resolve())
+    if receipt["roots"].get("home") != expected_home or receipt["roots"].get("codex_home") != expected_codex:
+        raise CliError("Rollback receipt does not match the current HOME and CODEX_HOME")
+    if receipt["scope"] == "global" and receipt["roots"].get("target") != expected_home:
+        raise CliError("Global rollback receipt target does not match HOME")
+    for change in receipt["changes"]:
+        if not isinstance(change, dict) or set(change) != {
+            "root", "path", "existed", "before_sha256", "before_mode", "after_sha256", "after_mode"
+        }:
+            raise CliError("Rollback receipt contains a malformed change")
+        if not isinstance(change["after_sha256"], str) or not re.fullmatch(r"[0-9a-f]{64}", change["after_sha256"]):
+            raise CliError("Rollback receipt contains a malformed post-update hash")
+        if not isinstance(change["after_mode"], int) or not 0 <= change["after_mode"] <= 0o777:
+            raise CliError("Rollback receipt contains a malformed post-update mode")
+        if not isinstance(change["existed"], bool):
+            raise CliError("Rollback receipt contains a malformed existence flag")
+        if change["existed"] and (
+            not isinstance(change["before_sha256"], str)
+            or not re.fullmatch(r"[0-9a-f]{64}", change["before_sha256"])
+            or not isinstance(change["before_mode"], int)
+            or not 0 <= change["before_mode"] <= 0o777
+        ):
+            raise CliError("Rollback receipt contains a malformed pre-update baseline")
+        if not change["existed"] and (change["before_sha256"] is not None or change["before_mode"] is not None):
+            raise CliError("Rollback receipt create operation has an existing-file baseline")
+        if change["root"] not in receipt["roots"] or Path(change["path"]).is_absolute() or ".." in Path(change["path"]).parts:
+            raise CliError("Rollback receipt contains an unsafe path")
+        if not allowed_update_path(change["root"], change["path"], {}):
+            raise CliError("Rollback receipt contains a path outside managed update surfaces")
+        current = safe_update_path(Path(receipt["roots"][change["root"]]), change["path"])
+        actual_hash = file_sha256(current) if current.is_file() else None
+        actual_mode = current.stat().st_mode & 0o777 if current.is_file() else None
+        if actual_hash != change["after_sha256"] or actual_mode != change["after_mode"]:
+            raise CliError(f"Rollback refused: {change['root']}:{change['path']} changed after update")
+    restore_changes(receipt["changes"], receipt["roots"], backup_root)
+    ok(f"rolled back {len(receipt['changes'])} file(s) from {receipt_path}")
+    return 0
+
+
+def cmd_update_configure(args: argparse.Namespace) -> int:
+    policy = {"auto_check": args.auto_check}
+    root = home_dir().resolve()
+    state = load_update_state(root)
+    state["update_policy"] = policy
+    atomic_write(state_path(root), json.dumps(state, indent=2, ensure_ascii=False) + "\n")
+    if args.auto_check == "weekly":
+        ok("weekly report-only update checks enabled; installation still requires 'update apply --plan'")
+    else:
+        ok("automatic update checks disabled")
+    return 0
+
+
+def maybe_report_automatic_update() -> None:
+    try:
+        state = load_state(home_dir().resolve())
+        policy = state.get("update_policy")
+        if not isinstance(policy, dict) or policy.get("auto_check") != "weekly":
+            return
+        now = dt.datetime.now(dt.timezone.utc)
+        raw_attempt = policy.get("last_attempt_at")
+        if isinstance(raw_attempt, str):
+            try:
+                last_attempt = dt.datetime.fromisoformat(raw_attempt)
+            except ValueError:
+                last_attempt = None
+            if last_attempt and last_attempt.tzinfo and now - last_attempt < dt.timedelta(days=7):
+                return
+        policy = {**policy, "last_attempt_at": now.isoformat()}
+        record_state(home_dir().resolve(), "update_policy", policy, dry_run=False)
+        releases = stable_release_tags(OFFICIAL_REMOTE, timeout_seconds=3)
+        if not releases:
+            return
+        latest, tag = releases[-1]
+        current = tuple(int(part) for part in VERSION.split(".")) if re.fullmatch(r"\d+\.\d+\.\d+", VERSION) else (0, 0, 0)
+        policy["last_checked_at"] = now.isoformat()
+        record_state(home_dir().resolve(), "update_policy", policy, dry_run=False)
+        if latest > current:
+            say(f"update available: {tag}; run 'agentsmith update plan' when you want to inspect it")
+    except (CliError, OSError) as exc:
+        warn(f"weekly update check skipped: {exc}")
 
 
 def reassemble_managed_targets(args: argparse.Namespace) -> None:
@@ -1308,6 +2675,8 @@ def cmd_install(args: argparse.Namespace) -> int:
     validate_design_system_source(args.design_system)
     if args.global_mode and args.target:
         raise CliError("--target cannot be combined with --global; global destinations are fixed by each runtime")
+    if args.global_mode and csv(args.with_mcp):
+        raise CliError("--with-mcp is project-scoped; global MCP ownership is not supported")
     if args.global_mode and args.assemble_only and not args.dry_run:
         warn("--assemble-only skips runtime config but still WRITES global instruction files; use --dry-run to write nothing")
     if args.tracker_writes and args.tracker_writes not in {"ask", "allowed"}:
@@ -1378,6 +2747,7 @@ def cmd_install(args: argparse.Namespace) -> int:
         install_skills(skill_root, agents, force=args.force, dry_run=args.dry_run)
         record_state(skill_root, "skills_installed", True, dry_run=args.dry_run)
     install_hooks(target, agents, args)
+    record_installation_manifest(target, agents, profiles, args, recovery)
     ok(f"installed for {', '.join(agents)}; canonical project instructions: AGENTS.md")
     return 0
 
@@ -2296,7 +3666,11 @@ def add_common_install_flags(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--also-gemini-md", action="store_true")
     parser.add_argument("--org-policy", action="store_true")
     parser.add_argument("--update-plugins", action="store_true")
-    parser.add_argument("--self-update", action="store_true")
+    parser.add_argument(
+        "--self-update",
+        action="store_true",
+        help="deprecated: fast-forward only the clean harness checkout; does not provide staged install rollback",
+    )
     parser.add_argument("--from", dest="update_from")
     parser.add_argument("--no-reassemble", action="store_true")
     parser.add_argument("--wizard", action="store_true")
@@ -2316,6 +3690,24 @@ def parser() -> argparse.ArgumentParser:
     sub = root.add_subparsers(dest="command")
     install = sub.add_parser("install", help="install or update managed rules and adapters")
     add_common_install_flags(install)
+    update = sub.add_parser("update", help="check and apply staged stable-release updates")
+    update_sub = update.add_subparsers(dest="update_command", required=True)
+    update_check = update_sub.add_parser("check", help="report the latest stable release without changing an install")
+    update_check.add_argument("--from", dest="update_from", help="explicit Git remote or local test remote")
+    update_check.add_argument("--json", action="store_true")
+    update_plan = update_sub.add_parser("plan", help="stage and inspect a release without changing an install")
+    plan_scope = update_plan.add_mutually_exclusive_group(required=True)
+    plan_scope.add_argument("--global", dest="global_mode", action="store_true")
+    plan_scope.add_argument("--target")
+    update_plan.add_argument("--version", help="stable release tag (default: latest stable)")
+    update_plan.add_argument("--from", dest="update_from", help="explicit Git remote or local test remote")
+    update_plan.add_argument("--save", help="write the plan to this local file")
+    update_apply = update_sub.add_parser("apply", help="apply an inspected plan and write a rollback receipt")
+    update_apply.add_argument("--plan", required=True)
+    update_rollback = update_sub.add_parser("rollback", help="restore exact pre-update bytes from a receipt")
+    update_rollback.add_argument("--receipt", required=True)
+    update_configure = update_sub.add_parser("configure", help="opt into or disable report-only update checks")
+    update_configure.add_argument("--auto-check", required=True, choices=("weekly", "off"))
     agents = sub.add_parser("agents", help="inspect the supported agent registry")
     agents_sub = agents.add_subparsers(dest="agents_command", required=True)
     listing = agents_sub.add_parser("list")
@@ -2362,7 +3754,7 @@ def parser() -> argparse.ArgumentParser:
 def normalize_legacy_argv(argv: list[str]) -> list[str]:
     if not argv:
         return ["install", "--wizard"]
-    commands = {"install", "agents", "doctor", "compatibility", "verify", "handoff", "new-feedback", "new-research", "secret-scan", "hook", "evaluate"}
+    commands = {"install", "update", "agents", "doctor", "compatibility", "verify", "handoff", "new-feedback", "new-research", "secret-scan", "hook", "evaluate"}
     if argv[0] in commands or argv[0] in {"-h", "--help", "--version"}:
         return argv
     if "--doctor" in argv:
@@ -2387,6 +3779,8 @@ def apply_wizard_answers(args: argparse.Namespace, input_fn: Any = input) -> Non
 def run(argv: list[str] | None = None) -> int:
     require_python()
     args = parser().parse_args(normalize_legacy_argv(list(argv if argv is not None else sys.argv[1:])))
+    if args.command != "update":
+        maybe_report_automatic_update()
     if args.command == "install":
         if args.wizard:
             print("Agentsmith interactive wizard is intentionally minimal in non-interactive automation.")
@@ -2395,6 +3789,18 @@ def run(argv: list[str] | None = None) -> int:
                 return 0
             apply_wizard_answers(args)
         return cmd_install(args)
+    if args.command == "update":
+        if args.update_command == "check":
+            return cmd_update_check(args)
+        if args.update_command == "plan":
+            return cmd_update_plan(args)
+        if args.update_command == "apply":
+            return cmd_update_apply(args)
+        if args.update_command == "rollback":
+            return cmd_update_rollback(args)
+        if args.update_command == "configure":
+            return cmd_update_configure(args)
+        raise CliError(f"Unknown update command: {args.update_command}")
     if args.command == "agents":
         return cmd_agents_list(args)
     if args.command == "doctor":

--- a/agentsmith.py
+++ b/agentsmith.py
@@ -657,7 +657,7 @@ def record_installation_manifest(
         name for name in [*prior_mcp, *requested_mcp]
         if isinstance(name, str) and name in available_mcp
     ))
-    safety = {
+    safety = {} if args.assemble_only else {
         agent_id: args.safety
         for agent_id in agents
         if agent_id in {"claude", "codex"}
@@ -683,6 +683,7 @@ def record_installation_manifest(
         "agents": agents,
         "profiles": profiles,
         "include_core": not args.profile_only,
+        "assemble_only": bool(args.assemble_only),
         "safety": safety,
         "operator": {
             "name": args.operator_name or recovery.get("operator_name") or "the project lead",
@@ -1264,11 +1265,18 @@ def validate_installation_manifest(state: dict[str, Any]) -> dict[str, Any]:
         raise CliError("Installation state has no manifest; rerun install with explicit choices before planning an update")
     allowed_installation = {
         "installed_version", "source", "scope", "agents", "profiles", "include_core",
-        "safety", "operator", "tracker", "capabilities", "managed_files",
+        "assemble_only", "safety", "operator", "tracker", "capabilities", "managed_files",
     }
     unknown_installation = sorted(set(installation) - allowed_installation)
     if unknown_installation:
         raise CliError(f"Installation manifest has unknown field(s): {', '.join(unknown_installation)}")
+    if "assemble_only" not in installation:
+        raise CliError(
+            "Installation manifest does not record the --assemble-only choice; rerun install with "
+            "the intended choice (include --assemble-only to keep native configuration disabled)"
+        )
+    if not isinstance(installation["assemble_only"], bool):
+        raise CliError("Installation manifest assemble_only field must be true or false; rerun install explicitly")
     required = allowed_installation
     missing = sorted(required - set(installation))
     if missing:
@@ -1329,14 +1337,24 @@ def reconstruct_pre_manifest_installation(target: Path, scope: str, state: dict[
     agents = list(dict.fromkeys(agents))
     if not agents:
         raise CliError("Pre-manifest agent selection cannot be inferred; rerun install with explicit --agent choices")
-    safety: dict[str, str] = {}
-    for agent_id in agents:
-        if agent_id not in {"claude", "codex"}:
-            continue
-        value = native_safety.get(agent_id)
-        if value not in {"cautious", "trusted"}:
-            raise CliError(f"Pre-manifest safety for {agent_id} cannot be inferred; rerun install with explicit --safety")
-        safety[agent_id] = value
+    native_agents = [agent_id for agent_id in agents if agent_id in {"claude", "codex"}]
+    native_evidence = [native_safety.get(agent_id) for agent_id in native_agents]
+    if native_agents and all(agent_id not in native_safety for agent_id in native_agents):
+        assemble_only = True
+        safety: dict[str, str] = {}
+    elif native_agents and all(
+        agent_id in native_safety and value in {"cautious", "trusted"}
+        for agent_id, value in zip(native_agents, native_evidence, strict=True)
+    ):
+        assemble_only = False
+        safety = dict(zip(native_agents, native_evidence, strict=True))
+    elif native_agents:
+        raise CliError(
+            "Pre-manifest --assemble-only state is mixed or ambiguous; rerun install with explicit choices"
+        )
+    else:
+        assemble_only = False
+        safety = {}
     recovery = recover_identity(managed_instructions)
     runtime = target / ".agentsmith" / "agentsmith.py" if scope == "project" else Path(__file__).resolve()
     installed_version = VERSION
@@ -1359,6 +1377,7 @@ def reconstruct_pre_manifest_installation(target: Path, scope: str, state: dict[
         "agents": agents,
         "profiles": list(profiles),
         "include_core": include_core,
+        "assemble_only": assemble_only,
         "safety": safety,
         "operator": {
             "name": recovery.get("operator_name", "the project lead"),
@@ -1764,6 +1783,8 @@ def install_arguments_from_manifest(plan: dict[str, Any], shadow_target: Path) -
         arguments += ["--profile", profile]
     if not installation["include_core"]:
         arguments.append("--profile-only")
+    if installation["assemble_only"]:
+        arguments.append("--assemble-only")
     safety_values = set(installation["safety"].values())
     if len(safety_values) > 1:
         raise CliError("Update cannot reproduce mixed native safety settings; reinstall each scope explicitly")
@@ -1970,7 +1991,10 @@ def validate_post_update_health(plan: dict[str, Any]) -> None:
     installation = plan["installation"]
     state_root = Path(plan["roots"]["home"] if plan["scope"] == "global" else plan["roots"]["target"])
     installed = validate_installation_manifest(load_update_state(state_root))
-    for field in ("scope", "agents", "profiles", "include_core", "safety", "operator", "tracker", "capabilities"):
+    for field in (
+        "scope", "agents", "profiles", "include_core", "assemble_only", "safety", "operator", "tracker",
+        "capabilities",
+    ):
         if installed.get(field) != installation.get(field):
             raise CliError(f"Post-update health check failed: installation manifest changed {field}")
     if installed.get("installed_version") != plan["release"]["version"]:
@@ -2075,9 +2099,10 @@ def validate_post_update_health(plan: dict[str, Any]) -> None:
         if str(runtime) not in text or "hook git-pre-commit" not in text:
             raise CliError("Post-update health check failed: managed Git pre-commit hook is missing or stale")
 
-    for agent_id, expected_safety in installation["safety"].items():
-        if inspect_safety(agent_id)["state"] != expected_safety:
-            raise CliError(f"Post-update health check failed: native safety does not match the manifest for {agent_id}")
+    if not installation["assemble_only"]:
+        for agent_id, expected_safety in installation["safety"].items():
+            if inspect_safety(agent_id)["state"] != expected_safety:
+                raise CliError(f"Post-update health check failed: native safety does not match the manifest for {agent_id}")
 
 
 def restore_changes(changes: list[dict[str, Any]], roots: dict[str, str], backup_root: Path) -> None:

--- a/agentsmith.py
+++ b/agentsmith.py
@@ -631,6 +631,7 @@ def record_installation_manifest(
     profiles: list[str],
     args: argparse.Namespace,
     recovery: dict[str, str],
+    installed_skill_directories: list[Path],
 ) -> None:
     if args.dry_run:
         return
@@ -663,19 +664,48 @@ def record_installation_manifest(
         if agent_id in {"claude", "codex"}
     }
     state["schema_version"] = 1
-    managed_files: list[dict[str, str]] = []
     managed_root = home_dir() if args.global_mode else target
-    for relative_root in (Path(".agents") / "skills", Path(".claude") / "skills"):
-        skill_root = managed_root / relative_root
-        if not skill_root.is_dir():
+    managed_root_name = "home" if args.global_mode else "target"
+    managed_files_by_path: dict[str, dict[str, str]] = {}
+    prior_managed_files = prior_installation.get("managed_files", []) if isinstance(prior_installation, dict) else []
+    if isinstance(prior_managed_files, list):
+        for item in prior_managed_files:
+            if not isinstance(item, dict) or set(item) != {"root", "path", "sha256"}:
+                continue
+            relative = Path(item["path"]) if isinstance(item["path"], str) else Path()
+            if (
+                item["root"] == managed_root_name
+                and len(relative.parts) >= 4
+                and relative.parts[:2] in {(".agents", "skills"), (".claude", "skills")}
+                and isinstance(item["sha256"], str)
+                and re.fullmatch(r"[0-9a-f]{64}", item["sha256"])
+            ):
+                managed_files_by_path[item["path"]] = dict(item)
+    for skill_directory in installed_skill_directories:
+        try:
+            relative_directory = skill_directory.relative_to(managed_root)
+        except ValueError as exc:
+            raise CliError(f"Installed skill directory is outside its managed root: {skill_directory}") from exc
+        if (
+            len(relative_directory.parts) != 3
+            or relative_directory.parts[:2] not in {(".agents", "skills"), (".claude", "skills")}
+        ):
+            raise CliError(f"Installed skill directory is outside a managed skill surface: {skill_directory}")
+        prefix = relative_directory.as_posix() + "/"
+        managed_files_by_path = {
+            path: item for path, item in managed_files_by_path.items() if not path.startswith(prefix)
+        }
+        if not skill_directory.is_dir():
             continue
-        for path in sorted(skill_root.rglob("*")):
+        for path in sorted(skill_directory.rglob("*")):
             if path.is_file():
-                managed_files.append({
-                    "root": "home" if args.global_mode else "target",
-                    "path": path.relative_to(managed_root).as_posix(),
+                relative_path = path.relative_to(managed_root).as_posix()
+                managed_files_by_path[relative_path] = {
+                    "root": managed_root_name,
+                    "path": relative_path,
                     "sha256": file_sha256(path),
-                })
+                }
+    managed_files = [managed_files_by_path[path] for path in sorted(managed_files_by_path)]
     state["installation"] = {
         "installed_version": VERSION,
         "source": source,
@@ -809,9 +839,10 @@ def reconcile_codex_toml(path: Path, safety: str | None, mcp: dict[str, Any], *,
             tomllib.load(handle)
 
 
-def install_skills(target: Path, agents: list[str], *, force: bool, dry_run: bool) -> None:
+def install_skills(target: Path, agents: list[str], *, force: bool, dry_run: bool) -> list[Path]:
     canonical = target / ".agents" / "skills"
     destinations = [canonical]
+    installed_directories: list[Path] = []
     if "claude" in agents:
         destinations.append(target / ".claude" / "skills")
     for destination in destinations:
@@ -828,7 +859,9 @@ def install_skills(target: Path, agents: list[str], *, force: bool, dry_run: boo
             if dest.exists():
                 shutil.rmtree(dest)
             shutil.copytree(source, dest)
+            installed_directories.append(dest)
         ok(f"skills installed into {destination}")
+    return installed_directories
 
 
 def install_adapters(target: Path, agents: list[str], *, dry_run: bool) -> None:
@@ -2607,18 +2640,38 @@ def remove_owned_hooks(path: Path, *, dry_run: bool) -> None:
         path.unlink()
 
 
-def remove_owned_skills(target: Path, agents: list[str], *, dry_run: bool) -> None:
+def remove_owned_skills(
+    target: Path, agents: list[str], ownership: dict[str, Any], *, dry_run: bool
+) -> None:
     destinations = [target / ".agents" / "skills"]
     if "claude" in agents:
         destinations.append(target / ".claude" / "skills")
+    installation = ownership.get("installation", {})
+    inventory = installation.get("managed_files", []) if isinstance(installation, dict) else []
+    inventory = inventory if isinstance(inventory, list) else []
+    expected_root = "home" if isinstance(installation, dict) and installation.get("scope") == "global" else "target"
     for destination in destinations:
         for source in sorted((ROOT / "skills").iterdir()):
             installed = destination / source.name
             if not source.is_dir() or not installed.is_dir():
                 continue
-            source_files = {p.relative_to(source): p.read_bytes() for p in source.rglob("*") if p.is_file()}
-            installed_files = {p.relative_to(installed): p.read_bytes() for p in installed.rglob("*") if p.is_file()}
-            if source_files != installed_files:
+            prefix = installed.relative_to(target).as_posix() + "/"
+            recorded = {
+                item["path"][len(prefix):]: item["sha256"]
+                for item in inventory
+                if isinstance(item, dict)
+                and item.get("root") == expected_root
+                and isinstance(item.get("path"), str)
+                and item["path"].startswith(prefix)
+                and isinstance(item.get("sha256"), str)
+            }
+            if not recorded:
+                continue
+            installed_files = {
+                path.relative_to(installed).as_posix(): file_sha256(path)
+                for path in installed.rglob("*") if path.is_file()
+            }
+            if recorded != installed_files:
                 warn(f"modified skill preserved during uninstall: {installed}")
                 continue
             if dry_run:
@@ -2698,7 +2751,9 @@ def uninstall(args: argparse.Namespace, agents: list[str], target: Path) -> int:
                         if data: atomic_write(settings, json.dumps(data, indent=2, ensure_ascii=False) + "\n")
                         else: settings.unlink()
     if ownership.get("skills_installed"):
-        remove_owned_skills(home_dir() if args.global_mode else target, agents, dry_run=args.dry_run)
+        remove_owned_skills(
+            home_dir() if args.global_mode else target, agents, ownership, dry_run=args.dry_run
+        )
     ok("uninstall removed only Agentsmith-owned instruction/config blocks; scaffolding was retained")
     return 0
 
@@ -2790,12 +2845,15 @@ def cmd_install(args: argparse.Namespace) -> int:
         scaffold_design_system(target, args.design_system, dry_run=args.dry_run)
     install_native_config(target, agents, args)
     install_claude_plugin_packs(agents, args.with_plugins, dry_run=args.dry_run)
+    installed_skill_directories: list[Path] = []
     if args.with_skills:
         skill_root = home_dir() if args.global_mode else target
-        install_skills(skill_root, agents, force=args.force, dry_run=args.dry_run)
+        installed_skill_directories = install_skills(
+            skill_root, agents, force=args.force, dry_run=args.dry_run
+        )
         record_state(skill_root, "skills_installed", True, dry_run=args.dry_run)
     install_hooks(target, agents, args)
-    record_installation_manifest(target, agents, profiles, args, recovery)
+    record_installation_manifest(target, agents, profiles, args, recovery, installed_skill_directories)
     ok(f"installed for {', '.join(agents)}; canonical project instructions: AGENTS.md")
     return 0
 

--- a/agentsmith.py
+++ b/agentsmith.py
@@ -1465,6 +1465,11 @@ def installation_fingerprints(target: Path, installation: dict[str, Any]) -> tup
         for agent_id in installation["agents"]:
             if agent_id in adapters:
                 add("target", adapters[agent_id])
+        if installation["capabilities"].get("mcp"):
+            if "claude" in installation["agents"]:
+                add("target", ".mcp.json")
+            if "codex" in installation["agents"]:
+                add("target", ".codex/config.toml")
         if installation["capabilities"].get("skills"):
             add("target", ".agents/skills")
             if "claude" in installation["agents"]:
@@ -1856,7 +1861,7 @@ def allowed_update_path(root_name: str, relative: str, installation: dict[str, A
     if root_name == "target":
         exact = {
             "AGENTS.md", "CLAUDE.md", ".harness/verify.conf", ".aider.conf.yml", ".goosehints",
-            ".gemini/settings.json", ".continue/rules/agentsmith.md",
+            ".gemini/settings.json", ".continue/rules/agentsmith.md", ".mcp.json", ".codex/config.toml",
             *RUNTIME_FILES, ".agentsmith/autonomous-run.py", ".agentsmith/state.json",
         }
         prefixes = (".harness/templates/", ".agents/skills/", ".claude/skills/")

--- a/agentsmith.py
+++ b/agentsmith.py
@@ -1679,6 +1679,11 @@ def recheck_plan_fingerprints(plan: dict[str, Any]) -> None:
 
 
 def copy_plan_inputs_to_shadow(plan: dict[str, Any], shadow_roots: dict[str, Path]) -> None:
+    live_roots = {
+        "target": Path(plan["target"]),
+        "home": home_dir(),
+        "codex_home": codex_home(),
+    }
     for item in plan["fingerprints"]:
         if item["sha256"] is None:
             continue
@@ -1686,6 +1691,10 @@ def copy_plan_inputs_to_shadow(plan: dict[str, Any], shadow_roots: dict[str, Pat
         destination = safe_update_path(shadow_roots[item["root"]], item["path"])
         destination.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(source, destination)
+        original = destination.read_bytes()
+        translated = translate_root_paths(original, live_roots, shadow_roots)
+        if translated != original:
+            destination.write_bytes(translated)
 
 
 def prepare_owned_skills(plan: dict[str, Any], shadow_roots: dict[str, Path]) -> set[tuple[str, str]]:
@@ -1792,22 +1801,25 @@ def shadow_files(root: Path) -> dict[str, tuple[bytes, int]]:
     return result
 
 
-def translate_shadow_paths(
-    content: bytes, shadow_roots: dict[str, Path], actual_roots: dict[str, str]
+def translate_root_paths(
+    content: bytes,
+    source_roots: dict[str, str | Path],
+    destination_roots: dict[str, str | Path],
 ) -> bytes:
     try:
         text = content.decode("utf-8")
     except UnicodeDecodeError:
         return content
     replacements: set[tuple[str, str]] = set()
-    for root_name, shadow_root in shadow_roots.items():
-        actual = actual_roots[root_name]
-        resolved_shadow = shadow_root.resolve()
+    for root_name, source_root_value in source_roots.items():
+        source_root = Path(source_root_value)
+        destination_root = Path(destination_roots[root_name])
+        resolved_source = source_root.resolve()
         for old, new in (
-            (str(shadow_root), actual),
-            (str(resolved_shadow), actual),
-            (shadow_root.as_posix(), Path(actual).as_posix()),
-            (resolved_shadow.as_posix(), Path(actual).as_posix()),
+            (str(source_root), str(destination_root)),
+            (str(resolved_source), str(destination_root)),
+            (source_root.as_posix(), destination_root.as_posix()),
+            (resolved_source.as_posix(), destination_root.as_posix()),
         ):
             replacements.add((old, new))
             replacements.add((json.dumps(old, ensure_ascii=False)[1:-1], json.dumps(new, ensure_ascii=False)[1:-1]))
@@ -1922,7 +1934,7 @@ def stage_planned_update(
         for relative, (content, mode) in shadow_files(shadow_root).items():
             if not allowed_update_path(root_name, relative, plan["installation"]):
                 raise CliError(f"Release attempted an update outside the managed surface: {root_name}:{relative}")
-            content = translate_shadow_paths(content, shadow_roots, plan["roots"])
+            content = translate_root_paths(content, shadow_roots, plan["roots"])
             actual = safe_update_path(Path(plan["roots"][root_name]), relative)
             if actual.exists() and not actual.is_file():
                 raise CliError(f"Update refused to replace non-file path {actual}")

--- a/agentsmith.py
+++ b/agentsmith.py
@@ -1887,6 +1887,47 @@ def translate_root_paths(
     return text.encode("utf-8")
 
 
+def refresh_translated_statusline_hashes(
+    plan: dict[str, Any], translated_files: dict[str, dict[str, tuple[bytes, int]]]
+) -> None:
+    """Make statusline ownership hashes describe final, path-translated file bytes."""
+    home_files = translated_files.get("home", {})
+    state_entry = home_files.get(".agentsmith/state.json")
+    if state_entry is None:
+        return
+    content, mode = state_entry
+    try:
+        state = json.loads(content.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise CliError("Staged home state is not valid UTF-8 JSON") from exc
+    ownership = state.get("native_statuslines", {}) if isinstance(state, dict) else {}
+    claude = ownership.get("claude", {}) if isinstance(ownership, dict) else {}
+    recorded_files = claude.get("files", {}) if isinstance(claude, dict) else {}
+    if not isinstance(recorded_files, dict):
+        return
+    home_root = Path(plan["roots"]["home"])
+    changed = False
+    for raw_path, recorded_hash in list(recorded_files.items()):
+        if not isinstance(raw_path, str) or not isinstance(recorded_hash, str):
+            continue
+        try:
+            relative = Path(raw_path).relative_to(home_root).as_posix()
+        except ValueError:
+            continue
+        translated = home_files.get(relative)
+        if translated is None:
+            continue
+        final_hash = hashlib.sha256(translated[0]).hexdigest()
+        if final_hash != recorded_hash:
+            recorded_files[raw_path] = final_hash
+            changed = True
+    if changed:
+        home_files[".agentsmith/state.json"] = (
+            (json.dumps(state, indent=2, ensure_ascii=False) + "\n").encode("utf-8"),
+            mode,
+        )
+
+
 def allowed_update_path(root_name: str, relative: str, installation: dict[str, Any]) -> bool:
     path = Path(relative)
     if ".." in path.parts or path.is_absolute():
@@ -1988,12 +2029,20 @@ def stage_planned_update(
     else:
         trusted_stage_install(checkout, plan["release"]["version"], install_arguments, shadow_env)
     retain_customized_skill_baselines(plan, shadow_roots, preserved_skills)
-    proposed: list[tuple[str, str, bytes, int]] = []
+    translated_files: dict[str, dict[str, tuple[bytes, int]]] = {}
     for root_name, shadow_root in shadow_roots.items():
+        translated_files[root_name] = {}
         for relative, (content, mode) in shadow_files(shadow_root).items():
             if not allowed_update_path(root_name, relative, plan["installation"]):
                 raise CliError(f"Release attempted an update outside the managed surface: {root_name}:{relative}")
-            content = translate_root_paths(content, shadow_roots, plan["roots"])
+            translated_files[root_name][relative] = (
+                translate_root_paths(content, shadow_roots, plan["roots"]),
+                mode,
+            )
+    refresh_translated_statusline_hashes(plan, translated_files)
+    proposed: list[tuple[str, str, bytes, int]] = []
+    for root_name, files in translated_files.items():
+        for relative, (content, mode) in files.items():
             actual = safe_update_path(Path(plan["roots"][root_name]), relative)
             if actual.exists() and not actual.is_file():
                 raise CliError(f"Update refused to replace non-file path {actual}")

--- a/agentsmith.py
+++ b/agentsmith.py
@@ -1802,7 +1802,13 @@ def translate_shadow_paths(
     replacements: set[tuple[str, str]] = set()
     for root_name, shadow_root in shadow_roots.items():
         actual = actual_roots[root_name]
-        for old, new in ((str(shadow_root), actual), (shadow_root.as_posix(), Path(actual).as_posix())):
+        resolved_shadow = shadow_root.resolve()
+        for old, new in (
+            (str(shadow_root), actual),
+            (str(resolved_shadow), actual),
+            (shadow_root.as_posix(), Path(actual).as_posix()),
+            (resolved_shadow.as_posix(), Path(actual).as_posix()),
+        ):
             replacements.add((old, new))
             replacements.add((json.dumps(old, ensure_ascii=False)[1:-1], json.dumps(new, ensure_ascii=False)[1:-1]))
     for old, new in sorted(replacements, key=lambda item: len(item[0]), reverse=True):

--- a/agentsmith.py
+++ b/agentsmith.py
@@ -2143,18 +2143,43 @@ def validate_post_update_health(plan: dict[str, Any]) -> None:
                 raise CliError(f"Post-update health check failed: native safety does not match the manifest for {agent_id}")
 
 
-def restore_changes(changes: list[dict[str, Any]], roots: dict[str, str], backup_root: Path) -> None:
+def prepare_restoration(
+    changes: list[dict[str, Any]], roots: dict[str, str], backup_root: Path
+) -> list[tuple[Path, bytes | None, int | None]]:
+    seen: set[tuple[str, str]] = set()
+    prepared: list[tuple[Path, bytes | None, int | None]] = []
     for change in reversed(changes):
+        identity = (change["root"], change["path"])
+        if identity in seen:
+            raise CliError(f"Rollback receipt contains a duplicate change path: {change['root']}:{change['path']}")
+        seen.add(identity)
         path = safe_update_path(Path(roots[change["root"]]), change["path"])
         if change["existed"]:
             backup_path = safe_update_path(backup_root, Path(change["root"]) / change["path"])
-            content = backup_path.read_bytes()
+            if not backup_path.is_file():
+                raise CliError(f"Rollback backup is missing for {change['root']}:{change['path']}")
+            try:
+                content = backup_path.read_bytes()
+            except OSError as exc:
+                raise CliError(f"Cannot read rollback backup for {change['root']}:{change['path']}: {exc}") from exc
             if hashlib.sha256(content).hexdigest() != change["before_sha256"]:
                 raise CliError(f"Rollback backup hash mismatch for {change['root']}:{change['path']}")
-            atomic_write_bytes(path, content, change["before_mode"])
-        elif path.exists():
+            prepared.append((path, content, change["before_mode"]))
+        else:
             if path.is_dir():
                 raise CliError(f"Rollback refused to remove unexpected directory {path}")
+            prepared.append((path, None, None))
+    return prepared
+
+
+def restore_changes(changes: list[dict[str, Any]], roots: dict[str, str], backup_root: Path) -> None:
+    prepared = prepare_restoration(changes, roots, backup_root)
+    for path, content, mode in prepared:
+        if content is not None:
+            if mode is None:
+                raise CliError(f"Rollback restoration mode is missing for {path}")
+            atomic_write_bytes(path, content, mode)
+        elif path.exists():
             path.unlink()
 
 

--- a/agentsmith.py
+++ b/agentsmith.py
@@ -3039,8 +3039,21 @@ def doctor_project_root(target: Path) -> Path:
 
 
 def resolve_doctor_path(value: str, base: Path | None = None) -> Path:
-    rendered = value.replace("$CODEX_HOME", str(codex_home())).replace("${CODEX_HOME}", str(codex_home()))
-    path = Path(rendered).expanduser()
+    runtime_home = home_dir()
+    rendered = value
+    for marker, destination in (
+        ("${CODEX_HOME}", codex_home()),
+        ("$CODEX_HOME", codex_home()),
+        ("${HOME}", runtime_home),
+        ("$HOME", runtime_home),
+    ):
+        rendered = rendered.replace(marker, str(destination))
+    if rendered == "~":
+        path = runtime_home
+    elif rendered.startswith(("~/", "~\\")):
+        path = runtime_home / rendered[2:]
+    else:
+        path = Path(rendered).expanduser()
     return path.resolve() if path.is_absolute() else ((base or Path.cwd()) / path).resolve()
 
 

--- a/agentsmith.py
+++ b/agentsmith.py
@@ -2025,6 +2025,28 @@ def proposed_change_manifest(
     return result
 
 
+def proposal_mismatch_summary(expected: list[dict[str, Any]], actual: list[dict[str, Any]]) -> str:
+    """Describe proposal drift without exposing staged file contents or hash values."""
+    expected_by_path = {(item["root"], item["path"]): item for item in expected}
+    actual_by_path = {(item["root"], item["path"]): item for item in actual}
+    details: list[str] = []
+    for identity in sorted(expected_by_path.keys() | actual_by_path.keys()):
+        root_name, relative = identity
+        if identity not in actual_by_path:
+            details.append(f"missing {root_name}:{relative}")
+            continue
+        if identity not in expected_by_path:
+            details.append(f"unexpected {root_name}:{relative}")
+            continue
+        changed = sorted(
+            field for field in expected_by_path[identity]
+            if expected_by_path[identity][field] != actual_by_path[identity].get(field)
+        )
+        if changed:
+            details.append(f"changed {root_name}:{relative} ({', '.join(changed)})")
+    return "; ".join(details) or "proposal ordering differs"
+
+
 def validate_post_update_health(plan: dict[str, Any]) -> None:
     installation = plan["installation"]
     state_root = Path(plan["roots"]["home"] if plan["scope"] == "global" else plan["roots"]["target"])
@@ -2197,7 +2219,10 @@ def cmd_update_apply(args: argparse.Namespace) -> int:
         checkout, proposed = stage_planned_update(plan, temporary_root, execute_candidate=True)
         actual_proposal = proposed_change_manifest(plan, proposed)
         if actual_proposal != plan["proposed_changes"]:
-            raise CliError("Update refused: staged managed changes do not match the authenticated plan")
+            detail = proposal_mismatch_summary(plan["proposed_changes"], actual_proposal)
+            raise CliError(
+                "Update refused: staged managed changes do not match the authenticated plan: " + detail
+            )
         try:
             for root_name, relative, content, mode in proposed:
                 actual = safe_update_path(Path(plan["roots"][root_name]), relative)

--- a/docs/02-your-first-hour.md
+++ b/docs/02-your-first-hour.md
@@ -22,6 +22,7 @@ CLAUDE.md                        generated copy when Claude is selected
 .planning/progress-log.md        a running log the agent appends to
 docs/feedback/README.md          the post-incident convention (see below)
 .agentsmith/                     Python runtime + POSIX/Windows command shims
+.agentsmith/state.json           local installation choices and ownership fingerprints
 ```
 
 The Python program and templates are copied into the project, so installed commands do not depend
@@ -29,6 +30,14 @@ on the AgentSmith folder you cloned. Each rule file is written inside marker com
 (`<!-- BEGIN AGENTSMITH … -->`): that block belongs to setup. To change the rules, edit `core/`
 or `profiles/` in your harness checkout and re-run setup; anything you add *outside* the markers
 (project specifics) is yours and survives every re-run.
+
+When a stable release is available, use `agentsmith update plan --target . --save FILE` before
+installing it. Planning does not change the installation. The first plan creates a local key under
+`~/.agentsmith` to authenticate plans and receipts. Read the saved plan, then run `agentsmith update
+apply --plan FILE` only when you approve those managed changes. Apply prints a rollback receipt
+outside the project; keep that path until the update is accepted. Weekly availability checks are
+off unless you explicitly enable them with `agentsmith update configure --auto-check weekly`, and
+they never install anything automatically.
 
 ## Minutes 10–25: read your instruction file — the tour
 

--- a/docs/17-troubleshooting.md
+++ b/docs/17-troubleshooting.md
@@ -26,6 +26,28 @@ the file and changes only its safety setting. Run the same command with `--dry-r
 paths without writing. Use `--safety trusted` only if preserving the larger blast radius is the
 intended choice.
 
+**"`update apply` says a file changed after planning."** The saved plan contains fingerprints of
+every existing managed file it may touch. A person, tool, or background process changed one after
+the plan was created, so applying the old plan could overwrite newer work. Do not force it. Inspect
+the named file, keep the intended edit, and create a new plan. Planning and an offline `update
+check` make no installation changes.
+
+**"An update says its integrity key is missing."** Plans and rollback receipts are authenticated
+with `~/.agentsmith/update-integrity.key`. They work only for the local account that created them.
+Do not copy a plan from another machine or edit it. Create a new plan on this machine. Keep the key
+with its receipts and backups while a rollback may still be needed.
+
+**"Rollback refuses because a file changed after the update."** Rollback restores exact saved
+bytes, so it checks the post-update hash before overwriting anything. Preserve or commit the newer
+edit first, then decide whether to recreate it after rollback. Do not edit the receipt: its local
+authentication, paths, and backup hashes are part of the safety boundary. Receipts and backups live under
+`~/.agentsmith`, outside tracked project files.
+
+**"The weekly update check reports that it is offline."** The requested command still runs. Weekly
+checks are short, opportunistic, and report-only; they never install a release. Run `agentsmith
+update check --from REMOTE` later to diagnose the remote, or disable the opt-in with `agentsmith
+update configure --auto-check off`.
+
 **"It keeps trying the same fix and won't stop."** The stop-rule in `core/40` says two identical
 failures means re-diagnose, not retry — but a loop or a long run can slip it. The cause is usually
 a wrong root-cause diagnosis (R1) or a flake treated as a regression. Interrupt it, and make it

--- a/docs/19-glossary.md
+++ b/docs/19-glossary.md
@@ -22,6 +22,12 @@ an expert developer, most of the friction here is words — clear that, and the 
   this one path and does not search other Orca account homes.
 - **Managed block** — the marked region of a rule file or Codex TOML that setup owns and
   rewrites. Anything outside it is yours and survives re-runs.
+- **Update plan** — an authenticated description of one exact stable release and one installation
+  scope. It records current fingerprints and proposed managed changes; `apply --plan` is the
+  explicit approval boundary. Planning does not change the installation.
+- **Rollback receipt** — the local record written after a successful staged update. It points to
+  exact pre-update backups under `~/.agentsmith`; rollback restores changed files and removes only
+  files that update created.
 
 ## The rulebook's parts
 

--- a/scripts/test-update.py
+++ b/scripts/test-update.py
@@ -1,0 +1,930 @@
+#!/usr/bin/env python3
+"""Behavioral tests for the staged stable-release updater."""
+
+from __future__ import annotations
+
+import json
+import io
+import hashlib
+import hmac
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest import mock
+from contextlib import redirect_stderr, redirect_stdout
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CORE = ROOT / "agentsmith.py"
+sys.path.insert(0, str(ROOT))
+import agentsmith as runtime  # noqa: E402
+
+
+def integrity(payload: dict[str, object], key: bytes) -> str:
+    unsigned = {key: value for key, value in payload.items() if key != "integrity"}
+    canonical = json.dumps(unsigned, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return "hmac-sha256:" + hmac.new(key, canonical, hashlib.sha256).hexdigest()
+
+
+class UpdateCheckTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory(prefix="agentsmith update ü ")
+        self.root = Path(self.temporary.name)
+        self.seed = self.root / "seed"
+        self.remote = self.root / "remote.git"
+        self.seed.mkdir()
+        self.git("init", "-q", "-b", "main")
+        self.git("config", "user.name", "Updater Test")
+        self.git("config", "user.email", "user@example.com")
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def git(self, *arguments: str) -> subprocess.CompletedProcess[str]:
+        result = subprocess.run(
+            ["git", "-C", str(self.seed), *arguments],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        return result
+
+    def commit_and_tag(
+        self,
+        version: str,
+        *,
+        broken_doctor: bool = False,
+        broken_runtime_health: bool = False,
+        candidate_execution_probe: Path | None = None,
+    ) -> None:
+        for directory in ("config", "core", "profiles", "scripts", "skills", "templates"):
+            destination = self.seed / directory
+            if not destination.exists():
+                shutil.copytree(ROOT / directory, destination)
+        for helper in ("native_launcher.py", "evaluate.py"):
+            shutil.copy2(ROOT / helper, self.seed / helper)
+        (self.seed / "VERSION").write_text(version + "\n", encoding="utf-8")
+        runtime = CORE.read_text(encoding="utf-8")
+        runtime = re.sub(r'^VERSION = "[^"]+"$', f'VERSION = "{version}"', runtime, count=1, flags=re.MULTILINE)
+        if broken_doctor:
+            runtime = runtime.replace(
+                '\nif __name__ == "__main__":',
+                '\ndef cmd_doctor(args: object) -> int:\n    return 9\n\nif __name__ == "__main__":',
+                1,
+            )
+        if broken_runtime_health:
+            runtime = runtime.replace(
+                '\nif __name__ == "__main__":',
+                '\ndef copy_runtime(target: Path, *, dry_run: bool) -> Path:\n'
+                '    return target / ".agentsmith" / "agentsmith.py"\n\n'
+                'if __name__ == "__main__":',
+                1,
+            )
+        if candidate_execution_probe is not None:
+            runtime = runtime.replace(
+                '\nif __name__ == "__main__":',
+                f'\nPath({json.dumps(str(candidate_execution_probe))}).write_text("candidate executed", encoding="utf-8")\n\n'
+                'if __name__ == "__main__":',
+                1,
+            )
+        (self.seed / "agentsmith.py").write_text(runtime, encoding="utf-8")
+        identity = (ROOT / "core" / "00-identity.md").read_text(encoding="utf-8")
+        identity += f"\nRELEASE_PROBE_{version.replace('.', '_').replace('-', '_')}\n"
+        (self.seed / "core" / "00-identity.md").write_text(identity, encoding="utf-8")
+        skill = (ROOT / "skills" / "handoff" / "SKILL.md").read_text(encoding="utf-8")
+        skill += f"\nRELEASE_SKILL_PROBE_{version.replace('.', '_').replace('-', '_')}\n"
+        (self.seed / "skills" / "handoff" / "SKILL.md").write_text(skill, encoding="utf-8")
+        self.git("add", ".")
+        self.git("commit", "-qm", f"release {version}")
+        self.git("tag", f"v{version}")
+
+    def run_core(self, *arguments: str, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(CORE), *arguments],
+            text=True,
+            capture_output=True,
+            check=False,
+            env=env,
+        )
+
+    def test_check_selects_highest_stable_semver_and_excludes_prereleases(self) -> None:
+        for version in ("0.2.0", "0.3.0-rc.1", "0.2.7", "1.0.0-beta.2"):
+            self.commit_and_tag(version)
+        self.git("tag", "not-a-release")
+        cloned = subprocess.run(
+            ["git", "clone", "-q", "--bare", str(self.seed), str(self.remote)],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(cloned.returncode, 0, cloned.stdout + cloned.stderr)
+
+        result = self.run_core("update", "check", "--from", str(self.remote), "--json")
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["current_version"], "0.2.0")
+        self.assertEqual(payload["latest_version"], "0.2.7")
+        self.assertEqual(payload["tag"], "v0.2.7")
+        self.assertTrue(payload["update_available"])
+        self.assertEqual(payload["remote"], str(self.remote))
+
+    def test_fresh_install_records_versioned_update_manifest_without_project_path(self) -> None:
+        target = self.root / "project"
+        target.mkdir()
+        isolated_home = self.root / "home"
+        environment = {
+            **os.environ,
+            "HOME": str(isolated_home),
+            "CODEX_HOME": str(self.root / "codex-home"),
+        }
+
+        result = self.run_core(
+            "install",
+            "--agent", "codex",
+            "--profile", "software-dev",
+            "--target", str(target),
+            "--operator-name", "Update Test",
+            "--tracker", "Linear",
+            "--tracker-writes", "ask",
+            "--safety", "trusted",
+            "--with-skills",
+            "--with-mcp", "context7",
+            "--with-handoff-hooks",
+            env=environment,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        state = json.loads((target / ".agentsmith" / "state.json").read_text(encoding="utf-8"))
+        self.assertEqual(state["schema_version"], 1)
+        installation = state["installation"]
+        self.assertEqual(installation["installed_version"], "0.2.0")
+        self.assertEqual(installation["scope"], "project")
+        self.assertEqual(installation["agents"], ["codex"])
+        self.assertEqual(installation["profiles"], ["software-dev"])
+        self.assertTrue(installation["include_core"])
+        self.assertEqual(installation["safety"], {"codex": "trusted"})
+        self.assertEqual(installation["tracker"], {"name": "Linear", "writes": "ask"})
+        self.assertEqual(
+            installation["capabilities"],
+            {"handoff_hooks": True, "hooks": False, "mcp": ["context7"], "skills": True, "ui_design_hook": False},
+        )
+        self.assertNotIn(str(target), json.dumps(state))
+
+    def test_saved_plan_verifies_release_and_is_installation_write_free(self) -> None:
+        self.commit_and_tag("0.2.0")
+        self.commit_and_tag("0.2.1")
+        cloned = subprocess.run(
+            ["git", "clone", "-q", "--bare", str(self.seed), str(self.remote)],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(cloned.returncode, 0, cloned.stdout + cloned.stderr)
+        target = self.root / "planned project"
+        target.mkdir()
+        environment = {
+            **os.environ,
+            "HOME": str(self.root / "home"),
+            "CODEX_HOME": str(self.root / "codex-home"),
+        }
+        installed = self.run_core(
+            "install", "--agent", "codex", "--profile", "software-dev",
+            "--target", str(target), "--operator-name", "Plan Test",
+            env=environment,
+        )
+        self.assertEqual(installed.returncode, 0, installed.stdout + installed.stderr)
+        before = {
+            path.relative_to(target): path.read_bytes()
+            for path in target.rglob("*")
+            if path.is_file()
+        }
+        plan_path = self.root / "plans" / "update.json"
+
+        result = self.run_core(
+            "update", "plan", "--target", str(target), "--version", "v0.2.1",
+            "--from", str(self.remote), "--save", str(plan_path),
+            env=environment,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        after = {
+            path.relative_to(target): path.read_bytes()
+            for path in target.rglob("*")
+            if path.is_file()
+        }
+        self.assertEqual(after, before)
+        second_plan_path = self.root / "second-apply-plan.json"
+        second_plan = self.run_core(
+            "update", "plan", "--target", str(target), "--version", "v0.2.1",
+            "--from", str(self.remote), "--save", str(second_plan_path), env=environment,
+        )
+        self.assertEqual(second_plan.returncode, 0, second_plan.stdout + second_plan.stderr)
+        second_fingerprints = {
+            item["path"] for item in json.loads(second_plan_path.read_text(encoding="utf-8"))["fingerprints"]
+        }
+        self.assertNotIn(".agentsmith/update-integrity.key", second_fingerprints)
+        self.assertFalse(any("update-receipts" in path or "update-backups" in path for path in second_fingerprints))
+        plan = json.loads(plan_path.read_text(encoding="utf-8"))
+        self.assertEqual(plan["schema_version"], 1)
+        self.assertEqual(plan["scope"], "project")
+        self.assertEqual(plan["target"], str(target.resolve()))
+        self.assertEqual(plan["release"]["tag"], "v0.2.1")
+        self.assertEqual(plan["release"]["version"], "0.2.1")
+        self.assertEqual(plan["release"]["commit"], self.git("rev-list", "-n", "1", "v0.2.1").stdout.strip())
+        fingerprints = {item["path"]: item["sha256"] for item in plan["fingerprints"]}
+        self.assertIn("AGENTS.md", fingerprints)
+        self.assertIn(".agentsmith/agentsmith.py", fingerprints)
+        self.assertIn("doctor --strict", " ".join(plan["verification"]))
+        self.assertTrue(plan["integrity"].startswith("hmac-sha256:"))
+        self.assertTrue(plan["proposed_changes"])
+        self.assertTrue(all(set(item) == {
+            "root", "path", "operation", "before_sha256", "before_mode", "after_sha256", "after_mode"
+        } for item in plan["proposed_changes"]))
+        runtime_change = next(item for item in plan["proposed_changes"] if item["path"] == ".agentsmith/agentsmith.py")
+        self.assertEqual(runtime_change["operation"], "replace")
+        self.assertEqual(runtime_change["before_sha256"], fingerprints[".agentsmith/agentsmith.py"])
+        self.assertRegex(runtime_change["after_sha256"], r"^[0-9a-f]{64}$")
+
+    def test_planning_treats_candidate_release_code_as_data(self) -> None:
+        execution_probe = self.root / "candidate-executed-outside-shadow"
+        self.commit_and_tag("0.2.0")
+        self.commit_and_tag("0.2.1", candidate_execution_probe=execution_probe)
+        cloned = subprocess.run(
+            ["git", "clone", "-q", "--bare", str(self.seed), str(self.remote)],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(cloned.returncode, 0, cloned.stdout + cloned.stderr)
+        target = self.root / "data-only planning project"
+        target.mkdir()
+        environment = {
+            **os.environ,
+            "HOME": str(self.root / "data-only-home"),
+            "CODEX_HOME": str(self.root / "data-only-codex"),
+        }
+        installed = self.run_core(
+            "install", "--agent", "codex", "--profile", "software-dev", "--target", str(target),
+            env=environment,
+        )
+        self.assertEqual(installed.returncode, 0, installed.stdout + installed.stderr)
+
+        planned = self.run_core(
+            "update", "plan", "--target", str(target), "--version", "v0.2.1",
+            "--from", str(self.remote), "--save", str(self.root / "data-only-plan.json"), env=environment,
+        )
+
+        self.assertEqual(planned.returncode, 0, planned.stdout + planned.stderr)
+        self.assertFalse(execution_probe.exists())
+
+    def test_apply_and_rollback_preserve_foreign_content_and_restore_exact_bytes(self) -> None:
+        self.commit_and_tag("0.2.0")
+        self.commit_and_tag("0.2.1")
+        cloned = subprocess.run(
+            ["git", "clone", "-q", "--bare", str(self.seed), str(self.remote)],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(cloned.returncode, 0, cloned.stdout + cloned.stderr)
+        target = self.root / "rollback project"
+        target.mkdir()
+        environment = {
+            **os.environ,
+            "HOME": str(self.root / "home"),
+            "CODEX_HOME": str(self.root / "codex-home"),
+        }
+        installed = self.run_core(
+            "install", "--agent", "codex", "--profile", "software-dev",
+            "--target", str(target), "--operator-name", "Rollback Test",
+            env=environment,
+        )
+        self.assertEqual(installed.returncode, 0, installed.stdout + installed.stderr)
+        agents_path = target / "AGENTS.md"
+        agents_path.write_text("# Foreign heading\n\n" + agents_path.read_text(encoding="utf-8"), encoding="utf-8")
+        research = target / "docs" / "research" / "source.md"
+        research.parent.mkdir(parents=True, exist_ok=True)
+        research.write_bytes(b"costly source material\n")
+        plan_path = self.root / "apply-plan.json"
+        planned = self.run_core(
+            "update", "plan", "--target", str(target), "--version", "v0.2.1",
+            "--from", str(self.remote), "--save", str(plan_path), env=environment,
+        )
+        self.assertEqual(planned.returncode, 0, planned.stdout + planned.stderr)
+        before = {
+            path.relative_to(target): path.read_bytes()
+            for path in target.rglob("*")
+            if path.is_file()
+        }
+
+        applied = self.run_core("update", "apply", "--plan", str(plan_path), env=environment)
+
+        self.assertEqual(applied.returncode, 0, applied.stdout + applied.stderr)
+        updated_agents = agents_path.read_text(encoding="utf-8")
+        self.assertIn("# Foreign heading", updated_agents)
+        self.assertIn("RELEASE_PROBE_0_2_1", updated_agents)
+        self.assertEqual(research.read_bytes(), b"costly source material\n")
+        updated_runtime = (target / ".agentsmith" / "agentsmith.py").read_text(encoding="utf-8")
+        self.assertIn('VERSION = "0.2.1"', updated_runtime)
+        receipt_line = next(line for line in applied.stdout.splitlines() if "rollback receipt:" in line)
+        receipt_path = Path(receipt_line.split("rollback receipt:", 1)[1].strip())
+        self.assertFalse(receipt_path.is_relative_to(target))
+        self.assertTrue(receipt_path.is_file())
+        if os.name != "nt":
+            receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+            agents_change = next(item for item in receipt["changes"] if item["path"] == "AGENTS.md")
+            agents_path.chmod(agents_change["after_mode"] ^ 0o100)
+            refused_mode_change = self.run_core(
+                "update", "rollback", "--receipt", str(receipt_path), env=environment,
+            )
+            self.assertNotEqual(refused_mode_change.returncode, 0)
+            self.assertIn("changed after update", refused_mode_change.stderr)
+            agents_path.chmod(agents_change["after_mode"])
+
+        rolled_back = self.run_core("update", "rollback", "--receipt", str(receipt_path), env=environment)
+
+        self.assertEqual(rolled_back.returncode, 0, rolled_back.stdout + rolled_back.stderr)
+        after = {
+            path.relative_to(target): path.read_bytes()
+            for path in target.rglob("*")
+            if path.is_file()
+        }
+        self.assertEqual(after, before)
+        later_plan_path = self.root / "plan-after-receipt.json"
+        later_plan = self.run_core(
+            "update", "plan", "--target", str(target), "--version", "v0.2.1",
+            "--from", str(self.remote), "--save", str(later_plan_path), env=environment,
+        )
+        self.assertEqual(later_plan.returncode, 0, later_plan.stdout + later_plan.stderr)
+        later_fingerprints = {
+            item["path"] for item in json.loads(later_plan_path.read_text(encoding="utf-8"))["fingerprints"]
+        }
+        self.assertFalse(any("update-receipts" in path or "update-backups" in path for path in later_fingerprints))
+
+    def test_configure_requires_explicit_weekly_opt_in_and_can_turn_it_off(self) -> None:
+        environment = {
+            **os.environ,
+            "HOME": str(self.root / "home"),
+            "CODEX_HOME": str(self.root / "codex-home"),
+        }
+
+        enabled = self.run_core("update", "configure", "--auto-check", "weekly", env=environment)
+
+        self.assertEqual(enabled.returncode, 0, enabled.stdout + enabled.stderr)
+        state_path = Path(environment["HOME"]) / ".agentsmith" / "state.json"
+        enabled_state = json.loads(state_path.read_text(encoding="utf-8"))
+        self.assertEqual(enabled_state["update_policy"], {"auto_check": "weekly"})
+
+        disabled = self.run_core("update", "configure", "--auto-check", "off", env=environment)
+
+        self.assertEqual(disabled.returncode, 0, disabled.stdout + disabled.stderr)
+        disabled_state = json.loads(state_path.read_text(encoding="utf-8"))
+        self.assertEqual(disabled_state["update_policy"], {"auto_check": "off"})
+
+    def test_global_mcp_is_rejected_before_any_installation_write(self) -> None:
+        environment = {
+            **os.environ,
+            "HOME": str(self.root / "global-mcp-home"),
+            "CODEX_HOME": str(self.root / "global-mcp-codex"),
+        }
+
+        result = self.run_core(
+            "install", "--agent", "codex", "--global", "--with-mcp", "context7", env=environment,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("project-scoped", result.stderr)
+        self.assertFalse(Path(environment["HOME"]).exists())
+        self.assertFalse(Path(environment["CODEX_HOME"]).exists())
+
+    def test_offline_check_fails_without_creating_installation_state(self) -> None:
+        environment = {
+            **os.environ,
+            "HOME": str(self.root / "offline-home"),
+            "CODEX_HOME": str(self.root / "offline-codex"),
+        }
+
+        result = self.run_core(
+            "update", "check", "--from", str(self.root / "missing-remote.git"), "--json",
+            env=environment,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("no installation changes were made", result.stderr)
+        self.assertFalse((Path(environment["HOME"]) / ".agentsmith").exists())
+
+    def test_plan_fails_closed_on_malformed_existing_state_before_remote_access(self) -> None:
+        target = self.root / "malformed-state-project"
+        state_path = target / ".agentsmith" / "state.json"
+        state_path.parent.mkdir(parents=True)
+        state_path.write_text("{not json\n", encoding="utf-8")
+        environment = {
+            **os.environ,
+            "HOME": str(self.root / "malformed-home"),
+            "CODEX_HOME": str(self.root / "malformed-codex"),
+        }
+
+        result = self.run_core(
+            "update", "plan", "--target", str(target), "--from", str(self.root / "must-not-be-read.git"),
+            env=environment,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("malformed update state", result.stderr)
+        self.assertEqual(state_path.read_text(encoding="utf-8"), "{not json\n")
+
+    def test_apply_rejects_unknown_plan_fields_and_post_plan_fingerprint_drift(self) -> None:
+        self.commit_and_tag("0.2.0")
+        self.commit_and_tag("0.2.1")
+        cloned = subprocess.run(
+            ["git", "clone", "-q", "--bare", str(self.seed), str(self.remote)],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(cloned.returncode, 0, cloned.stdout + cloned.stderr)
+        target = self.root / "drift project"
+        target.mkdir()
+        environment = {
+            **os.environ,
+            "HOME": str(self.root / "drift-home"),
+            "CODEX_HOME": str(self.root / "drift-codex"),
+        }
+        installed = self.run_core(
+            "install", "--agent", "codex", "--profile", "software-dev", "--target", str(target),
+            env=environment,
+        )
+        self.assertEqual(installed.returncode, 0, installed.stdout + installed.stderr)
+        plan_path = self.root / "guarded-plan.json"
+        planned = self.run_core(
+            "update", "plan", "--target", str(target), "--version", "v0.2.1",
+            "--from", str(self.remote), "--save", str(plan_path), env=environment,
+        )
+        self.assertEqual(planned.returncode, 0, planned.stdout + planned.stderr)
+        original = plan_path.read_bytes()
+        tampered = json.loads(original)
+        tampered["unexpected_command"] = ["do", "not", "run"]
+        plan_path.write_text(json.dumps(tampered, indent=2) + "\n", encoding="utf-8")
+
+        rejected = self.run_core("update", "apply", "--plan", str(plan_path), env=environment)
+
+        self.assertNotEqual(rejected.returncode, 0)
+        self.assertIn("integrity check failed", rejected.stderr)
+        tampered["integrity"] = integrity(
+            tampered, (Path(environment["HOME"]) / ".agentsmith" / "update-integrity.key").read_bytes()
+        )
+        plan_path.write_text(json.dumps(tampered, indent=2) + "\n", encoding="utf-8")
+        rejected = self.run_core("update", "apply", "--plan", str(plan_path), env=environment)
+        self.assertNotEqual(rejected.returncode, 0)
+        self.assertIn("not supported", rejected.stderr)
+        mismatched = json.loads(original)
+        mismatched["proposed_changes"][0]["after_sha256"] = "0" * 64
+        mismatched["integrity"] = integrity(
+            mismatched, (Path(environment["HOME"]) / ".agentsmith" / "update-integrity.key").read_bytes()
+        )
+        plan_path.write_text(json.dumps(mismatched, indent=2) + "\n", encoding="utf-8")
+        mismatch_rejected = self.run_core("update", "apply", "--plan", str(plan_path), env=environment)
+        self.assertNotEqual(mismatch_rejected.returncode, 0)
+        self.assertIn("do not match the authenticated plan", mismatch_rejected.stderr)
+        plan_path.write_bytes(original)
+        agents = target / "AGENTS.md"
+        agents.write_text(agents.read_text(encoding="utf-8") + "\npost-plan operator edit\n", encoding="utf-8")
+        drifted = self.run_core("update", "apply", "--plan", str(plan_path), env=environment)
+        self.assertNotEqual(drifted.returncode, 0)
+        self.assertIn("changed after planning", drifted.stderr)
+        self.assertNotIn('VERSION = "0.2.1"', (target / ".agentsmith" / "agentsmith.py").read_text(encoding="utf-8"))
+
+    def test_plan_reconstructs_provable_pre_manifest_state_without_migration_write(self) -> None:
+        self.commit_and_tag("0.2.0")
+        self.commit_and_tag("0.2.1")
+        cloned = subprocess.run(
+            ["git", "clone", "-q", "--bare", str(self.seed), str(self.remote)],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(cloned.returncode, 0, cloned.stdout + cloned.stderr)
+        target = self.root / "legacy project"
+        target.mkdir()
+        environment = {
+            **os.environ,
+            "HOME": str(self.root / "legacy-home"),
+            "CODEX_HOME": str(self.root / "legacy-codex"),
+        }
+        installed = self.run_core(
+            "install", "--agent", "codex", "--profile", "software-dev", "--target", str(target),
+            "--operator-name", "Legacy Operator", "--safety", "trusted", env=environment,
+        )
+        self.assertEqual(installed.returncode, 0, installed.stdout + installed.stderr)
+        legacy_state_path = target / ".agentsmith" / "state.json"
+        legacy_state_path.write_text("{}\n", encoding="utf-8")
+        before = legacy_state_path.read_bytes()
+        plan_path = self.root / "legacy-plan.json"
+
+        planned = self.run_core(
+            "update", "plan", "--target", str(target), "--version", "v0.2.1",
+            "--from", str(self.remote), "--save", str(plan_path), env=environment,
+        )
+
+        self.assertEqual(planned.returncode, 0, planned.stdout + planned.stderr)
+        self.assertEqual(legacy_state_path.read_bytes(), before)
+        plan = json.loads(plan_path.read_text(encoding="utf-8"))
+        self.assertTrue(plan["migration_warnings"])
+        self.assertEqual(plan["installation"]["agents"], ["codex"])
+        self.assertEqual(plan["installation"]["profiles"], ["software-dev"])
+        self.assertEqual(plan["installation"]["safety"], {"codex": "trusted"})
+        self.assertEqual(plan["installation"]["operator"]["name"], "Legacy Operator")
+
+    def test_global_update_is_scoped_and_rolls_back_managed_home_files(self) -> None:
+        self.commit_and_tag("0.2.0")
+        self.commit_and_tag("0.2.1")
+        cloned = subprocess.run(
+            ["git", "clone", "-q", "--bare", str(self.seed), str(self.remote)],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(cloned.returncode, 0, cloned.stdout + cloned.stderr)
+        home = self.root / "global-home"
+        codex_home = self.root / "global-codex"
+        environment = {**os.environ, "HOME": str(home), "CODEX_HOME": str(codex_home)}
+        installed = self.run_core(
+            "install", "--agent", "codex", "--global", "--profile", "software-dev",
+            "--operator-name", "Global Operator", "--with-handoff-hooks", env=environment,
+        )
+        self.assertEqual(installed.returncode, 0, installed.stdout + installed.stderr)
+        managed_paths = [
+            home / ".agentsmith" / "state.json",
+            home / ".agentsmith" / "agentsmith.py",
+            codex_home / "AGENTS.md",
+            codex_home / "config.toml",
+            codex_home / "hooks.json",
+        ]
+        before = {path: path.read_bytes() for path in managed_paths}
+        plan_path = self.root / "global-plan.json"
+        planned = self.run_core(
+            "update", "plan", "--global", "--version", "v0.2.1", "--from", str(self.remote),
+            "--save", str(plan_path), env=environment,
+        )
+        self.assertEqual(planned.returncode, 0, planned.stdout + planned.stderr)
+
+        applied = self.run_core("update", "apply", "--plan", str(plan_path), env=environment)
+
+        self.assertEqual(applied.returncode, 0, applied.stdout + applied.stderr)
+        self.assertIn("RELEASE_PROBE_0_2_1", (codex_home / "AGENTS.md").read_text(encoding="utf-8"))
+        self.assertIn(str(home / ".agentsmith" / "agentsmith.py"), (codex_home / "hooks.json").read_text(encoding="utf-8"))
+        self.assertNotIn("agentsmith-apply-", (codex_home / "hooks.json").read_text(encoding="utf-8"))
+        receipt_line = next(line for line in applied.stdout.splitlines() if "rollback receipt:" in line)
+        receipt_path = Path(receipt_line.split("rollback receipt:", 1)[1].strip())
+        rolled_back = self.run_core("update", "rollback", "--receipt", str(receipt_path), env=environment)
+        self.assertEqual(rolled_back.returncode, 0, rolled_back.stdout + rolled_back.stderr)
+        self.assertEqual({path: path.read_bytes() for path in managed_paths}, before)
+
+    def test_update_refreshes_owned_skills_but_preserves_customized_skill(self) -> None:
+        self.commit_and_tag("0.2.0")
+        self.commit_and_tag("0.2.1")
+        cloned = subprocess.run(
+            ["git", "clone", "-q", "--bare", str(self.seed), str(self.remote)],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(cloned.returncode, 0, cloned.stdout + cloned.stderr)
+        target = self.root / "skills project"
+        target.mkdir()
+        environment = {
+            **os.environ,
+            "HOME": str(self.root / "skills-home"),
+            "CODEX_HOME": str(self.root / "skills-codex"),
+        }
+        installed = self.run_core(
+            "install", "--agent", "codex", "--profile", "software-dev", "--target", str(target),
+            "--with-skills", env=environment,
+        )
+        self.assertEqual(installed.returncode, 0, installed.stdout + installed.stderr)
+        customized = target / ".agents" / "skills" / "example-skill" / "SKILL.md"
+        customized.write_text(customized.read_text(encoding="utf-8") + "\nLOCAL CUSTOMIZATION\n", encoding="utf-8")
+        plan_path = self.root / "skills-plan.json"
+        planned = self.run_core(
+            "update", "plan", "--target", str(target), "--version", "v0.2.1",
+            "--from", str(self.remote), "--save", str(plan_path), env=environment,
+        )
+        self.assertEqual(planned.returncode, 0, planned.stdout + planned.stderr)
+
+        applied = self.run_core("update", "apply", "--plan", str(plan_path), env=environment)
+
+        self.assertEqual(applied.returncode, 0, applied.stdout + applied.stderr)
+        handoff = target / ".agents" / "skills" / "handoff" / "SKILL.md"
+        self.assertIn("RELEASE_SKILL_PROBE_0_2_1", handoff.read_text(encoding="utf-8"))
+        self.assertIn("LOCAL CUSTOMIZATION", customized.read_text(encoding="utf-8"))
+
+    def test_weekly_check_reports_only_and_offline_failure_does_not_block_command(self) -> None:
+        home = self.root / "weekly-home"
+        codex_home = self.root / "weekly-codex"
+        environment = {"HOME": str(home), "CODEX_HOME": str(codex_home)}
+        state_path = home / ".agentsmith" / "state.json"
+        state_path.parent.mkdir(parents=True)
+        state_path.write_text(json.dumps({"update_policy": {"auto_check": "weekly"}}) + "\n", encoding="utf-8")
+        output = io.StringIO()
+        errors = io.StringIO()
+        with mock.patch.dict(os.environ, environment, clear=False), mock.patch.object(
+            runtime, "stable_release_tags", return_value=[((0, 2, 1), "v0.2.1")]
+        ) as checked, redirect_stdout(output), redirect_stderr(errors):
+            result = runtime.run(["agents", "list"])
+        self.assertEqual(result, 0)
+        checked.assert_called_once_with(runtime.OFFICIAL_REMOTE, timeout_seconds=3)
+        self.assertIn("update available: v0.2.1", output.getvalue())
+        self.assertIn("claude", output.getvalue())
+
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        state["update_policy"]["last_attempt_at"] = "2000-01-01T00:00:00+00:00"
+        state_path.write_text(json.dumps(state) + "\n", encoding="utf-8")
+        with mock.patch.dict(os.environ, environment, clear=False), mock.patch.object(
+            runtime, "stable_release_tags", side_effect=runtime.CliError("offline")
+        ), redirect_stdout(io.StringIO()), redirect_stderr(errors):
+            offline_result = runtime.run(["agents", "list"])
+        self.assertEqual(offline_result, 0)
+        self.assertIn("weekly update check skipped", errors.getvalue())
+
+        state["update_policy"]["last_attempt_at"] = "2000-01-01T00:00:00+00:00"
+        state_path.write_text(json.dumps(state) + "\n", encoding="utf-8")
+        write_errors = io.StringIO()
+        with mock.patch.dict(os.environ, environment, clear=False), mock.patch.object(
+            runtime, "record_state", side_effect=PermissionError("read-only home")
+        ), redirect_stdout(io.StringIO()), redirect_stderr(write_errors):
+            write_failure_result = runtime.run(["agents", "list"])
+        self.assertEqual(write_failure_result, 0)
+        self.assertIn("weekly update check skipped", write_errors.getvalue())
+
+    def test_failed_post_apply_health_check_restores_pre_update_bytes_automatically(self) -> None:
+        self.commit_and_tag("0.2.0")
+        self.commit_and_tag("0.2.1", broken_doctor=True)
+        cloned = subprocess.run(
+            ["git", "clone", "-q", "--bare", str(self.seed), str(self.remote)],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(cloned.returncode, 0, cloned.stdout + cloned.stderr)
+        target = self.root / "failed apply project"
+        target.mkdir()
+        environment = {
+            **os.environ,
+            "HOME": str(self.root / "failed-home"),
+            "CODEX_HOME": str(self.root / "failed-codex"),
+        }
+        installed = self.run_core(
+            "install", "--agent", "codex", "--profile", "software-dev", "--target", str(target),
+            env=environment,
+        )
+        self.assertEqual(installed.returncode, 0, installed.stdout + installed.stderr)
+        plan_path = self.root / "failed-plan.json"
+        planned = self.run_core(
+            "update", "plan", "--target", str(target), "--version", "v0.2.1",
+            "--from", str(self.remote), "--save", str(plan_path), env=environment,
+        )
+        self.assertEqual(planned.returncode, 0, planned.stdout + planned.stderr)
+        before = {path.relative_to(target): path.read_bytes() for path in target.rglob("*") if path.is_file()}
+
+        applied = self.run_core("update", "apply", "--plan", str(plan_path), env=environment)
+
+        self.assertNotEqual(applied.returncode, 0)
+        self.assertIn("Post-update doctor failed", applied.stderr)
+        after = {path.relative_to(target): path.read_bytes() for path in target.rglob("*") if path.is_file()}
+        self.assertEqual(after, before)
+        receipt_root = Path(environment["HOME"]) / ".agentsmith" / "update-receipts"
+        self.assertFalse(receipt_root.exists())
+
+    def test_apply_rejects_changed_candidate_installer_semantics_for_project_scope(self) -> None:
+        self.commit_and_tag("0.2.0")
+        self.commit_and_tag("0.2.1", broken_runtime_health=True)
+        cloned = subprocess.run(
+            ["git", "clone", "-q", "--bare", str(self.seed), str(self.remote)],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(cloned.returncode, 0, cloned.stdout + cloned.stderr)
+        target = self.root / "stale runtime project"
+        target.mkdir()
+        environment = {
+            **os.environ,
+            "HOME": str(self.root / "stale-project-home"),
+            "CODEX_HOME": str(self.root / "stale-project-codex"),
+        }
+        installed = self.run_core(
+            "install", "--agent", "codex", "--profile", "software-dev", "--target", str(target),
+            env=environment,
+        )
+        self.assertEqual(installed.returncode, 0, installed.stdout + installed.stderr)
+        before = {path.relative_to(target): path.read_bytes() for path in target.rglob("*") if path.is_file()}
+        plan_path = self.root / "stale-project-plan.json"
+        planned = self.run_core(
+            "update", "plan", "--target", str(target), "--version", "v0.2.1",
+            "--from", str(self.remote), "--save", str(plan_path), env=environment,
+        )
+        self.assertEqual(planned.returncode, 0, planned.stdout + planned.stderr)
+
+        applied = self.run_core("update", "apply", "--plan", str(plan_path), env=environment)
+
+        self.assertNotEqual(applied.returncode, 0)
+        self.assertIn("staged managed changes do not match the authenticated plan", applied.stderr)
+        after = {path.relative_to(target): path.read_bytes() for path in target.rglob("*") if path.is_file()}
+        self.assertEqual(after, before)
+
+    def test_apply_rejects_changed_candidate_installer_semantics_for_global_scope(self) -> None:
+        self.commit_and_tag("0.2.0")
+        self.commit_and_tag("0.2.1", broken_runtime_health=True)
+        cloned = subprocess.run(
+            ["git", "clone", "-q", "--bare", str(self.seed), str(self.remote)],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(cloned.returncode, 0, cloned.stdout + cloned.stderr)
+        home = self.root / "stale-global-home"
+        codex_home = self.root / "stale-global-codex"
+        environment = {**os.environ, "HOME": str(home), "CODEX_HOME": str(codex_home)}
+        installed = self.run_core(
+            "install", "--agent", "codex", "--global", "--with-handoff-hooks", env=environment,
+        )
+        self.assertEqual(installed.returncode, 0, installed.stdout + installed.stderr)
+        observed = [
+            home / ".agentsmith" / "state.json",
+            home / ".agentsmith" / "agentsmith.py",
+            codex_home / "AGENTS.md",
+            codex_home / "config.toml",
+            codex_home / "hooks.json",
+        ]
+        before = {path: path.read_bytes() for path in observed}
+        plan_path = self.root / "stale-global-plan.json"
+        planned = self.run_core(
+            "update", "plan", "--global", "--version", "v0.2.1",
+            "--from", str(self.remote), "--save", str(plan_path), env=environment,
+        )
+        self.assertEqual(planned.returncode, 0, planned.stdout + planned.stderr)
+
+        applied = self.run_core("update", "apply", "--plan", str(plan_path), env=environment)
+
+        self.assertNotEqual(applied.returncode, 0)
+        self.assertIn("staged managed changes do not match the authenticated plan", applied.stderr)
+        self.assertEqual({path: path.read_bytes() for path in observed}, before)
+
+    def test_atomic_replace_retries_transient_sharing_denial_with_a_fixed_cap(self) -> None:
+        source = Path("temporary-update-file")
+        destination = Path("managed-destination")
+        with mock.patch.object(
+            Path, "replace", side_effect=[PermissionError("sharing violation"), PermissionError("sharing violation"), None]
+        ) as replaced, mock.patch.object(runtime.time, "sleep") as slept:
+            runtime.replace_with_retry(source, destination)
+        self.assertEqual(replaced.call_count, 3)
+        self.assertEqual([call.args[0] for call in slept.call_args_list], [0.05, 0.1])
+
+    def test_native_hook_update_points_to_real_runtime_not_discarded_shadow(self) -> None:
+        self.commit_and_tag("0.2.0")
+        self.commit_and_tag("0.2.1")
+        cloned = subprocess.run(
+            ["git", "clone", "-q", "--bare", str(self.seed), str(self.remote)],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(cloned.returncode, 0, cloned.stdout + cloned.stderr)
+        target = self.root / "hook project"
+        target.mkdir()
+        environment = {
+            **os.environ,
+            "HOME": str(self.root / "hook-home"),
+            "CODEX_HOME": str(self.root / "hook-codex"),
+        }
+        installed = self.run_core(
+            "install", "--agent", "codex", "--profile", "software-dev", "--target", str(target),
+            "--with-handoff-hooks", env=environment,
+        )
+        self.assertEqual(installed.returncode, 0, installed.stdout + installed.stderr)
+        plan_path = self.root / "hook-plan.json"
+        planned = self.run_core(
+            "update", "plan", "--target", str(target), "--version", "v0.2.1",
+            "--from", str(self.remote), "--save", str(plan_path), env=environment,
+        )
+        self.assertEqual(planned.returncode, 0, planned.stdout + planned.stderr)
+
+        applied = self.run_core("update", "apply", "--plan", str(plan_path), env=environment)
+
+        self.assertEqual(applied.returncode, 0, applied.stdout + applied.stderr)
+        hooks = (Path(environment["CODEX_HOME"]) / "hooks.json").read_text(encoding="utf-8")
+        self.assertIn(str(target / ".agentsmith" / "agentsmith.py"), hooks)
+        self.assertNotIn("agentsmith-apply-", hooks)
+
+    def test_plain_installer_rerun_does_not_forget_still_managed_capabilities(self) -> None:
+        target = self.root / "capability rerun"
+        target.mkdir()
+        environment = {
+            **os.environ,
+            "HOME": str(self.root / "capability-home"),
+            "CODEX_HOME": str(self.root / "capability-codex"),
+        }
+        first = self.run_core(
+            "install", "--agent", "codex", "--profile", "software-dev", "--target", str(target),
+            "--with-skills", "--with-mcp", "context7", "--with-handoff-hooks", env=environment,
+        )
+        self.assertEqual(first.returncode, 0, first.stdout + first.stderr)
+
+        second = self.run_core(
+            "install", "--agent", "codex", "--profile", "software-dev", "--target", str(target),
+            env=environment,
+        )
+
+        self.assertEqual(second.returncode, 0, second.stdout + second.stderr)
+        state = json.loads((target / ".agentsmith" / "state.json").read_text(encoding="utf-8"))
+        self.assertEqual(
+            state["installation"]["capabilities"],
+            {"handoff_hooks": True, "hooks": False, "mcp": ["context7"], "skills": True, "ui_design_hook": False},
+        )
+
+    def test_cautious_rerun_cannot_make_the_next_update_restore_trusted_safety(self) -> None:
+        self.commit_and_tag("0.2.0")
+        self.commit_and_tag("0.2.1")
+        cloned = subprocess.run(
+            ["git", "clone", "-q", "--bare", str(self.seed), str(self.remote)],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(cloned.returncode, 0, cloned.stdout + cloned.stderr)
+        target = self.root / "safety project"
+        target.mkdir()
+        environment = {
+            **os.environ,
+            "HOME": str(self.root / "safety-home"),
+            "CODEX_HOME": str(self.root / "safety-codex"),
+        }
+        trusted = self.run_core(
+            "install", "--agent", "codex", "--profile", "software-dev", "--target", str(target),
+            "--safety", "trusted", env=environment,
+        )
+        self.assertEqual(trusted.returncode, 0, trusted.stdout + trusted.stderr)
+        cautious = self.run_core(
+            "install", "--agent", "codex", "--profile", "software-dev", "--target", str(target),
+            env=environment,
+        )
+        self.assertEqual(cautious.returncode, 0, cautious.stdout + cautious.stderr)
+        state_path = target / ".agentsmith" / "state.json"
+        self.assertEqual(json.loads(state_path.read_text(encoding="utf-8"))["installation"]["safety"], {"codex": "cautious"})
+        plan_path = self.root / "cautious-plan.json"
+        planned = self.run_core(
+            "update", "plan", "--target", str(target), "--version", "v0.2.1",
+            "--from", str(self.remote), "--save", str(plan_path), env=environment,
+        )
+        self.assertEqual(planned.returncode, 0, planned.stdout + planned.stderr)
+        self.assertEqual(json.loads(plan_path.read_text(encoding="utf-8"))["installation"]["safety"], {"codex": "cautious"})
+        applied = self.run_core("update", "apply", "--plan", str(plan_path), env=environment)
+        self.assertEqual(applied.returncode, 0, applied.stdout + applied.stderr)
+        config = (Path(environment["CODEX_HOME"]) / "config.toml").read_text(encoding="utf-8")
+        self.assertIn('approval_policy = "on-request"', config)
+        self.assertIn('sandbox_mode = "workspace-write"', config)
+
+    def test_update_plan_rejects_a_symbolic_link_in_a_managed_path(self) -> None:
+        self.commit_and_tag("0.2.0")
+        self.commit_and_tag("0.2.1")
+        cloned = subprocess.run(
+            ["git", "clone", "-q", "--bare", str(self.seed), str(self.remote)],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(cloned.returncode, 0, cloned.stdout + cloned.stderr)
+        target = self.root / "symlink project"
+        target.mkdir()
+        environment = {
+            **os.environ,
+            "HOME": str(self.root / "symlink-home"),
+            "CODEX_HOME": str(self.root / "symlink-codex"),
+        }
+        installed = self.run_core(
+            "install", "--agent", "codex", "--profile", "software-dev", "--target", str(target),
+            env=environment,
+        )
+        self.assertEqual(installed.returncode, 0, installed.stdout + installed.stderr)
+        moved_state = self.root / "moved-agentsmith-state"
+        shutil.move(str(target / ".agentsmith"), moved_state)
+        (target / ".agentsmith").symlink_to(moved_state, target_is_directory=True)
+
+        planned = self.run_core(
+            "update", "plan", "--target", str(target), "--version", "v0.2.1",
+            "--from", str(self.remote), env=environment,
+        )
+
+        self.assertNotEqual(planned.returncode, 0)
+        self.assertIn("symbolic link", planned.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test-update.py
+++ b/scripts/test-update.py
@@ -62,6 +62,7 @@ class UpdateCheckTests(unittest.TestCase):
         broken_doctor: bool = False,
         broken_runtime_health: bool = False,
         candidate_execution_probe: Path | None = None,
+        statusline_probe: str | None = None,
     ) -> None:
         for directory in ("config", "core", "profiles", "scripts", "skills", "templates"):
             destination = self.seed / directory
@@ -94,6 +95,12 @@ class UpdateCheckTests(unittest.TestCase):
                 1,
             )
         (self.seed / "agentsmith.py").write_text(runtime, encoding="utf-8")
+        if statusline_probe is not None:
+            statusline = self.seed / "config" / "statusline.py"
+            statusline.write_text(
+                statusline.read_text(encoding="utf-8") + f"\n# {statusline_probe}\n",
+                encoding="utf-8",
+            )
         identity = (ROOT / "core" / "00-identity.md").read_text(encoding="utf-8")
         identity += f"\nRELEASE_PROBE_{version.replace('.', '_').replace('-', '_')}\n"
         (self.seed / "core" / "00-identity.md").write_text(identity, encoding="utf-8")
@@ -799,13 +806,85 @@ class UpdateCheckTests(unittest.TestCase):
         actual = self.root / "actual"
         content = str(canonical_shadow / ".agentsmith" / "agentsmith.py").encode("utf-8")
 
-        translated = runtime.translate_shadow_paths(
+        translated = runtime.translate_root_paths(
             content,
             {"target": shadow},
             {"target": str(actual)},
         ).decode("utf-8")
 
         self.assertEqual(translated, str(actual / ".agentsmith" / "agentsmith.py"))
+
+    def test_statusline_update_is_staged_without_touching_live_installation(self) -> None:
+        self.commit_and_tag("0.2.0")
+        self.commit_and_tag("0.2.1", statusline_probe="RELEASE_STATUSLINE_PROBE_0_2_1")
+        cloned = subprocess.run(
+            ["git", "clone", "-q", "--bare", str(self.seed), str(self.remote)],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(cloned.returncode, 0, cloned.stdout + cloned.stderr)
+        target = self.root / "statusline project"
+        target.mkdir()
+        home = self.root / "statusline-home"
+        environment = {
+            **os.environ,
+            "HOME": str(home),
+            "CODEX_HOME": str(self.root / "statusline-codex"),
+        }
+        installed = self.run_core(
+            "install", "--agent", "claude", "--profile", "software-dev", "--target", str(target),
+            env=environment,
+        )
+        self.assertEqual(installed.returncode, 0, installed.stdout + installed.stderr)
+        helper = home / ".claude" / "agentsmith-statusline.py"
+        self.assertNotIn("RELEASE_STATUSLINE_PROBE_0_2_1", helper.read_text(encoding="utf-8"))
+        watched_roots = (target, home, Path(environment["CODEX_HOME"]))
+        before = {
+            path: (path.read_bytes(), path.stat().st_mode & 0o777)
+            for root in watched_roots
+            if root.exists()
+            for path in root.rglob("*")
+            if path.is_file()
+        }
+        before_backups = {
+            path
+            for root in watched_roots if root.exists()
+            for path in root.rglob("*.bak.*")
+        }
+        plan_path = self.root / "statusline-plan.json"
+
+        planned = self.run_core(
+            "update", "plan", "--target", str(target), "--version", "v0.2.1",
+            "--from", str(self.remote), "--save", str(plan_path), env=environment,
+        )
+
+        self.assertEqual(planned.returncode, 0, planned.stdout + planned.stderr)
+        after = {
+            path: (path.read_bytes(), path.stat().st_mode & 0o777)
+            for root in watched_roots
+            if root.exists()
+            for path in root.rglob("*")
+            if path.is_file() and path.name != "update-integrity.key"
+        }
+        self.assertEqual(after, before)
+        self.assertEqual({
+            path
+            for root in watched_roots if root.exists()
+            for path in root.rglob("*.bak.*")
+        }, before_backups)
+        plan = json.loads(plan_path.read_text(encoding="utf-8"))
+        helper_change = next(
+            item for item in plan["proposed_changes"]
+            if item["root"] == "home" and item["path"] == ".claude/agentsmith-statusline.py"
+        )
+        self.assertEqual(helper_change["operation"], "replace")
+        self.assertNotIn("RELEASE_STATUSLINE_PROBE_0_2_1", helper.read_text(encoding="utf-8"))
+
+        applied = self.run_core("update", "apply", "--plan", str(plan_path), env=environment)
+
+        self.assertEqual(applied.returncode, 0, applied.stdout + applied.stderr)
+        self.assertIn("RELEASE_STATUSLINE_PROBE_0_2_1", helper.read_text(encoding="utf-8"))
 
     def test_native_hook_update_points_to_real_runtime_not_discarded_shadow(self) -> None:
         self.commit_and_tag("0.2.0")

--- a/scripts/test-update.py
+++ b/scripts/test-update.py
@@ -579,11 +579,14 @@ class UpdateCheckTests(unittest.TestCase):
 
         self.assertEqual(applied.returncode, 0, applied.stdout + applied.stderr)
         self.assertIn("RELEASE_PROBE_0_2_1", (codex_home / "AGENTS.md").read_text(encoding="utf-8"))
-        self.assertIn(
-            str(home.resolve() / ".agentsmith" / "agentsmith.py"),
-            (codex_home / "hooks.json").read_text(encoding="utf-8"),
-        )
-        self.assertNotIn("agentsmith-apply-", (codex_home / "hooks.json").read_text(encoding="utf-8"))
+        hooks = json.loads((codex_home / "hooks.json").read_text(encoding="utf-8"))
+        commands = [
+            hook["command"]
+            for entry in hooks["hooks"]["UserPromptSubmit"]
+            for hook in entry["hooks"]
+        ]
+        self.assertTrue(any(str(home.resolve() / ".agentsmith" / "agentsmith.py") in command for command in commands))
+        self.assertFalse(any("agentsmith-apply-" in command for command in commands))
         receipt_line = next(line for line in applied.stdout.splitlines() if "rollback receipt:" in line)
         receipt_path = Path(receipt_line.split("rollback receipt:", 1)[1].strip())
         rolled_back = self.run_core("update", "rollback", "--receipt", str(receipt_path), env=environment)
@@ -836,9 +839,14 @@ class UpdateCheckTests(unittest.TestCase):
         applied = self.run_core("update", "apply", "--plan", str(plan_path), env=environment)
 
         self.assertEqual(applied.returncode, 0, applied.stdout + applied.stderr)
-        hooks = (Path(environment["CODEX_HOME"]) / "hooks.json").read_text(encoding="utf-8")
-        self.assertIn(str(target / ".agentsmith" / "agentsmith.py"), hooks)
-        self.assertNotIn("agentsmith-apply-", hooks)
+        hooks = json.loads((Path(environment["CODEX_HOME"]) / "hooks.json").read_text(encoding="utf-8"))
+        commands = [
+            hook["command"]
+            for entry in hooks["hooks"]["UserPromptSubmit"]
+            for hook in entry["hooks"]
+        ]
+        self.assertTrue(any(str(target.resolve() / ".agentsmith" / "agentsmith.py") in command for command in commands))
+        self.assertFalse(any("agentsmith-apply-" in command for command in commands))
 
     def test_plain_installer_rerun_does_not_forget_still_managed_capabilities(self) -> None:
         target = self.root / "capability rerun"

--- a/scripts/test-update.py
+++ b/scripts/test-update.py
@@ -1332,6 +1332,14 @@ class UpdateCheckTests(unittest.TestCase):
         recorded = rendered["native_statuslines"]["claude"]["files"][str(wrapper_path)]
         self.assertEqual(recorded, hashlib.sha256(after).hexdigest())
 
+    def test_doctor_tilde_paths_use_the_runtime_home_override(self) -> None:
+        isolated_home = self.root / "doctor-runtime-home"
+
+        with mock.patch.object(runtime, "home_dir", return_value=isolated_home):
+            resolved = runtime.resolve_doctor_path("~/.claude/CLAUDE.md")
+
+        self.assertEqual(resolved, (isolated_home / ".claude" / "CLAUDE.md").resolve())
+
     def test_statusline_update_is_staged_without_touching_live_installation(self) -> None:
         self.commit_and_tag("0.2.0")
         self.commit_and_tag("0.2.1", statusline_probe="RELEASE_STATUSLINE_PROBE_0_2_1")

--- a/scripts/test-update.py
+++ b/scripts/test-update.py
@@ -176,6 +176,7 @@ class UpdateCheckTests(unittest.TestCase):
         self.assertEqual(installation["agents"], ["codex"])
         self.assertEqual(installation["profiles"], ["software-dev"])
         self.assertTrue(installation["include_core"])
+        self.assertFalse(installation["assemble_only"])
         self.assertEqual(installation["safety"], {"codex": "trusted"})
         self.assertEqual(installation["tracker"], {"name": "Linear", "writes": "ask"})
         self.assertEqual(
@@ -546,8 +547,168 @@ class UpdateCheckTests(unittest.TestCase):
         self.assertTrue(plan["migration_warnings"])
         self.assertEqual(plan["installation"]["agents"], ["codex"])
         self.assertEqual(plan["installation"]["profiles"], ["software-dev"])
+        self.assertFalse(plan["installation"]["assemble_only"])
         self.assertEqual(plan["installation"]["safety"], {"codex": "trusted"})
         self.assertEqual(plan["installation"]["operator"]["name"], "Legacy Operator")
+
+    def test_assemble_only_is_preserved_for_project_and_global_updates(self) -> None:
+        self.commit_and_tag("0.2.0")
+        self.commit_and_tag("0.2.1")
+        cloned = subprocess.run(
+            ["git", "clone", "-q", "--bare", str(self.seed), str(self.remote)],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(cloned.returncode, 0, cloned.stdout + cloned.stderr)
+        for scope in ("project", "global"):
+            with self.subTest(scope=scope):
+                target = self.root / f"assemble-only-{scope}-project"
+                target.mkdir()
+                home = self.root / f"assemble-only-{scope}-home"
+                codex_home = self.root / f"assemble-only-{scope}-codex"
+                environment = {**os.environ, "HOME": str(home), "CODEX_HOME": str(codex_home)}
+                scope_arguments = ["--global"] if scope == "global" else ["--target", str(target)]
+                installed = self.run_core(
+                    "install", "--agent", "claude,codex", "--profile", "software-dev",
+                    "--assemble-only", *scope_arguments, env=environment,
+                )
+                self.assertEqual(installed.returncode, 0, installed.stdout + installed.stderr)
+                state_root = home if scope == "global" else target
+                state_path = state_root / ".agentsmith" / "state.json"
+                state = json.loads(state_path.read_text(encoding="utf-8"))
+                self.assertTrue(state["installation"]["assemble_only"])
+                self.assertEqual(state["installation"]["safety"], {})
+                home_state_path = home / ".agentsmith" / "state.json"
+                home_state = json.loads(home_state_path.read_text(encoding="utf-8")) if home_state_path.exists() else {}
+                self.assertNotIn("native_safety", home_state)
+                native_paths = [
+                    home / ".claude" / "settings.json",
+                    home / ".claude" / "agentsmith-statusline.py",
+                    codex_home / "config.toml",
+                ]
+                self.assertTrue(all(not path.exists() for path in native_paths))
+                plan_path = self.root / f"assemble-only-{scope}-plan.json"
+
+                planned = self.run_core(
+                    "update", "plan", *scope_arguments, "--version", "v0.2.1",
+                    "--from", str(self.remote), "--save", str(plan_path), env=environment,
+                )
+
+                self.assertEqual(planned.returncode, 0, planned.stdout + planned.stderr)
+                plan = json.loads(plan_path.read_text(encoding="utf-8"))
+                self.assertTrue(plan["installation"]["assemble_only"])
+                self.assertFalse(any(
+                    item["path"] in {".claude/settings.json", ".claude/agentsmith-statusline.py", "config.toml"}
+                    for item in plan["proposed_changes"]
+                ))
+                applied = self.run_core("update", "apply", "--plan", str(plan_path), env=environment)
+                self.assertEqual(applied.returncode, 0, applied.stdout + applied.stderr)
+                self.assertTrue(all(not path.exists() for path in native_paths))
+                updated = json.loads(state_path.read_text(encoding="utf-8"))["installation"]
+                self.assertTrue(updated["assemble_only"])
+                self.assertEqual(updated["safety"], {})
+
+    def test_assemble_only_migration_requires_unambiguous_native_ownership(self) -> None:
+        self.commit_and_tag("0.2.1")
+        cloned = subprocess.run(
+            ["git", "clone", "-q", "--bare", str(self.seed), str(self.remote)],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(cloned.returncode, 0, cloned.stdout + cloned.stderr)
+        project = self.root / "legacy-assemble-only-project"
+        project.mkdir()
+        project_home = self.root / "legacy-assemble-only-home"
+        project_environment = {
+            **os.environ,
+            "HOME": str(project_home),
+            "CODEX_HOME": str(self.root / "legacy-assemble-only-codex"),
+        }
+        installed = self.run_core(
+            "install", "--agent", "claude", "--profile", "software-dev", "--assemble-only",
+            "--target", str(project), env=project_environment,
+        )
+        self.assertEqual(installed.returncode, 0, installed.stdout + installed.stderr)
+        (project / ".agentsmith" / "state.json").write_text("{}\n", encoding="utf-8")
+        plan_path = self.root / "legacy-assemble-only-plan.json"
+
+        planned = self.run_core(
+            "update", "plan", "--target", str(project), "--version", "v0.2.1",
+            "--from", str(self.remote), "--save", str(plan_path), env=project_environment,
+        )
+
+        self.assertEqual(planned.returncode, 0, planned.stdout + planned.stderr)
+        self.assertTrue(json.loads(plan_path.read_text(encoding="utf-8"))["installation"]["assemble_only"])
+
+        global_home = self.root / "legacy-mixed-home"
+        global_codex = self.root / "legacy-mixed-codex"
+        global_environment = {**os.environ, "HOME": str(global_home), "CODEX_HOME": str(global_codex)}
+        global_installed = self.run_core(
+            "install", "--agent", "claude,codex", "--global", "--profile", "software-dev",
+            env=global_environment,
+        )
+        self.assertEqual(global_installed.returncode, 0, global_installed.stdout + global_installed.stderr)
+        global_state_path = global_home / ".agentsmith" / "state.json"
+        global_state = json.loads(global_state_path.read_text(encoding="utf-8"))
+        global_state.pop("installation")
+        global_state.pop("schema_version")
+        global_state["native_safety"].pop("codex")
+        global_state_path.write_text(json.dumps(global_state) + "\n", encoding="utf-8")
+
+        mixed = self.run_core(
+            "update", "plan", "--global", "--version", "v0.2.1", "--from", str(self.remote),
+            env=global_environment,
+        )
+
+        self.assertNotEqual(mixed.returncode, 0)
+        self.assertIn("assemble-only", mixed.stderr)
+
+        global_state["native_safety"] = {"claude": None, "codex": None}
+        global_state_path.write_text(json.dumps(global_state) + "\n", encoding="utf-8")
+        invalid = self.run_core(
+            "update", "plan", "--global", "--version", "v0.2.1", "--from", str(self.remote),
+            env=global_environment,
+        )
+        self.assertNotEqual(invalid.returncode, 0)
+        self.assertIn("assemble-only", invalid.stderr)
+
+    def test_schema_one_manifest_without_assemble_only_requires_reinstall(self) -> None:
+        target = self.root / "old-schema-one"
+        target.mkdir()
+        environment = {
+            **os.environ,
+            "HOME": str(self.root / "old-schema-home"),
+            "CODEX_HOME": str(self.root / "old-schema-codex"),
+        }
+        installed = self.run_core(
+            "install", "--agent", "codex", "--profile", "software-dev", "--target", str(target),
+            env=environment,
+        )
+        self.assertEqual(installed.returncode, 0, installed.stdout + installed.stderr)
+        state_path = target / ".agentsmith" / "state.json"
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        state["installation"].pop("assemble_only", None)
+        state_path.write_text(json.dumps(state) + "\n", encoding="utf-8")
+
+        planned = self.run_core(
+            "update", "plan", "--target", str(target), "--from", str(self.root / "unused.git"),
+            env=environment,
+        )
+
+        self.assertNotEqual(planned.returncode, 0)
+        self.assertIn("--assemble-only", planned.stderr)
+        self.assertIn("rerun install", planned.stderr)
+
+        state["installation"]["assemble_only"] = "false"
+        state_path.write_text(json.dumps(state) + "\n", encoding="utf-8")
+        malformed = self.run_core(
+            "update", "plan", "--target", str(target), "--from", str(self.root / "unused.git"),
+            env=environment,
+        )
+        self.assertNotEqual(malformed.returncode, 0)
+        self.assertIn("must be true or false", malformed.stderr)
 
     def test_global_update_is_scoped_and_rolls_back_managed_home_files(self) -> None:
         self.commit_and_tag("0.2.0")

--- a/scripts/test-update.py
+++ b/scripts/test-update.py
@@ -1302,6 +1302,36 @@ class UpdateCheckTests(unittest.TestCase):
         self.assertNotIn("b" * 64, summary)
         self.assertNotIn("c" * 64, summary)
 
+    def test_translated_statusline_hash_tracks_the_translated_wrapper_bytes(self) -> None:
+        home = self.root / "translated-home"
+        wrapper_path = home / ".claude" / "agentsmith-statusline.ps1"
+        before = b"shadow-specific wrapper\n"
+        after = b"live-path wrapper\n"
+        state = {
+            "native_statuslines": {
+                "claude": {
+                    "files": {str(wrapper_path): hashlib.sha256(before).hexdigest()},
+                },
+            },
+        }
+        translated = {
+            "home": {
+                ".agentsmith/state.json": (
+                    (json.dumps(state, indent=2, ensure_ascii=False) + "\n").encode("utf-8"),
+                    0o600,
+                ),
+                ".claude/agentsmith-statusline.ps1": (after, 0o600),
+            },
+        }
+
+        runtime.refresh_translated_statusline_hashes(
+            {"roots": {"home": str(home)}}, translated
+        )
+
+        rendered = json.loads(translated["home"][".agentsmith/state.json"][0])
+        recorded = rendered["native_statuslines"]["claude"]["files"][str(wrapper_path)]
+        self.assertEqual(recorded, hashlib.sha256(after).hexdigest())
+
     def test_statusline_update_is_staged_without_touching_live_installation(self) -> None:
         self.commit_and_tag("0.2.0")
         self.commit_and_tag("0.2.1", statusline_probe="RELEASE_STATUSLINE_PROBE_0_2_1")

--- a/scripts/test-update.py
+++ b/scripts/test-update.py
@@ -376,6 +376,97 @@ class UpdateCheckTests(unittest.TestCase):
         }
         self.assertFalse(any("update-receipts" in path or "update-backups" in path for path in later_fingerprints))
 
+    def test_rollback_preflights_all_backups_and_duplicate_paths_before_writing(self) -> None:
+        self.commit_and_tag("0.2.0")
+        self.commit_and_tag("0.2.1")
+        cloned = subprocess.run(
+            ["git", "clone", "-q", "--bare", str(self.seed), str(self.remote)],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(cloned.returncode, 0, cloned.stdout + cloned.stderr)
+
+        def change_snapshot(receipt: dict[str, object]) -> dict[Path, tuple[bytes, int]]:
+            roots = receipt["roots"]
+            assert isinstance(roots, dict)
+            changes = receipt["changes"]
+            assert isinstance(changes, list)
+            return {
+                path: (path.read_bytes(), path.stat().st_mode & 0o777)
+                for change in changes
+                if isinstance(change, dict)
+                for path in [Path(str(roots[change["root"]])) / str(change["path"])]
+                if path.is_file()
+            }
+
+        for failure in ("missing", "corrupt", "duplicate"):
+            with self.subTest(failure=failure):
+                target = self.root / f"rollback-preflight-{failure}-project"
+                target.mkdir()
+                home = self.root / f"rollback-preflight-{failure}-home"
+                environment = {
+                    **os.environ,
+                    "HOME": str(home),
+                    "CODEX_HOME": str(self.root / f"rollback-preflight-{failure}-codex"),
+                }
+                installed = self.run_core(
+                    "install", "--agent", "codex", "--profile", "software-dev", "--target", str(target),
+                    env=environment,
+                )
+                self.assertEqual(installed.returncode, 0, installed.stdout + installed.stderr)
+                plan_path = self.root / f"rollback-preflight-{failure}-plan.json"
+                planned = self.run_core(
+                    "update", "plan", "--target", str(target), "--version", "v0.2.1",
+                    "--from", str(self.remote), "--save", str(plan_path), env=environment,
+                )
+                self.assertEqual(planned.returncode, 0, planned.stdout + planned.stderr)
+                applied = self.run_core("update", "apply", "--plan", str(plan_path), env=environment)
+                self.assertEqual(applied.returncode, 0, applied.stdout + applied.stderr)
+                receipt_line = next(line for line in applied.stdout.splitlines() if "rollback receipt:" in line)
+                receipt_path = Path(receipt_line.split("rollback receipt:", 1)[1].strip())
+                original_receipt = receipt_path.read_bytes()
+                receipt = json.loads(original_receipt)
+                updated = change_snapshot(receipt)
+                self.assertGreater(len(updated), 1)
+
+                if failure == "duplicate":
+                    receipt["changes"].append(dict(receipt["changes"][0]))
+                    key = (home / ".agentsmith" / "update-integrity.key").read_bytes()
+                    receipt["integrity"] = integrity(receipt, key)
+                    receipt_path.write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
+                else:
+                    candidate = next(
+                        change for change in receipt["changes"][:-1] if change["existed"]
+                    )
+                    backup_path = Path(receipt["backup_root"]) / candidate["root"] / candidate["path"]
+                    original_backup = backup_path.read_bytes()
+                    held_backup = backup_path.with_name(backup_path.name + ".held")
+                    if failure == "missing":
+                        backup_path.rename(held_backup)
+                    else:
+                        backup_path.write_bytes(b"corrupt rollback backup")
+
+                refused = self.run_core(
+                    "update", "rollback", "--receipt", str(receipt_path), env=environment,
+                )
+
+                self.assertNotEqual(refused.returncode, 0)
+                expected_error = "duplicate" if failure == "duplicate" else "backup"
+                self.assertIn(expected_error, refused.stderr.lower())
+                self.assertEqual(change_snapshot(json.loads(original_receipt)), updated)
+
+                if failure == "duplicate":
+                    receipt_path.write_bytes(original_receipt)
+                elif failure == "missing":
+                    held_backup.rename(backup_path)
+                else:
+                    backup_path.write_bytes(original_backup)
+                rolled_back = self.run_core(
+                    "update", "rollback", "--receipt", str(receipt_path), env=environment,
+                )
+                self.assertEqual(rolled_back.returncode, 0, rolled_back.stdout + rolled_back.stderr)
+
     def test_configure_requires_explicit_weekly_opt_in_and_can_turn_it_off(self) -> None:
         environment = {
             **os.environ,

--- a/scripts/test-update.py
+++ b/scripts/test-update.py
@@ -1272,6 +1272,36 @@ class UpdateCheckTests(unittest.TestCase):
 
         self.assertEqual(translated, str(actual / ".agentsmith" / "agentsmith.py"))
 
+    def test_proposal_mismatch_summary_names_paths_and_fields_without_contents(self) -> None:
+        expected = [{
+            "root": "home",
+            "path": ".agentsmith/state.json",
+            "operation": "replace",
+            "before_sha256": "a" * 64,
+            "before_mode": 0o600,
+            "after_sha256": "b" * 64,
+            "after_mode": 0o600,
+        }]
+        actual = [{**expected[0], "after_sha256": "c" * 64, "after_mode": 0o666}, {
+            "root": "home",
+            "path": ".claude/settings.json",
+            "operation": "create",
+            "before_sha256": None,
+            "before_mode": None,
+            "after_sha256": "d" * 64,
+            "after_mode": 0o600,
+        }]
+
+        summary = runtime.proposal_mismatch_summary(expected, actual)
+
+        self.assertEqual(
+            summary,
+            "changed home:.agentsmith/state.json (after_mode, after_sha256); "
+            "unexpected home:.claude/settings.json",
+        )
+        self.assertNotIn("b" * 64, summary)
+        self.assertNotIn("c" * 64, summary)
+
     def test_statusline_update_is_staged_without_touching_live_installation(self) -> None:
         self.commit_and_tag("0.2.0")
         self.commit_and_tag("0.2.1", statusline_probe="RELEASE_STATUSLINE_PROBE_0_2_1")

--- a/scripts/test-update.py
+++ b/scripts/test-update.py
@@ -801,6 +801,34 @@ class UpdateCheckTests(unittest.TestCase):
         self.assertNotEqual(malformed.returncode, 0)
         self.assertIn("must be true or false", malformed.stderr)
 
+    def test_plan_rejects_future_state_schema_instead_of_reconstructing_it(self) -> None:
+        target = self.root / "future-schema-project"
+        target.mkdir()
+        environment = {
+            **os.environ,
+            "HOME": str(self.root / "future-schema-home"),
+            "CODEX_HOME": str(self.root / "future-schema-codex"),
+        }
+        installed = self.run_core(
+            "install", "--agent", "codex", "--profile", "software-dev", "--target", str(target),
+            env=environment,
+        )
+        self.assertEqual(installed.returncode, 0, installed.stdout + installed.stderr)
+        state_path = target / ".agentsmith" / "state.json"
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        state["schema_version"] = 2
+        state_path.write_text(json.dumps(state) + "\n", encoding="utf-8")
+
+        planned = self.run_core(
+            "update", "plan", "--target", str(target), "--from", str(self.root / "must-not-be-read.git"),
+            env=environment,
+        )
+
+        self.assertNotEqual(planned.returncode, 0)
+        self.assertIn("unsupported schema", planned.stderr)
+        self.assertNotIn("Update check failed", planned.stderr)
+        self.assertEqual(json.loads(state_path.read_text(encoding="utf-8"))["schema_version"], 2)
+
     def test_global_update_is_scoped_and_rolls_back_managed_home_files(self) -> None:
         self.commit_and_tag("0.2.0")
         self.commit_and_tag("0.2.1")

--- a/scripts/test-update.py
+++ b/scripts/test-update.py
@@ -784,7 +784,25 @@ class UpdateCheckTests(unittest.TestCase):
         )
         self.assertEqual(installed.returncode, 0, installed.stdout + installed.stderr)
         customized = target / ".agents" / "skills" / "example-skill" / "SKILL.md"
+        state_path = target / ".agentsmith" / "state.json"
+        original_inventory = json.loads(state_path.read_text(encoding="utf-8"))["installation"]["managed_files"]
+        original_baseline = next(
+            item["sha256"] for item in original_inventory
+            if item["path"] == ".agents/skills/example-skill/SKILL.md"
+        )
         customized.write_text(customized.read_text(encoding="utf-8") + "\nLOCAL CUSTOMIZATION\n", encoding="utf-8")
+        rerun = self.run_core(
+            "install", "--agent", "codex", "--profile", "software-dev", "--target", str(target),
+            env=environment,
+        )
+        self.assertEqual(rerun.returncode, 0, rerun.stdout + rerun.stderr)
+        rerun_inventory = json.loads(state_path.read_text(encoding="utf-8"))["installation"]["managed_files"]
+        rerun_baseline = next(
+            item["sha256"] for item in rerun_inventory
+            if item["path"] == ".agents/skills/example-skill/SKILL.md"
+        )
+        self.assertEqual(rerun_baseline, original_baseline)
+        self.assertNotEqual(rerun_baseline, hashlib.sha256(customized.read_bytes()).hexdigest())
         plan_path = self.root / "skills-plan.json"
         planned = self.run_core(
             "update", "plan", "--target", str(target), "--version", "v0.2.1",
@@ -798,6 +816,98 @@ class UpdateCheckTests(unittest.TestCase):
         handoff = target / ".agents" / "skills" / "handoff" / "SKILL.md"
         self.assertIn("RELEASE_SKILL_PROBE_0_2_1", handoff.read_text(encoding="utf-8"))
         self.assertIn("LOCAL CUSTOMIZATION", customized.read_text(encoding="utf-8"))
+
+    def test_colliding_skills_remain_foreign_until_force_replaces_them(self) -> None:
+        self.commit_and_tag("0.2.0")
+        self.commit_and_tag("0.2.1")
+        cloned = subprocess.run(
+            ["git", "clone", "-q", "--bare", str(self.seed), str(self.remote)],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(cloned.returncode, 0, cloned.stdout + cloned.stderr)
+        target = self.root / "colliding-skills-project"
+        target.mkdir()
+        environment = {
+            **os.environ,
+            "HOME": str(self.root / "colliding-skills-home"),
+            "CODEX_HOME": str(self.root / "colliding-skills-codex"),
+        }
+        collisions = [
+            target / ".agents" / "skills" / "handoff" / "SKILL.md",
+            target / ".claude" / "skills" / "handoff" / "SKILL.md",
+        ]
+        for index, path in enumerate(collisions):
+            path.parent.mkdir(parents=True)
+            if index == 0:
+                path.write_bytes((ROOT / "skills" / "handoff" / "SKILL.md").read_bytes())
+            else:
+                path.write_text(f"FOREIGN COLLISION {index}\n", encoding="utf-8")
+        before = {path: path.read_bytes() for path in collisions}
+
+        installed = self.run_core(
+            "install", "--agent", "claude", "--profile", "software-dev", "--target", str(target),
+            "--with-skills", env=environment,
+        )
+
+        self.assertEqual(installed.returncode, 0, installed.stdout + installed.stderr)
+        self.assertEqual({path: path.read_bytes() for path in collisions}, before)
+        state_path = target / ".agentsmith" / "state.json"
+        inventory_paths = {
+            item["path"]
+            for item in json.loads(state_path.read_text(encoding="utf-8"))["installation"]["managed_files"]
+        }
+        self.assertFalse(any(path.endswith("/handoff/SKILL.md") for path in inventory_paths))
+        plan_path = self.root / "colliding-skills-plan.json"
+        planned = self.run_core(
+            "update", "plan", "--target", str(target), "--version", "v0.2.1",
+            "--from", str(self.remote), "--save", str(plan_path), env=environment,
+        )
+        self.assertEqual(planned.returncode, 0, planned.stdout + planned.stderr)
+        plan = json.loads(plan_path.read_text(encoding="utf-8"))
+        self.assertFalse(any("/handoff/" in f"/{item['path']}/" for item in plan["proposed_changes"]))
+
+        applied = self.run_core("update", "apply", "--plan", str(plan_path), env=environment)
+
+        self.assertEqual(applied.returncode, 0, applied.stdout + applied.stderr)
+        self.assertEqual({path: path.read_bytes() for path in collisions}, before)
+        updated_inventory = {
+            item["path"]
+            for item in json.loads(state_path.read_text(encoding="utf-8"))["installation"]["managed_files"]
+        }
+        self.assertFalse(any(path.endswith("/handoff/SKILL.md") for path in updated_inventory))
+        uninstalled = self.run_core(
+            "install", "--agent", "claude", "--target", str(target), "--uninstall", env=environment,
+        )
+        self.assertEqual(uninstalled.returncode, 0, uninstalled.stdout + uninstalled.stderr)
+        self.assertTrue(all(path.is_file() for path in collisions))
+        self.assertEqual({path: path.read_bytes() for path in collisions}, before)
+
+        force_target = self.root / "forced-colliding-skills-project"
+        force_target.mkdir()
+        forced_collisions = [
+            force_target / ".agents" / "skills" / "handoff" / "SKILL.md",
+            force_target / ".claude" / "skills" / "handoff" / "SKILL.md",
+        ]
+        for path in forced_collisions:
+            path.parent.mkdir(parents=True)
+            path.write_text("FOREIGN BEFORE FORCE\n", encoding="utf-8")
+        forced = self.run_core(
+            "install", "--agent", "claude", "--profile", "software-dev", "--target", str(force_target),
+            "--with-skills", "--force", env=environment,
+        )
+        self.assertEqual(forced.returncode, 0, forced.stdout + forced.stderr)
+        self.assertTrue(all(b"FOREIGN BEFORE FORCE" not in path.read_bytes() for path in forced_collisions))
+        forced_inventory = {
+            item["path"]
+            for item in json.loads(
+                (force_target / ".agentsmith" / "state.json").read_text(encoding="utf-8")
+            )["installation"]["managed_files"]
+        }
+        self.assertTrue(all(
+            path.relative_to(force_target).as_posix() in forced_inventory for path in forced_collisions
+        ))
 
     def test_project_mcp_is_authenticated_updated_and_rolled_back_with_foreign_servers(self) -> None:
         self.commit_and_tag("0.2.0")

--- a/scripts/test-update.py
+++ b/scripts/test-update.py
@@ -799,6 +799,102 @@ class UpdateCheckTests(unittest.TestCase):
         self.assertIn("RELEASE_SKILL_PROBE_0_2_1", handoff.read_text(encoding="utf-8"))
         self.assertIn("LOCAL CUSTOMIZATION", customized.read_text(encoding="utf-8"))
 
+    def test_project_mcp_is_authenticated_updated_and_rolled_back_with_foreign_servers(self) -> None:
+        self.commit_and_tag("0.2.0")
+        self.commit_and_tag("0.2.1")
+        cloned = subprocess.run(
+            ["git", "clone", "-q", "--bare", str(self.seed), str(self.remote)],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(cloned.returncode, 0, cloned.stdout + cloned.stderr)
+        for agent_id in ("claude", "codex"):
+            with self.subTest(agent=agent_id):
+                target = self.root / f"{agent_id}-mcp-project"
+                target.mkdir()
+                environment = {
+                    **os.environ,
+                    "HOME": str(self.root / f"{agent_id}-mcp-home"),
+                    "CODEX_HOME": str(self.root / f"{agent_id}-mcp-codex-home"),
+                }
+                installed = self.run_core(
+                    "install", "--agent", agent_id, "--profile", "software-dev", "--target", str(target),
+                    "--with-mcp", "context7", env=environment,
+                )
+                self.assertEqual(installed.returncode, 0, installed.stdout + installed.stderr)
+                if agent_id == "claude":
+                    mcp_path = target / ".mcp.json"
+                    foreign = {
+                        "mcpServers": {"foreign": {"command": "foreign", "args": ["--keep"]}},
+                        "foreignTopLevel": {"keep": True},
+                    }
+                    mcp_path.write_text(json.dumps(foreign, indent=2) + "\n", encoding="utf-8")
+                else:
+                    mcp_path = target / ".codex" / "config.toml"
+                    mcp_path.write_text(
+                        'foreign_setting = "keep"\n\n[mcp_servers.foreign]\n'
+                        'command = "foreign"\nargs = ["--keep"]\n',
+                        encoding="utf-8",
+                    )
+                before = mcp_path.read_bytes()
+                plan_path = self.root / f"{agent_id}-mcp-plan.json"
+
+                planned = self.run_core(
+                    "update", "plan", "--target", str(target), "--version", "v0.2.1",
+                    "--from", str(self.remote), "--save", str(plan_path), env=environment,
+                )
+
+                self.assertEqual(planned.returncode, 0, planned.stdout + planned.stderr)
+                plan = json.loads(plan_path.read_text(encoding="utf-8"))
+                relative = ".mcp.json" if agent_id == "claude" else ".codex/config.toml"
+                fingerprint = next(
+                    item for item in plan["fingerprints"]
+                    if item["root"] == "target" and item["path"] == relative
+                )
+                self.assertEqual(fingerprint["sha256"], hashlib.sha256(before).hexdigest())
+                self.assertTrue(any(
+                    item["root"] == "target" and item["path"] == relative
+                    for item in plan["proposed_changes"]
+                ))
+
+                applied = self.run_core("update", "apply", "--plan", str(plan_path), env=environment)
+
+                self.assertEqual(applied.returncode, 0, applied.stdout + applied.stderr)
+                inspected = runtime.inspect_mcp(
+                    agent_id,
+                    {"skills_tools": {"mcp": {"client_support": "native"}}},
+                    target,
+                )
+                self.assertEqual(inspected["managed_names"], ["context7"])
+                self.assertEqual(inspected["foreign_names"], ["foreign"])
+                if agent_id == "claude":
+                    updated = json.loads(mcp_path.read_text(encoding="utf-8"))
+                    self.assertEqual(updated["foreignTopLevel"], {"keep": True})
+                    self.assertEqual(
+                        updated["mcpServers"]["foreign"],
+                        {"command": "foreign", "args": ["--keep"]},
+                    )
+                else:
+                    import tomllib
+                    updated = tomllib.loads(mcp_path.read_text(encoding="utf-8"))
+                    self.assertEqual(updated["foreign_setting"], "keep")
+                    self.assertEqual(
+                        updated["mcp_servers"]["foreign"],
+                        {"command": "foreign", "args": ["--keep"]},
+                    )
+                receipt_line = next(line for line in applied.stdout.splitlines() if "rollback receipt:" in line)
+                receipt_path = Path(receipt_line.split("rollback receipt:", 1)[1].strip())
+                receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+                self.assertTrue(any(item["root"] == "target" and item["path"] == relative for item in receipt["changes"]))
+
+                rolled_back = self.run_core(
+                    "update", "rollback", "--receipt", str(receipt_path), env=environment,
+                )
+
+                self.assertEqual(rolled_back.returncode, 0, rolled_back.stdout + rolled_back.stderr)
+                self.assertEqual(mcp_path.read_bytes(), before)
+
     def test_weekly_check_reports_only_and_offline_failure_does_not_block_command(self) -> None:
         home = self.root / "weekly-home"
         codex_home = self.root / "weekly-codex"

--- a/scripts/test-update.py
+++ b/scripts/test-update.py
@@ -579,7 +579,10 @@ class UpdateCheckTests(unittest.TestCase):
 
         self.assertEqual(applied.returncode, 0, applied.stdout + applied.stderr)
         self.assertIn("RELEASE_PROBE_0_2_1", (codex_home / "AGENTS.md").read_text(encoding="utf-8"))
-        self.assertIn(str(home / ".agentsmith" / "agentsmith.py"), (codex_home / "hooks.json").read_text(encoding="utf-8"))
+        self.assertIn(
+            str(home.resolve() / ".agentsmith" / "agentsmith.py"),
+            (codex_home / "hooks.json").read_text(encoding="utf-8"),
+        )
         self.assertNotIn("agentsmith-apply-", (codex_home / "hooks.json").read_text(encoding="utf-8"))
         receipt_line = next(line for line in applied.stdout.splitlines() if "rollback receipt:" in line)
         receipt_path = Path(receipt_line.split("rollback receipt:", 1)[1].strip())
@@ -786,6 +789,20 @@ class UpdateCheckTests(unittest.TestCase):
             runtime.replace_with_retry(source, destination)
         self.assertEqual(replaced.call_count, 3)
         self.assertEqual([call.args[0] for call in slept.call_args_list], [0.05, 0.1])
+
+    def test_shadow_path_translation_rewrites_canonical_aliases(self) -> None:
+        shadow = self.root / "alias" / ".." / "shadow"
+        canonical_shadow = shadow.resolve()
+        actual = self.root / "actual"
+        content = str(canonical_shadow / ".agentsmith" / "agentsmith.py").encode("utf-8")
+
+        translated = runtime.translate_shadow_paths(
+            content,
+            {"target": shadow},
+            {"target": str(actual)},
+        ).decode("utf-8")
+
+        self.assertEqual(translated, str(actual / ".agentsmith" / "agentsmith.py"))
 
     def test_native_hook_update_points_to_real_runtime_not_discarded_shadow(self) -> None:
         self.commit_and_tag("0.2.0")


### PR DESCRIPTION
## Summary

- add authenticated check, plan, apply, rollback, and opt-in weekly availability checks for stable releases
- keep candidate release code data-only until apply, then require exact staged paths, hashes, modes, and current-install fingerprints before atomic writes
- preserve rollback and manifest-aware health checks, including Windows short/long path alias canonicalization
- document the update and recovery workflow and run the 23-test updater suite across Ubuntu, macOS, and Windows

## Verification

- local full verify passed all 19 phases
- push CI run 33106533120 passed all four jobs
- updater suite passed 23 tests on Ubuntu, macOS, and Windows
- hosted Windows launcher and canonical-path checks passed

## Scope boundary

This PR does not authorize merge, live model evaluation, versioning, tagging, or release.