### PR TITLE
fix(update): reconstruct legacy Claude capabilities safely

### DIFF
--- a/agentsmith.py
+++ b/agentsmith.py
@@ -1317,6 +1317,46 @@ def validate_installation_manifest(state: dict[str, Any]) -> dict[str, Any]:
     return installation
 
 
+def detected_skill_capability(target: Path, scope: str, agents: list[str]) -> bool:
+    skill_root = home_dir() if scope == "global" else target
+    roots = [skill_root / ".agents" / "skills"]
+    if "claude" in agents:
+        roots.append(skill_root / ".claude" / "skills")
+    return any(root.is_dir() for root in roots)
+
+
+def configured_mcp_names(target: Path, scope: str, agents: list[str]) -> set[str]:
+    names: set[str] = set()
+    if "claude" in agents:
+        path = home_dir() / ".claude.json" if scope == "global" else target / ".mcp.json"
+        if path.is_file():
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError) as exc:
+                raise CliError(f"Cannot infer Claude MCP configuration from {path}; rerun install explicitly") from exc
+            servers = data.get("mcpServers", {}) if isinstance(data, dict) else None
+            if not isinstance(servers, dict):
+                raise CliError(f"Cannot infer Claude MCP configuration from {path}; rerun install explicitly")
+            names.update(servers)
+    if "codex" in agents:
+        path = codex_home() / "config.toml" if scope == "global" else target / ".codex" / "config.toml"
+        if path.is_file():
+            try:
+                data = tomllib.loads(path.read_text(encoding="utf-8"))
+            except (OSError, tomllib.TOMLDecodeError) as exc:
+                raise CliError(f"Cannot infer Codex MCP configuration from {path}; rerun install explicitly") from exc
+            servers = data.get("mcp_servers", {})
+            if not isinstance(servers, dict):
+                raise CliError(f"Cannot infer Codex MCP configuration from {path}; rerun install explicitly")
+            names.update(servers)
+    return names
+
+
+def supported_mcp_names() -> set[str]:
+    source = json.loads((ROOT / "config" / "mcp.example.json").read_text(encoding="utf-8"))["mcpServers"]
+    return set(source)
+
+
 def reconstruct_pre_manifest_installation(target: Path, scope: str, state: dict[str, Any]) -> dict[str, Any]:
     instruction_candidates = (
         [home_dir() / ".claude" / "CLAUDE.md", codex_home() / "AGENTS.md"]
@@ -1395,14 +1435,19 @@ def reconstruct_pre_manifest_installation(target: Path, scope: str, state: dict[
         declared = re.search(r'^VERSION = "([^"]+)"$', runtime.read_text(encoding="utf-8", errors="replace"), re.MULTILINE)
         if declared:
             installed_version = declared.group(1)
+    config_paths = []
+    if "claude" in agents:
+        config_paths.append(home_dir() / ".claude" / "settings.json")
+    if "codex" in agents:
+        config_paths.append(codex_home() / "config.toml")
     config_texts = []
-    for path in (home_dir() / ".claude" / "settings.json", codex_home() / "config.toml"):
+    for path in config_paths:
         if path.is_file():
             config_texts.append(path.read_text(encoding="utf-8", errors="replace"))
     combined_config = "\n".join(config_texts)
-    mcp_names = sorted(set(re.findall(r"(?m)^\[mcp_servers\.([A-Za-z0-9_-]+)\]\s*$", combined_config)))
-    skill_root = home_dir() if scope == "global" else target
-    skills = (skill_root / ".agents" / "skills").is_dir()
+    configured_mcp = configured_mcp_names(target, scope, agents)
+    mcp_names = sorted(configured_mcp if scope == "global" else configured_mcp & supported_mcp_names())
+    skills = detected_skill_capability(target, scope, agents)
     return {
         "installed_version": installed_version,
         "source": {"release": None, "commit": None},
@@ -1590,6 +1635,11 @@ def cmd_update_plan(args: argparse.Namespace) -> int:
         )
     if installation["scope"] != expected_scope:
         raise CliError(f"Installation manifest scope is {installation['scope']!r}, not {expected_scope!r}")
+    if expected_scope == "global" and installation["capabilities"].get("mcp"):
+        raise CliError(
+            "Update planning refused: detected global MCP configuration, but global MCP ownership is not supported; "
+            "rerun install with explicit choices after preserving that configuration"
+        )
     remote = args.update_from or OFFICIAL_REMOTE
     release = resolve_stable_release(remote, args.version)
     roots, fingerprints = installation_fingerprints(target, installation)
@@ -2137,6 +2187,18 @@ def validate_post_update_health(plan: dict[str, Any]) -> None:
             raise CliError(f"Post-update health check failed: managed instructions are missing or malformed in {path}")
 
     capabilities = installation["capabilities"]
+    reconstructed = any(
+        isinstance(warning, str) and warning.startswith("Pre-manifest installation choices were reconstructed")
+        for warning in plan["migration_warnings"]
+    )
+    if reconstructed:
+        observed_skills = detected_skill_capability(target, plan["scope"], installation["agents"])
+        if observed_skills and not capabilities.get("skills"):
+            raise CliError("Post-update health check failed: installed skill evidence was omitted from the manifest")
+        observed_mcp = configured_mcp_names(target, plan["scope"], installation["agents"])
+        managed_mcp = observed_mcp if plan["scope"] == "global" else observed_mcp & supported_mcp_names()
+        if managed_mcp - set(capabilities.get("mcp", [])):
+            raise CliError("Post-update health check failed: installed MCP evidence was omitted from the manifest")
     runtime_root = Path(plan["roots"]["home"]) if plan["scope"] == "global" else target
     needs_runtime = plan["scope"] == "project" or capabilities.get("handoff_hooks") or capabilities.get("ui_design_hook")
     runtime = runtime_root / ".agentsmith" / "agentsmith.py"
@@ -3206,7 +3268,17 @@ def inspect_skills(agent_id: str, agent: dict[str, Any], target: Path) -> dict[s
     roots = [target / ".agents" / "skills"]
     if agent_id == "claude":
         roots.append(target / ".claude" / "skills")
-    bundled = {path.name: directory_snapshot(path) for path in (ROOT / "skills").iterdir() if path.is_dir()}
+    bundled_root = ROOT / "skills"
+    bundled = (
+        {path.name: directory_snapshot(path) for path in bundled_root.iterdir() if path.is_dir()}
+        if bundled_root.is_dir()
+        else None
+    )
+    installation = load_state(target).get("installation", {})
+    installation = installation if isinstance(installation, dict) else {}
+    inventory = installation.get("managed_files", [])
+    inventory = inventory if isinstance(inventory, list) else []
+    inventory_root = "home" if installation.get("scope") == "global" else "target"
     managed_names: set[str] = set()
     stale_names: set[str] = set()
     foreign_names: set[str] = set()
@@ -3216,12 +3288,35 @@ def inspect_skills(agent_id: str, agent: dict[str, Any], target: Path) -> dict[s
         for installed in root.iterdir():
             if not installed.is_dir():
                 continue
-            if installed.name not in bundled:
-                foreign_names.add(installed.name)
-            elif directory_snapshot(installed) == bundled[installed.name]:
-                managed_names.add(installed.name)
+            if bundled is not None:
+                if installed.name not in bundled:
+                    foreign_names.add(installed.name)
+                elif directory_snapshot(installed) == bundled[installed.name]:
+                    managed_names.add(installed.name)
+                else:
+                    stale_names.add(installed.name)
             else:
-                stale_names.add(installed.name)
+                prefix = installed.relative_to(target).as_posix() + "/"
+                recorded = {
+                    item["path"]: item["sha256"]
+                    for item in inventory
+                    if isinstance(item, dict)
+                    and item.get("root") == inventory_root
+                    and isinstance(item.get("path"), str)
+                    and isinstance(item.get("sha256"), str)
+                    and item["path"].startswith(prefix)
+                }
+                current = {
+                    path.relative_to(target).as_posix(): file_sha256(path)
+                    for path in installed.rglob("*")
+                    if path.is_file()
+                }
+                if not recorded:
+                    foreign_names.add(installed.name)
+                elif current == recorded:
+                    managed_names.add(installed.name)
+                else:
+                    stale_names.add(installed.name)
     state = "stale" if stale_names else ("managed" if managed_names else ("foreign" if foreign_names else "missing"))
     return {
         "declared": str(agent.get("skills_tools", {}).get("agent_skills", {}).get("client_support", "unverified")),

--- a/docs/23-updating-existing-installations.md
+++ b/docs/23-updating-existing-installations.md
@@ -1,0 +1,137 @@
+# Updating existing AgentSmith installations
+
+This runbook is for installations created before AgentSmith included its staged updater. The first
+update is a bootstrap: run the updater from a temporary checkout of a stable release, point it at
+the existing installation, and keep planning separate from applying.
+
+## Current release and known blocker
+
+The current stable release is `v0.2.1`, commit
+`b838a77f1647cc6589009e8269c1e610a1a796a4`.
+
+**Do not apply `v0.2.1` to a pre-manifest, Claude-only installation when skills exist only under
+`~/.claude/skills` or its user-scope MCP configuration exists only in `~/.claude.json`.** In that legacy shape,
+`update plan --global` can incorrectly reconstruct `skills: false` and `mcp: []`, produce no skill
+changes, and report success. The post-update skill check is then skipped because it trusts the same
+false capability value.
+
+The defect is recorded in
+[`feedback/0020-legacy-claude-reconstruction-skipped-skills-and-mcp.md`](feedback/0020-legacy-claude-reconstruction-skipped-skills-and-mcp.md).
+Wait for a fixed release before updating that installation shape. Do not compensate by manually
+editing the authenticated plan.
+
+## Before updating
+
+Make the installation's current state recoverable. For a project installation, commit or otherwise
+back up local work and start from a clean working tree. This makes the updater's changes easy to
+review and keeps locally evolved rules visible.
+
+The preservation boundary is:
+
+- content outside AgentSmith-managed instruction markers remains in place;
+- customized installed skills are retained;
+- research, source material, and unowned configuration are not deletion targets;
+- edits inside AgentSmith-managed instruction blocks are regenerated and can be replaced.
+
+Move any intentional edits inside a managed block into the appropriate source `core/` or `profiles/`
+file, or preserve them separately, before applying an update.
+
+## Bootstrap the updater once per machine
+
+The temporary checkout does not change an installation. It supplies the new updater to an old
+installation that does not have one yet.
+
+```bash
+AGENTSMITH_BOOTSTRAP_DIR="$(mktemp -d)"
+
+git clone --depth 1 --branch v0.2.1 \
+  https://github.com/PromptPartner/agentsmith.git \
+  "$AGENTSMITH_BOOTSTRAP_DIR"
+
+git -C "$AGENTSMITH_BOOTSTRAP_DIR" rev-parse HEAD
+```
+
+For `v0.2.1`, the final command must print:
+
+```text
+b838a77f1647cc6589009e8269c1e610a1a796a4
+```
+
+## Update one project installation
+
+Use a unique plan filename for every installation. Planning reads and stages the proposed release,
+but does not modify the target.
+
+```bash
+AGENTSMITH_TARGET="/absolute/path/to/project"
+AGENTSMITH_PLAN="/tmp/agentsmith-project-name-v0.2.1-plan.json"
+
+git -C "$AGENTSMITH_TARGET" status --short
+
+python3 "$AGENTSMITH_BOOTSTRAP_DIR/agentsmith.py" update plan \
+  --target "$AGENTSMITH_TARGET" \
+  --version v0.2.1 \
+  --save "$AGENTSMITH_PLAN"
+
+python3 -m json.tool "$AGENTSMITH_PLAN" | less
+```
+
+Inspect `migration_warnings`, `installation.capabilities`, and `proposed_changes`. Stop if a
+capability reported by `doctor` disappears from the reconstructed installation. Press `q` to leave
+`less`.
+
+Applying is the state-changing approval boundary. Run it only after approving that exact plan:
+
+```bash
+python3 "$AGENTSMITH_BOOTSTRAP_DIR/agentsmith.py" update apply \
+  --plan "$AGENTSMITH_PLAN"
+```
+
+Apply prints the path to a machine-local rollback receipt. Keep it until the update is accepted,
+then inspect and verify the installed result:
+
+```bash
+git -C "$AGENTSMITH_TARGET" diff
+
+python3 "$AGENTSMITH_TARGET/.agentsmith/agentsmith.py" doctor \
+  --agent all \
+  --target "$AGENTSMITH_TARGET" \
+  --strict
+```
+
+## Update a global installation
+
+Global scope is separate from every project scope. Create and inspect its own plan:
+
+```bash
+AGENTSMITH_PLAN="/tmp/agentsmith-global-v0.2.1-plan.json"
+
+python3 "$AGENTSMITH_BOOTSTRAP_DIR/agentsmith.py" update plan \
+  --global \
+  --version v0.2.1 \
+  --save "$AGENTSMITH_PLAN"
+
+python3 -m json.tool "$AGENTSMITH_PLAN" | less
+```
+
+Do not apply this plan if the legacy Claude-only blocker above matches the installation. Otherwise,
+after approving the plan:
+
+```bash
+python3 "$AGENTSMITH_BOOTSTRAP_DIR/agentsmith.py" update apply \
+  --plan "$AGENTSMITH_PLAN"
+```
+
+## Roll back
+
+Rollback restores the exact pre-update bytes recorded during apply. It refuses to overwrite files
+that changed again after the update.
+
+```bash
+python3 "$AGENTSMITH_BOOTSTRAP_DIR/agentsmith.py" update rollback \
+  --receipt "/path/printed/by/update-apply.json"
+```
+
+Plans and receipts are authenticated with the local account's
+`~/.agentsmith/update-integrity.key`. Do not edit a plan or receipt, and do not copy one between
+machines. Repeat plan, inspection, and apply separately for every installation.

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,7 @@ is a harness" to "make it your team's own," with the glossary as the appendix:
 | [`20-wayfinding-spec-flow.md`](20-wayfinding-spec-flow.md) | Turn a foggy effort into an accepted terminal spec without collapsing decision and implementation tickets. |
 | [`21-autonomous-runs.md`](21-autonomous-runs.md) | Run one accepted coding ticket overnight through a local maker/checker controller. |
 | [`22-compatibility-contract.md`](22-compatibility-contract.md) | Support tiers, evidence vocabulary, canonical instructions, and certification rules. |
+| [`23-updating-existing-installations.md`](23-updating-existing-installations.md) | Bootstrap staged updates safely, preserve local evolution, and check known legacy blockers. |
 | [`feedback/README.md`](feedback/README.md) | The post-incident log: how lessons become system changes. |
 | [`research/`](research/) | Source research the docs above were distilled from. |
 

--- a/docs/feedback/0020-legacy-claude-reconstruction-skipped-skills-and-mcp.md
+++ b/docs/feedback/0020-legacy-claude-reconstruction-skipped-skills-and-mcp.md
@@ -1,0 +1,77 @@
+# Feedback 0020: legacy claude reconstruction skipped skills and mcp
+
+> A harness post-incident. The point is not to fix THIS bug — it's to change the
+> SYSTEM so this CLASS of mistake is less likely next time (core/60). Keep it small,
+> specific, and traceable to the incident. Never delete this; archive if obsolete (R9).
+
+- **Date:** 2026-08-28
+- **Status:** open   <!-- open | applied | wont-fix -->
+- **Cost:** A real legacy Claude-only upgrade reported success while silently omitting installed
+  skills and MCP capabilities. The operator had to compare `doctor` with the saved plan to catch
+  the near-miss before relying on the updated harness.
+
+## 1. Evidence / symptom
+
+On stable `v0.2.1` (`b838a77f`), a pre-manifest Claude-only global installation had skills under
+`~/.claude/skills` but no canonical `~/.agents/skills` directory. User-scope Claude MCP configuration
+was in `~/.claude.json`. Before updating:
+
+- `doctor --agent claude --target /root` reported `skills stale` and `mcp missing`;
+- `update plan --global` reconstructed `capabilities` as `skills: false` and `mcp: []`;
+- the saved plan contained zero skill entries in `proposed_changes` and exited successfully.
+
+The resulting core instructions referenced `/writing-rules`, but the skill was never installed.
+
+## 2. Failure mechanism
+
+`reconstruct_pre_manifest_installation()` uses Codex-shaped probes for both agents:
+
+- skill detection checks only `(skill_root / ".agents" / "skills").is_dir()`, while
+  `install_skills()` writes both `.agents/skills` and `.claude/skills` for Claude and
+  `inspect_skills()` correctly inspects both roots;
+- MCP detection applies a TOML table regex to concatenated Claude JSON and Codex TOML. A Claude
+  `mcpServers` object cannot match a TOML `[mcp_servers.NAME]` table.
+
+The false reconstruction compounds because the post-update skill health check runs only when
+`capabilities.get("skills")` is true. The incorrect value therefore disables the check that should
+catch the omitted capability. No legacy Claude-only migration fixture exercises this shape.
+
+## 3. Bounded edit
+
+Reconstruct legacy capabilities per selected agent using the same roots and file formats as the
+installer and doctor:
+
+- recognize either canonical `.agents/skills` or Claude's legacy `.claude/skills` as evidence that
+  skills were installed;
+- parse Claude `mcpServers` as JSON and Codex `mcp_servers` as TOML rather than scanning a combined
+  text blob;
+- fail planning explicitly if a detected legacy capability cannot be migrated safely;
+- make post-update validation compare reconstructed capability evidence with the installed result,
+  so a false capability value cannot suppress its own guard.
+
+## 4. Named surface
+
+- Production: `agentsmith.py`, specifically `reconstruct_pre_manifest_installation()` and the
+  post-update capability checks.
+- Deterministic guard: `scripts/test-update.py`, already the `update` phase in
+  `.harness/verify.conf` and part of the three-platform CI matrix.
+- Operator warning until fixed: `docs/23-updating-existing-installations.md`.
+
+## 5. Non-regression validation
+
+Implemented locally; status remains `open` until the cross-platform release gate runs. The new
+fixtures cover a pre-manifest Claude-only global install containing only `.claude/skills` plus a
+`~/.claude.json` `mcpServers` object and no `.agents` directory. They prove:
+
+1. the unfixed implementation reconstructs `skills: false` for the reported global shape;
+2. planning after the fix detects both capabilities and refuses with the explicit global MCP
+   ownership error, never a successful omission;
+3. a supported project apply creates the canonical skill root, keeps the Claude mirror, retains
+   Claude JSON MCP, and passes both apply-time and installed-runtime strict health checks;
+4. an installation with no selected-agent skill or MCP evidence is not falsely upgraded into those
+   capabilities;
+5. post-update validation rejects authenticated reconstructed state whose false skill or empty MCP
+   value would otherwise suppress its own check.
+
+The full 19-phase verification suite must then pass on every supported CI platform before this
+entry can move to `applied`.

--- a/docs/feedback/0021-installed-runtime-doctor-required-unshipped-skill-sources.md
+++ b/docs/feedback/0021-installed-runtime-doctor-required-unshipped-skill-sources.md
@@ -1,0 +1,40 @@
+# Feedback 0021: installed runtime doctor required unshipped skill sources
+
+> A harness post-incident. Keep this small, specific, and traceable to the observed failure.
+
+- **Date:** 2026-08-28
+- **Status:** applied
+- **Cost:** The updater's apply-time health check passed, but invoking `doctor --strict` through the
+  installed project runtime crashed instead of inspecting the updated installation.
+
+## 1. Evidence / symptom
+
+The legacy Claude migration fixture applied successfully. A subsequent invocation of
+`.agentsmith/agentsmith.py doctor --agent claude --strict` raised `FileNotFoundError` while reading
+`.agentsmith/skills`. Project runtime installation copies the runtime and registry, not bundled skill
+source directories. Apply-time doctor did not expose this because it runs from the complete staged
+release checkout.
+
+## 2. Failure mechanism
+
+`inspect_skills()` assumed `ROOT/skills` always exists. That is true in a source checkout and false
+for the installed project runtime, so verification covered a different runtime shape than operators
+actually invoke.
+
+## 3. Bounded edit
+
+When bundled skill sources exist, retain the exact source comparison. When they do not, classify
+installed skills against the schema-v1 manifest's managed-file paths and hashes. Treat directories
+without inventory as foreign rather than crashing.
+
+## 4. Named surface
+
+- Production: `agentsmith.py`, `inspect_skills()`.
+- Deterministic guard: the legacy Claude plan/apply fixture in `scripts/test-update.py` invokes the
+  installed runtime's strict doctor after apply.
+
+## 5. Non-regression validation
+
+`test_legacy_claude_project_capabilities_survive_plan_apply_and_strict_health` now exercises plan,
+apply, installed runtime, and strict doctor. It fails with the prior `FileNotFoundError` and passes
+with the inventory fallback.

--- a/scripts/test-update.py
+++ b/scripts/test-update.py
@@ -658,6 +658,227 @@ class UpdateCheckTests(unittest.TestCase):
         self.assertEqual(plan["installation"]["safety"], {"codex": "trusted"})
         self.assertEqual(plan["installation"]["operator"]["name"], "Legacy Operator")
 
+    def test_legacy_claude_only_global_reconstruction_detects_capabilities_before_failing_closed(self) -> None:
+        self.commit_and_tag(CURRENT_VERSION)
+        self.commit_and_tag(NEXT_VERSION)
+        cloned = subprocess.run(
+            ["git", "clone", "-q", "--bare", str(self.seed), str(self.remote)],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(cloned.returncode, 0, cloned.stdout + cloned.stderr)
+        home = self.root / "legacy-claude-global-home"
+        codex_home = self.root / "legacy-claude-global-codex"
+        environment = {**os.environ, "HOME": str(home), "CODEX_HOME": str(codex_home)}
+        installed = self.run_core(
+            "install", "--agent", "claude", "--global", "--with-skills", env=environment,
+        )
+        self.assertEqual(installed.returncode, 0, installed.stdout + installed.stderr)
+        state_path = home / ".agentsmith" / "state.json"
+        legacy_state = json.loads(state_path.read_text(encoding="utf-8"))
+        legacy_state.pop("schema_version")
+        legacy_state.pop("installation")
+        state_path.write_text(json.dumps(legacy_state, indent=2) + "\n", encoding="utf-8")
+        shutil.rmtree(home / ".agents")
+        self.assertTrue((home / ".claude" / "skills").is_dir())
+        self.assertFalse((home / ".agents").exists())
+        (home / ".claude.json").write_text(
+            json.dumps({"mcpServers": {"context7": {"command": "legacy-context7"}}}, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+        with mock.patch.dict(os.environ, environment, clear=False):
+            reconstructed = runtime.reconstruct_pre_manifest_installation(home.resolve(), "global", legacy_state)
+
+        self.assertEqual(reconstructed["agents"], ["claude"])
+        self.assertTrue(reconstructed["capabilities"]["skills"])
+        self.assertEqual(reconstructed["capabilities"]["mcp"], ["context7"])
+        before = state_path.read_bytes()
+        plan_path = self.root / "legacy-claude-global-plan.json"
+
+        planned = self.run_core(
+            "update", "plan", "--global", "--version", NEXT_TAG,
+            "--from", str(self.remote), "--save", str(plan_path), env=environment,
+        )
+
+        self.assertNotEqual(planned.returncode, 0)
+        self.assertIn("global MCP ownership is not supported", planned.stderr)
+        self.assertFalse(plan_path.exists())
+        self.assertEqual(state_path.read_bytes(), before)
+
+    def test_legacy_claude_project_capabilities_survive_plan_apply_and_strict_health(self) -> None:
+        self.commit_and_tag(CURRENT_VERSION)
+        self.commit_and_tag(NEXT_VERSION)
+        cloned = subprocess.run(
+            ["git", "clone", "-q", "--bare", str(self.seed), str(self.remote)],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(cloned.returncode, 0, cloned.stdout + cloned.stderr)
+        target = self.root / "legacy-claude-project"
+        target.mkdir()
+        environment = {
+            **os.environ,
+            "HOME": str(self.root / "legacy-claude-project-home"),
+            "CODEX_HOME": str(self.root / "legacy-claude-project-codex"),
+        }
+        installed = self.run_core(
+            "install", "--agent", "claude", "--profile", "software-dev", "--target", str(target),
+            "--with-skills", "--with-mcp", "context7", env=environment,
+        )
+        self.assertEqual(installed.returncode, 0, installed.stdout + installed.stderr)
+        state_path = target / ".agentsmith" / "state.json"
+        legacy_state = json.loads(state_path.read_text(encoding="utf-8"))
+        legacy_state.pop("schema_version")
+        legacy_state.pop("installation")
+        state_path.write_text(json.dumps(legacy_state, indent=2) + "\n", encoding="utf-8")
+        shutil.rmtree(target / ".agents")
+        claude_skill = target / ".claude" / "skills" / "handoff" / "SKILL.md"
+        claude_skill_before = claude_skill.read_bytes()
+        mcp_path = target / ".mcp.json"
+        mcp_before = mcp_path.read_bytes()
+        plan_path = self.root / "legacy-claude-project-plan.json"
+
+        planned = self.run_core(
+            "update", "plan", "--target", str(target), "--version", NEXT_TAG,
+            "--from", str(self.remote), "--save", str(plan_path), env=environment,
+        )
+
+        self.assertEqual(planned.returncode, 0, planned.stdout + planned.stderr)
+        plan = json.loads(plan_path.read_text(encoding="utf-8"))
+        self.assertEqual(plan["schema_version"], 1)
+        self.assertTrue(plan["migration_warnings"])
+        self.assertEqual(
+            plan["installation"]["capabilities"],
+            {"handoff_hooks": False, "hooks": False, "mcp": ["context7"], "skills": True, "ui_design_hook": False},
+        )
+        self.assertTrue(any(item["path"].startswith(".agents/skills/") for item in plan["proposed_changes"]))
+
+        applied = self.run_core("update", "apply", "--plan", str(plan_path), env=environment)
+
+        self.assertEqual(applied.returncode, 0, applied.stdout + applied.stderr)
+        canonical_skill = target / ".agents" / "skills" / "handoff" / "SKILL.md"
+        self.assertIn(NEXT_SKILL_PROBE, canonical_skill.read_text(encoding="utf-8"))
+        self.assertEqual(claude_skill.read_bytes(), claude_skill_before)
+        self.assertEqual(mcp_path.read_bytes(), mcp_before)
+        updated = json.loads(state_path.read_text(encoding="utf-8"))
+        self.assertEqual(updated["schema_version"], 1)
+        self.assertEqual(updated["installation"]["capabilities"], plan["installation"]["capabilities"])
+        doctor = subprocess.run(
+            [
+                sys.executable, str(target / ".agentsmith" / "agentsmith.py"),
+                "doctor", "--agent", "claude", "--target", str(target), "--strict", "--json",
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+            env=environment,
+        )
+        self.assertEqual(doctor.returncode, 0, doctor.stdout + doctor.stderr)
+        doctor_result = json.loads(doctor.stdout)
+        self.assertEqual(doctor_result["claude"]["skills"]["state"], "managed")
+        self.assertIn("handoff", doctor_result["claude"]["skills"]["managed_names"])
+
+        updated["installation"] = []
+        state_path.write_text(json.dumps(updated, indent=2) + "\n", encoding="utf-8")
+        malformed_state_doctor = subprocess.run(
+            [
+                sys.executable, str(target / ".agentsmith" / "agentsmith.py"),
+                "doctor", "--agent", "claude", "--target", str(target), "--strict", "--json",
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+            env=environment,
+        )
+        self.assertEqual(
+            malformed_state_doctor.returncode, 0, malformed_state_doctor.stdout + malformed_state_doctor.stderr
+        )
+        malformed_result = json.loads(malformed_state_doctor.stdout)
+        self.assertEqual(malformed_result["claude"]["skills"]["state"], "foreign")
+
+    def test_pre_manifest_reconstruction_does_not_invent_unselected_or_absent_capabilities(self) -> None:
+        target = self.root / "legacy-empty-claude-project"
+        target.mkdir()
+        environment = {
+            **os.environ,
+            "HOME": str(self.root / "legacy-empty-home"),
+            "CODEX_HOME": str(self.root / "legacy-empty-codex"),
+        }
+        installed = self.run_core(
+            "install", "--agent", "claude", "--profile", "software-dev", "--target", str(target),
+            env=environment,
+        )
+        self.assertEqual(installed.returncode, 0, installed.stdout + installed.stderr)
+        state_path = target / ".agentsmith" / "state.json"
+        legacy_state = json.loads(state_path.read_text(encoding="utf-8"))
+        legacy_state.pop("schema_version")
+        legacy_state.pop("installation")
+        state_path.write_text(json.dumps(legacy_state, indent=2) + "\n", encoding="utf-8")
+        codex_config = Path(environment["CODEX_HOME"]) / "config.toml"
+        codex_config.parent.mkdir(parents=True)
+        codex_config.write_text('[mcp_servers.context7]\ncommand = "unselected"\n', encoding="utf-8")
+
+        with mock.patch.dict(os.environ, environment, clear=False):
+            reconstructed = runtime.reconstruct_pre_manifest_installation(target.resolve(), "project", legacy_state)
+
+        self.assertEqual(reconstructed["agents"], ["claude"])
+        self.assertFalse(reconstructed["capabilities"]["skills"])
+        self.assertEqual(reconstructed["capabilities"]["mcp"], [])
+
+    def test_post_update_health_rejects_false_reconstructed_capabilities(self) -> None:
+        home = self.root / "false-reconstruction-home"
+        codex_home = self.root / "false-reconstruction-codex"
+        environment = {**os.environ, "HOME": str(home), "CODEX_HOME": str(codex_home)}
+        installed = self.run_core(
+            "install", "--agent", "claude", "--global", "--with-skills", env=environment,
+        )
+        self.assertEqual(installed.returncode, 0, installed.stdout + installed.stderr)
+        (home / ".claude.json").write_text(
+            json.dumps({"mcpServers": {"context7": {"command": "legacy-context7"}}}, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        state_path = home / ".agentsmith" / "state.json"
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        installation = state["installation"]
+        installation["source"] = {"release": f"v{CURRENT_VERSION}", "commit": "a" * 40}
+        installation["capabilities"]["skills"] = False
+        state_path.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
+        plan = {
+            "scope": "global",
+            "target": str(home.resolve()),
+            "roots": {
+                "target": str(home.resolve()),
+                "home": str(home.resolve()),
+                "codex_home": str(codex_home.resolve()),
+            },
+            "release": {
+                "tag": f"v{CURRENT_VERSION}",
+                "version": CURRENT_VERSION,
+                "commit": "a" * 40,
+            },
+            "installation": installation,
+            "proposed_changes": [],
+            "migration_warnings": [
+                "Pre-manifest installation choices were reconstructed from managed markers and ownership state; "
+                "apply will persist schema version 1."
+            ],
+        }
+
+        with mock.patch.dict(os.environ, environment, clear=False), self.assertRaisesRegex(
+            runtime.CliError, "skill evidence was omitted"
+        ):
+            runtime.validate_post_update_health(plan)
+
+        installation["capabilities"]["skills"] = True
+        state_path.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
+        with mock.patch.dict(os.environ, environment, clear=False), self.assertRaisesRegex(
+            runtime.CliError, "MCP evidence was omitted"
+        ):
+            runtime.validate_post_update_health(plan)
+
     def test_assemble_only_is_preserved_for_project_and_global_updates(self) -> None:
         self.commit_and_tag(CURRENT_VERSION)
         self.commit_and_tag(NEXT_VERSION)


### PR DESCRIPTION
## Why

Stable v0.2.1 can silently reconstruct some pre-manifest Claude-only installations as `skills: false` and `mcp: []`, omitting capabilities from an apparently successful update plan.

## Changes

- reconstruct skills and MCP from the selected agent's actual roots and configuration formats
- refuse legacy global MCP migration explicitly because AgentSmith does not own global MCP
- validate reconstructed skill and MCP evidence independently of the manifest value
- exercise global fail-closed and supported project plan/apply paths end to end
- make installed-runtime doctor classify skills from schema-v1 inventory when source bundles are absent
- add the temporary v0.2.1 rollout warning and incident records

Schema remains version 1. `update apply --plan` remains the explicit approval boundary.

## Verification

- failing fixture reproduced `skills: false` before the fix
- 38 updater tests passed
- all 19 local verification phases passed
- changed Markdown rendered successfully
- independent review completed with no remaining findings

No affected v0.2.1 installation was updated.