### PR TITLE
chore(release): publish AgentSmith 0.2.2

### DIFF
--- a/agentsmith.py
+++ b/agentsmith.py
@@ -32,7 +32,7 @@ import urllib.error
 import urllib.request
 
 
-VERSION = "0.2.1"
+VERSION = "0.2.2"
 OFFICIAL_REMOTE = "https://github.com/PromptPartner/agentsmith.git"
 ROOT = Path(__file__).resolve().parent
 REGISTRY_PATH = ROOT / "config" / "agents.json"

--- a/docs/23-updating-existing-installations.md
+++ b/docs/23-updating-existing-installations.md
@@ -4,10 +4,9 @@ This runbook is for installations created before AgentSmith included its staged 
 update is a bootstrap: run the updater from a temporary checkout of a stable release, point it at
 the existing installation, and keep planning separate from applying.
 
-## Current release and known blocker
+## Current release and v0.2.1 blocker
 
-The current stable release is `v0.2.1`, commit
-`b838a77f1647cc6589009e8269c1e610a1a796a4`.
+The current stable release is `v0.2.2`.
 
 **Do not apply `v0.2.1` to a pre-manifest, Claude-only installation when skills exist only under
 `~/.claude/skills` or its user-scope MCP configuration exists only in `~/.claude.json`.** In that legacy shape,
@@ -15,10 +14,12 @@ The current stable release is `v0.2.1`, commit
 changes, and report success. The post-update skill check is then skipped because it trusts the same
 false capability value.
 
-The defect is recorded in
+The defect is fixed in `v0.2.2` and recorded in
 [`feedback/0020-legacy-claude-reconstruction-skipped-skills-and-mcp.md`](feedback/0020-legacy-claude-reconstruction-skipped-skills-and-mcp.md).
-Wait for a fixed release before updating that installation shape. Do not compensate by manually
-editing the authenticated plan.
+The fixed planner reconstructs Claude skill evidence and refuses global MCP migration explicitly,
+because AgentSmith does not own global MCP configuration. This refusal is fail-closed: follow its
+reinstall guidance after preserving the configuration. Do not compensate by manually editing the
+authenticated plan.
 
 ## Before updating
 
@@ -44,18 +45,16 @@ installation that does not have one yet.
 ```bash
 AGENTSMITH_BOOTSTRAP_DIR="$(mktemp -d)"
 
-git clone --depth 1 --branch v0.2.1 \
+git clone --depth 1 --branch v0.2.2 \
   https://github.com/PromptPartner/agentsmith.git \
   "$AGENTSMITH_BOOTSTRAP_DIR"
 
 git -C "$AGENTSMITH_BOOTSTRAP_DIR" rev-parse HEAD
+git -C "$AGENTSMITH_BOOTSTRAP_DIR" describe --tags --exact-match
 ```
 
-For `v0.2.1`, the final command must print:
-
-```text
-b838a77f1647cc6589009e8269c1e610a1a796a4
-```
+The final command must print `v0.2.2`. This proves the bootstrap is the immutable release tag rather
+than an unreviewed branch checkout.
 
 ## Update one project installation
 
@@ -64,13 +63,13 @@ but does not modify the target.
 
 ```bash
 AGENTSMITH_TARGET="/absolute/path/to/project"
-AGENTSMITH_PLAN="/tmp/agentsmith-project-name-v0.2.1-plan.json"
+AGENTSMITH_PLAN="/tmp/agentsmith-project-name-v0.2.2-plan.json"
 
 git -C "$AGENTSMITH_TARGET" status --short
 
 python3 "$AGENTSMITH_BOOTSTRAP_DIR/agentsmith.py" update plan \
   --target "$AGENTSMITH_TARGET" \
-  --version v0.2.1 \
+  --version v0.2.2 \
   --save "$AGENTSMITH_PLAN"
 
 python3 -m json.tool "$AGENTSMITH_PLAN" | less
@@ -104,18 +103,19 @@ python3 "$AGENTSMITH_TARGET/.agentsmith/agentsmith.py" doctor \
 Global scope is separate from every project scope. Create and inspect its own plan:
 
 ```bash
-AGENTSMITH_PLAN="/tmp/agentsmith-global-v0.2.1-plan.json"
+AGENTSMITH_PLAN="/tmp/agentsmith-global-v0.2.2-plan.json"
 
 python3 "$AGENTSMITH_BOOTSTRAP_DIR/agentsmith.py" update plan \
   --global \
-  --version v0.2.1 \
+  --version v0.2.2 \
   --save "$AGENTSMITH_PLAN"
 
 python3 -m json.tool "$AGENTSMITH_PLAN" | less
 ```
 
-Do not apply this plan if the legacy Claude-only blocker above matches the installation. Otherwise,
-after approving the plan:
+For the legacy Claude-only shape described above, v0.2.2 refuses planning when user-scope MCP is
+present; it does not create an applyable plan that omits the capability. Otherwise, after approving
+the plan:
 
 ```bash
 python3 "$AGENTSMITH_BOOTSTRAP_DIR/agentsmith.py" update apply \

--- a/docs/feedback/0020-legacy-claude-reconstruction-skipped-skills-and-mcp.md
+++ b/docs/feedback/0020-legacy-claude-reconstruction-skipped-skills-and-mcp.md
@@ -5,7 +5,7 @@
 > specific, and traceable to the incident. Never delete this; archive if obsolete (R9).
 
 - **Date:** 2026-08-28
-- **Status:** open   <!-- open | applied | wont-fix -->
+- **Status:** applied   <!-- open | applied | wont-fix -->
 - **Cost:** A real legacy Claude-only upgrade reported success while silently omitting installed
   skills and MCP capabilities. The operator had to compare `doctor` with the saved plan to catch
   the near-miss before relying on the updated harness.
@@ -59,9 +59,8 @@ installer and doctor:
 
 ## 5. Non-regression validation
 
-Implemented locally; status remains `open` until the cross-platform release gate runs. The new
-fixtures cover a pre-manifest Claude-only global install containing only `.claude/skills` plus a
-`~/.claude.json` `mcpServers` object and no `.agents` directory. They prove:
+The new fixtures cover a pre-manifest Claude-only global install containing only `.claude/skills`
+plus a `~/.claude.json` `mcpServers` object and no `.agents` directory. They prove:
 
 1. the unfixed implementation reconstructs `skills: false` for the reported global shape;
 2. planning after the fix detects both capabilities and refuses with the explicit global MCP
@@ -73,5 +72,6 @@ fixtures cover a pre-manifest Claude-only global install containing only `.claud
 5. post-update validation rejects authenticated reconstructed state whose false skill or empty MCP
    value would otherwise suppress its own check.
 
-The full 19-phase verification suite must then pass on every supported CI platform before this
-entry can move to `applied`.
+The full 19-phase local gate passed. PR #22 then passed the repository's cross-platform CI matrix
+on Ubuntu, macOS, and Windows, including the updater fixtures on every platform and the existing
+POSIX guardrails on Ubuntu.


### PR DESCRIPTION
## Why

PR #22 fixed the legacy Claude updater blocker, but existing installations can only consume that fix after it is available under a stable semantic-version tag. This release publishes the fail-closed reconstruction path as `v0.2.2`.

## Changes

- bump the AgentSmith runtime version to `0.2.2`
- update the legacy-install runbook to bootstrap and plan against `v0.2.2`
- retain the explicit warning that `v0.2.1` is unsafe for the affected legacy shape
- record the local and cross-platform non-regression evidence as applied

The updater state, plan, and rollback receipt remain schema version 1. `update apply --plan` remains the explicit installation approval boundary.

## Verification

- all 19 verification phases passed on the `0.2.2` tree
- all 38 updater tests passed while exercising a derived `0.2.2 -> 0.2.3` transition
- changed Markdown rendered successfully
- release diff received an independent review with no findings
- no dependencies changed; the changed-file secret and leak gates passed

After final PR CI, this PR is intended to be merged, tagged `v0.2.2`, and published as GitHub release `AgentSmith 0.2.2`.