### PR TITLE
fix(update): preserve foreign global MCP during migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ docs/feedback/[0-9]*.md
 !docs/feedback/0016-windows-doctor-corrupted-unicode-git-paths.md
 !docs/feedback/0017-windows-evaluator-fake-client-reparsed-structured-argv.md
 !docs/feedback/0018-windows-statusline-wrapper-reencoded-claude-json-stdin.md
+!docs/feedback/0022-global-update-blocked-by-foreign-mcp.md

--- a/agentsmith.py
+++ b/agentsmith.py
@@ -1357,6 +1357,12 @@ def supported_mcp_names() -> set[str]:
     return set(source)
 
 
+def managed_mcp_names(target: Path, scope: str, agents: list[str]) -> set[str]:
+    if scope == "global":
+        return set()
+    return configured_mcp_names(target, scope, agents) & supported_mcp_names()
+
+
 def reconstruct_pre_manifest_installation(target: Path, scope: str, state: dict[str, Any]) -> dict[str, Any]:
     instruction_candidates = (
         [home_dir() / ".claude" / "CLAUDE.md", codex_home() / "AGENTS.md"]
@@ -1445,8 +1451,7 @@ def reconstruct_pre_manifest_installation(target: Path, scope: str, state: dict[
         if path.is_file():
             config_texts.append(path.read_text(encoding="utf-8", errors="replace"))
     combined_config = "\n".join(config_texts)
-    configured_mcp = configured_mcp_names(target, scope, agents)
-    mcp_names = sorted(configured_mcp if scope == "global" else configured_mcp & supported_mcp_names())
+    mcp_names = sorted(managed_mcp_names(target, scope, agents))
     skills = detected_skill_capability(target, scope, agents)
     return {
         "installed_version": installed_version,
@@ -2195,8 +2200,7 @@ def validate_post_update_health(plan: dict[str, Any]) -> None:
         observed_skills = detected_skill_capability(target, plan["scope"], installation["agents"])
         if observed_skills and not capabilities.get("skills"):
             raise CliError("Post-update health check failed: installed skill evidence was omitted from the manifest")
-        observed_mcp = configured_mcp_names(target, plan["scope"], installation["agents"])
-        managed_mcp = observed_mcp if plan["scope"] == "global" else observed_mcp & supported_mcp_names()
+        managed_mcp = managed_mcp_names(target, plan["scope"], installation["agents"])
         if managed_mcp - set(capabilities.get("mcp", [])):
             raise CliError("Post-update health check failed: installed MCP evidence was omitted from the manifest")
     runtime_root = Path(plan["roots"]["home"]) if plan["scope"] == "global" else target

--- a/docs/23-updating-existing-installations.md
+++ b/docs/23-updating-existing-installations.md
@@ -4,7 +4,7 @@ This runbook is for installations created before AgentSmith included its staged 
 update is a bootstrap: run the updater from a temporary checkout of a stable release, point it at
 the existing installation, and keep planning separate from applying.
 
-## Current release and v0.2.1 blocker
+## Current release blockers
 
 The current stable release is `v0.2.2`.
 
@@ -14,12 +14,16 @@ The current stable release is `v0.2.2`.
 changes, and report success. The post-update skill check is then skipped because it trusts the same
 false capability value.
 
-The defect is fixed in `v0.2.2` and recorded in
+The silent capability-loss defect is fixed in `v0.2.2` and recorded in
 [`feedback/0020-legacy-claude-reconstruction-skipped-skills-and-mcp.md`](feedback/0020-legacy-claude-reconstruction-skipped-skills-and-mcp.md).
-The fixed planner reconstructs Claude skill evidence and refuses global MCP migration explicitly,
-because AgentSmith does not own global MCP configuration. This refusal is fail-closed: follow its
-reinstall guidance after preserving the configuration. Do not compensate by manually editing the
-authenticated plan.
+However, `v0.2.2` has a global-update regression: any user-scope MCP server in `~/.claude.json` or
+the Codex user configuration blocks `update plan --global`. AgentSmith cannot own global MCP
+servers, so those entries are foreign configuration and should be preserved and ignored. The
+correction is recorded in
+[`feedback/0022-global-update-blocked-by-foreign-mcp.md`](feedback/0022-global-update-blocked-by-foreign-mcp.md).
+Until that correction is published in a later stable release, use `v0.2.2` only for project updates
+on affected machines. Do not remove foreign MCP configuration or edit an authenticated plan as a
+workaround.
 
 ## Before updating
 
@@ -113,9 +117,9 @@ python3 "$AGENTSMITH_BOOTSTRAP_DIR/agentsmith.py" update plan \
 python3 -m json.tool "$AGENTSMITH_PLAN" | less
 ```
 
-For the legacy Claude-only shape described above, v0.2.2 refuses planning when user-scope MCP is
-present; it does not create an applyable plan that omits the capability. Otherwise, after approving
-the plan:
+`v0.2.2` refuses global planning when any user-scope MCP server is configured, including
+unrelated user-owned servers. Do not remove that configuration to work around the regression; wait
+for a fixed stable release. On an unaffected machine, after approving the plan:
 
 ```bash
 python3 "$AGENTSMITH_BOOTSTRAP_DIR/agentsmith.py" update apply \

--- a/docs/feedback/0020-legacy-claude-reconstruction-skipped-skills-and-mcp.md
+++ b/docs/feedback/0020-legacy-claude-reconstruction-skipped-skills-and-mcp.md
@@ -63,14 +63,18 @@ The new fixtures cover a pre-manifest Claude-only global install containing only
 plus a `~/.claude.json` `mcpServers` object and no `.agents` directory. They prove:
 
 1. the unfixed implementation reconstructs `skills: false` for the reported global shape;
-2. planning after the fix detects both capabilities and refuses with the explicit global MCP
-   ownership error, never a successful omission;
+2. planning after the fix detects skill capability but classifies user-scope global MCP as foreign,
+   because AgentSmith cannot own MCP configuration at global scope;
 3. a supported project apply creates the canonical skill root, keeps the Claude mirror, retains
    Claude JSON MCP, and passes both apply-time and installed-runtime strict health checks;
 4. an installation with no selected-agent skill or MCP evidence is not falsely upgraded into those
    capabilities;
-5. post-update validation rejects authenticated reconstructed state whose false skill or empty MCP
-   value would otherwise suppress its own check.
+5. post-update validation rejects authenticated reconstructed state whose false skill or managed
+   project MCP value would otherwise suppress its own check, while ignoring foreign global MCP.
+
+The original v0.2.2 fixture incorrectly treated refusal on any global MCP as the safe outcome. That
+regression and its corrected ownership invariant are recorded in
+[`feedback/0022-global-update-blocked-by-foreign-mcp.md`](0022-global-update-blocked-by-foreign-mcp.md).
 
 The full 19-phase local gate passed. PR #22 then passed the repository's cross-platform CI matrix
 on Ubuntu, macOS, and Windows, including the updater fixtures on every platform and the existing

--- a/docs/feedback/0022-global-update-blocked-by-foreign-mcp.md
+++ b/docs/feedback/0022-global-update-blocked-by-foreign-mcp.md
@@ -1,0 +1,62 @@
+# Feedback 0022: global update blocked by foreign MCP
+
+> A harness post-incident. The point is not to fix THIS bug — it is to change the
+> SYSTEM so this CLASS of mistake is less likely next time (core/60). Keep it small,
+> specific, and traceable to the incident. Never delete this; archive if obsolete (R9).
+
+- **Date:** 2026-08-29
+- **Status:** applied
+- **Cost:** Stable `v0.2.2` blocks every global update on a machine where a selected agent has any
+  user-scope MCP server. The operator found the released regression by tracing the configured and
+  supported MCP sets after the release gate had passed.
+
+## 1. Evidence / symptom
+
+A pre-manifest Claude global installation with an unrelated `gemini` server in `~/.claude.json`
+fails `update plan --global` with "global MCP ownership is not supported." The configured set is
+`{"gemini"}` and its intersection with AgentSmith-supported project MCP names is empty. No bypass
+exists at the explicit plan/apply boundary.
+
+The regression fixtures failed before the correction across both affected seams:
+
+- reconstruction returned `capabilities.mcp: ["gemini"]` instead of `[]`;
+- direct post-update health validation rejected foreign global MCP as omitted managed evidence;
+- malformed foreign Claude JSON and Codex TOML were parsed and rejected even though AgentSmith
+  cannot own either global MCP file.
+
+## 2. Failure mechanism
+
+The v0.2.2 legacy reconstruction fix correctly began parsing MCP configuration per agent, but then
+treated the full configured set as owned at global scope. The post-update evidence check duplicated
+the same special case. This inverted the ownership rule: `--with-mcp` is project-scoped, so every
+global MCP entry is foreign by construction.
+
+The v0.2.2 regression test encoded fail-closed refusal as the expected result. It proved detection,
+but did not trace the ownership invariant through a successful global plan and apply.
+
+## 3. Bounded edit
+
+Classify detected MCP names through one ownership helper: return no managed names at global scope
+before reading MCP files, and parse then intersect configured names with supported names at project
+scope. Keep the existing plan and health rejection of a non-empty global manifest capability as
+defense against invalid authenticated state.
+
+Replace the refusal fixture with a legacy global plan/apply path that proves an unrelated MCP server
+is preserved byte-for-byte and omitted from schema-v1 managed capabilities. Retain a direct health
+fixture using a supported MCP name to prove that name alone cannot imply global ownership.
+
+## 4. Named surface
+
+- Production ownership boundary: `managed_mcp_names()` in `agentsmith.py`, used by legacy
+  reconstruction and post-update evidence validation.
+- Deterministic guard: `scripts/test-update.py`, run by the `update` phase in
+  `.harness/verify.conf` and the cross-platform CI matrix.
+- Operator warning: `docs/23-updating-existing-installations.md` until a fixed release is published.
+
+## 5. Non-regression validation
+
+The regression fixtures fail on released `v0.2.2` at reconstruction and at the health gate. With the
+bounded edit they pass, including valid foreign-server preservation, malformed Claude and Codex
+file short-circuiting, authenticated apply, and schema-v1 persistence. All 39 updater tests pass,
+and the full 19-phase local verification gate passes, including secret and leak checks. A fresh
+independent review found no remaining ownership, test, documentation, or security issues.

--- a/scripts/test-update.py
+++ b/scripts/test-update.py
@@ -658,7 +658,7 @@ class UpdateCheckTests(unittest.TestCase):
         self.assertEqual(plan["installation"]["safety"], {"codex": "trusted"})
         self.assertEqual(plan["installation"]["operator"]["name"], "Legacy Operator")
 
-    def test_legacy_claude_only_global_reconstruction_detects_capabilities_before_failing_closed(self) -> None:
+    def test_legacy_claude_global_foreign_mcp_survives_plan_apply_and_health(self) -> None:
         self.commit_and_tag(CURRENT_VERSION)
         self.commit_and_tag(NEXT_VERSION)
         cloned = subprocess.run(
@@ -684,7 +684,7 @@ class UpdateCheckTests(unittest.TestCase):
         self.assertTrue((home / ".claude" / "skills").is_dir())
         self.assertFalse((home / ".agents").exists())
         (home / ".claude.json").write_text(
-            json.dumps({"mcpServers": {"context7": {"command": "legacy-context7"}}}, indent=2) + "\n",
+            json.dumps({"mcpServers": {"gemini": {"command": "user-owned-gemini"}}}, indent=2) + "\n",
             encoding="utf-8",
         )
 
@@ -693,8 +693,9 @@ class UpdateCheckTests(unittest.TestCase):
 
         self.assertEqual(reconstructed["agents"], ["claude"])
         self.assertTrue(reconstructed["capabilities"]["skills"])
-        self.assertEqual(reconstructed["capabilities"]["mcp"], ["context7"])
+        self.assertEqual(reconstructed["capabilities"]["mcp"], [])
         before = state_path.read_bytes()
+        foreign_mcp_before = (home / ".claude.json").read_bytes()
         plan_path = self.root / "legacy-claude-global-plan.json"
 
         planned = self.run_core(
@@ -702,10 +703,45 @@ class UpdateCheckTests(unittest.TestCase):
             "--from", str(self.remote), "--save", str(plan_path), env=environment,
         )
 
-        self.assertNotEqual(planned.returncode, 0)
-        self.assertIn("global MCP ownership is not supported", planned.stderr)
-        self.assertFalse(plan_path.exists())
+        self.assertEqual(planned.returncode, 0, planned.stdout + planned.stderr)
+        plan = json.loads(plan_path.read_text(encoding="utf-8"))
+        self.assertEqual(plan["schema_version"], 1)
+        self.assertEqual(plan["installation"]["capabilities"]["mcp"], [])
         self.assertEqual(state_path.read_bytes(), before)
+
+        applied = self.run_core("update", "apply", "--plan", str(plan_path), env=environment)
+
+        self.assertEqual(applied.returncode, 0, applied.stdout + applied.stderr)
+        self.assertEqual((home / ".claude.json").read_bytes(), foreign_mcp_before)
+        updated = json.loads(state_path.read_text(encoding="utf-8"))
+        self.assertEqual(updated["schema_version"], 1)
+        self.assertEqual(updated["installation"]["capabilities"]["mcp"], [])
+
+    def test_global_foreign_mcp_files_are_not_parsed_during_reconstruction(self) -> None:
+        for agent_id in ("claude", "codex"):
+            with self.subTest(agent_id=agent_id):
+                home = self.root / f"malformed-{agent_id}-home"
+                codex_home = self.root / f"malformed-{agent_id}-codex"
+                environment = {**os.environ, "HOME": str(home), "CODEX_HOME": str(codex_home)}
+                installed = self.run_core("install", "--agent", agent_id, "--global", env=environment)
+                self.assertEqual(installed.returncode, 0, installed.stdout + installed.stderr)
+                state_path = home / ".agentsmith" / "state.json"
+                legacy_state = json.loads(state_path.read_text(encoding="utf-8"))
+                legacy_state.pop("schema_version")
+                legacy_state.pop("installation")
+                state_path.write_text(json.dumps(legacy_state, indent=2) + "\n", encoding="utf-8")
+                if agent_id == "claude":
+                    (home / ".claude.json").write_text("{not-json\n", encoding="utf-8")
+                else:
+                    codex_config = codex_home / "config.toml"
+                    codex_config.write_text("[mcp_servers.invalid\n", encoding="utf-8")
+
+                with mock.patch.dict(os.environ, environment, clear=False):
+                    reconstructed = runtime.reconstruct_pre_manifest_installation(
+                        home.resolve(), "global", legacy_state
+                    )
+
+                self.assertEqual(reconstructed["capabilities"]["mcp"], [])
 
     def test_legacy_claude_project_capabilities_survive_plan_apply_and_strict_health(self) -> None:
         self.commit_and_tag(CURRENT_VERSION)
@@ -828,7 +864,7 @@ class UpdateCheckTests(unittest.TestCase):
         self.assertFalse(reconstructed["capabilities"]["skills"])
         self.assertEqual(reconstructed["capabilities"]["mcp"], [])
 
-    def test_post_update_health_rejects_false_reconstructed_capabilities(self) -> None:
+    def test_post_update_health_rejects_false_skills_but_ignores_global_foreign_mcp(self) -> None:
         home = self.root / "false-reconstruction-home"
         codex_home = self.root / "false-reconstruction-codex"
         environment = {**os.environ, "HOME": str(home), "CODEX_HOME": str(codex_home)}
@@ -836,10 +872,7 @@ class UpdateCheckTests(unittest.TestCase):
             "install", "--agent", "claude", "--global", "--with-skills", env=environment,
         )
         self.assertEqual(installed.returncode, 0, installed.stdout + installed.stderr)
-        (home / ".claude.json").write_text(
-            json.dumps({"mcpServers": {"context7": {"command": "legacy-context7"}}}, indent=2) + "\n",
-            encoding="utf-8",
-        )
+        (home / ".claude.json").write_text("{not-json\n", encoding="utf-8")
         state_path = home / ".agentsmith" / "state.json"
         state = json.loads(state_path.read_text(encoding="utf-8"))
         installation = state["installation"]
@@ -874,9 +907,7 @@ class UpdateCheckTests(unittest.TestCase):
 
         installation["capabilities"]["skills"] = True
         state_path.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
-        with mock.patch.dict(os.environ, environment, clear=False), self.assertRaisesRegex(
-            runtime.CliError, "MCP evidence was omitted"
-        ):
+        with mock.patch.dict(os.environ, environment, clear=False):
             runtime.validate_post_update_health(plan)
 
     def test_assemble_only_is_preserved_for_project_and_global_updates(self) -> None:


### PR DESCRIPTION
## Why

AgentSmith cannot own MCP configuration at global scope, but v0.2.2 reconstructed every discovered user-scope MCP server as managed. That made any foreign server block `update plan --global`; parsing foreign malformed JSON or TOML could also block planning and health validation.

## Change

- return an empty managed MCP set at global scope before reading client MCP files
- keep project-scope parsing and supported-name intersection unchanged
- preserve the defensive rejection of invalid non-empty global manifest capabilities
- replace the old refusal fixture with authenticated plan/apply and byte-preservation coverage
- cover malformed foreign Claude JSON and Codex TOML in reconstruction and health
- correct the update runbook and durable feedback record

Schema version 1 and the explicit authenticated plan/apply boundary are unchanged.

## Evidence

- red before fix: valid `gemini` reconstructed as managed; health rejected it as omitted
- red before short-circuit: malformed Claude JSON and Codex TOML blocked global reconstruction/health
- 39 updater tests pass
- all 19 local verification phases pass
- changed Markdown renders
- independent review found no remaining issues