### PR TITLE
fix(update): keep foreign skill trees outside managed inventory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ docs/feedback/[0-9]*.md
 !docs/feedback/0017-windows-evaluator-fake-client-reparsed-structured-argv.md
 !docs/feedback/0018-windows-statusline-wrapper-reencoded-claude-json-stdin.md
 !docs/feedback/0022-global-update-blocked-by-foreign-mcp.md
+!docs/feedback/0023-update-inventoried-foreign-skill-trees.md

--- a/KNOWN-ISSUES.md
+++ b/KNOWN-ISSUES.md
@@ -1,0 +1,10 @@
+# Known issues
+
+These defects are intentionally separate from the legacy global updater ownership fix. They are
+recorded here because no external tracker write has been authorized.
+
+- [ ] Project-scoped install writes Claude's user-global `permissions.defaultMode` through
+  `install_native_config()`; the default `--safety cautious` therefore changes the user's global
+  mode to `acceptEdits` from a project operation.
+- [ ] Project install appends a generated block to an existing unmarked `CLAUDE.md` and also adds
+  `AGENTS.md`, leaving two authoritative instruction rulebooks in one repository.

--- a/agentsmith.py
+++ b/agentsmith.py
@@ -1514,24 +1514,74 @@ def safe_update_path(root: Path, relative: str | Path) -> Path:
     return candidate
 
 
-def installation_fingerprints(target: Path, installation: dict[str, Any]) -> tuple[dict[str, str], list[dict[str, Any]]]:
+def safe_inventory_path(root: Path, relative: str | Path) -> Path:
+    """Return a contained read-only path, allowing only symlinks that resolve inside root."""
+    root = root.resolve()
+    relative_path = Path(relative)
+    if relative_path.is_absolute() or ".." in relative_path.parts or not relative_path.parts:
+        raise CliError(f"Update inventory path escapes its declared root: {relative}")
+    candidate = root.joinpath(relative_path)
+    try:
+        candidate.resolve(strict=False).relative_to(root)
+    except (OSError, ValueError) as exc:
+        raise CliError(f"Update inventory path escapes its declared root: {candidate}") from exc
+    return candidate
+
+
+def has_symlink_component(root: Path, relative: str | Path) -> bool:
+    current = root.resolve()
+    for part in Path(relative).parts:
+        current = current / part
+        if current.is_symlink():
+            return True
+    return False
+
+
+def inventory_files(root: Path, directory: Path) -> list[Path]:
+    """List regular inventory files without following contained links or reading escaping links."""
+    root = root.resolve()
+    relative_directory = directory.relative_to(root)
+    checked_directory = safe_inventory_path(root, relative_directory)
+    if checked_directory.is_symlink() or not checked_directory.is_dir():
+        return []
+    result: list[Path] = []
+    for child in checked_directory.rglob("*"):
+        relative = child.relative_to(root)
+        checked = safe_inventory_path(root, relative)
+        if has_symlink_component(root, relative):
+            continue
+        if checked.is_file():
+            result.append(checked)
+    return result
+
+
+def installation_fingerprints(
+    target: Path, installation: dict[str, Any], *, infer_legacy_skill_ownership: bool
+) -> tuple[dict[str, str], list[dict[str, Any]], list[dict[str, str]]]:
     roots = {
         "target": target,
         "home": home_dir().resolve(),
         "codex_home": codex_home().resolve(),
     }
     candidates: set[tuple[str, Path]] = set()
+    foreign_skill_directories: set[tuple[str, str]] = set()
 
     def add(root_name: str, relative: str) -> None:
         root = roots[root_name]
         path = safe_update_path(root, relative)
         if path.is_dir():
-            for child in path.rglob("*"):
-                checked = safe_update_path(root, child.relative_to(root))
-                if checked.is_file():
-                    candidates.add((root_name, checked))
+            for checked in inventory_files(root, path):
+                candidates.add((root_name, checked))
         else:
             candidates.add((root_name, path))
+
+    def add_owned_skills(root_name: str, skill_root: Path, classification: dict[Path, dict[str, set[str]]]) -> None:
+        groups = classification.get(skill_root, {})
+        for name in sorted(groups.get("managed", set()) | groups.get("stale", set())):
+            add(root_name, (skill_root / name).relative_to(roots[root_name]).as_posix())
+        for name in groups.get("foreign", set()):
+            relative = (skill_root / name).relative_to(roots[root_name]).as_posix()
+            foreign_skill_directories.add((root_name, relative))
 
     if installation["scope"] == "project":
         for relative in (
@@ -1554,18 +1604,27 @@ def installation_fingerprints(target: Path, installation: dict[str, Any]) -> tup
             if "codex" in installation["agents"]:
                 add("target", ".codex/config.toml")
         if installation["capabilities"].get("skills"):
-            add("target", ".agents/skills")
-            if "claude" in installation["agents"]:
-                add("target", ".claude/skills")
+            skill_agent = "claude" if "claude" in installation["agents"] else "codex"
+            classification = classify_skill_directories(
+                skill_agent, target, installation, infer_bundled_ownership=infer_legacy_skill_ownership
+            )
+            add_owned_skills("target", target / ".agents" / "skills", classification)
+            if skill_agent == "claude":
+                add_owned_skills("target", target / ".claude" / "skills", classification)
     else:
         if "claude" in installation["agents"]:
             add("home", ".claude/CLAUDE.md")
         if "codex" in installation["agents"]:
             add("codex_home", "AGENTS.md")
         if installation["capabilities"].get("skills"):
-            add("home", ".agents/skills")
-            if "claude" in installation["agents"]:
-                add("home", ".claude/skills")
+            skill_target = roots["home"]
+            skill_agent = "claude" if "claude" in installation["agents"] else "codex"
+            classification = classify_skill_directories(
+                skill_agent, skill_target, installation, infer_bundled_ownership=infer_legacy_skill_ownership
+            )
+            add_owned_skills("home", skill_target / ".agents" / "skills", classification)
+            if skill_agent == "claude":
+                add_owned_skills("home", skill_target / ".claude" / "skills", classification)
         if installation["capabilities"].get("handoff_hooks") or installation["capabilities"].get("ui_design_hook"):
             for relative in RUNTIME_FILES:
                 add("home", relative)
@@ -1591,7 +1650,11 @@ def installation_fingerprints(target: Path, installation: dict[str, Any]) -> tup
         add("codex_home", "hooks.json")
     entries = [fingerprint_entry(root_name, roots[root_name], path) for root_name, path in candidates]
     entries.sort(key=lambda item: (item["root"], item["path"]))
-    return {name: str(path) for name, path in roots.items()}, entries
+    preserved_foreign = [
+        {"root": root_name, "path": path}
+        for root_name, path in sorted(foreign_skill_directories)
+    ]
+    return {name: str(path) for name, path in roots.items()}, entries, preserved_foreign
 
 
 def update_integrity_key(*, create: bool) -> bytes:
@@ -1630,9 +1693,11 @@ def cmd_update_plan(args: argparse.Namespace) -> int:
     state = load_update_state(target)
     expected_scope = "global" if args.global_mode else "project"
     migration_warnings: list[str] = []
+    reconstructed = False
     if "schema_version" in state or "installation" in state:
         installation = validate_installation_manifest(state)
     else:
+        reconstructed = True
         installation = reconstruct_pre_manifest_installation(target, expected_scope, state)
         migration_warnings.append(
             "Pre-manifest installation choices were reconstructed from managed markers and ownership state; "
@@ -1647,7 +1712,9 @@ def cmd_update_plan(args: argparse.Namespace) -> int:
         )
     remote = args.update_from or OFFICIAL_REMOTE
     release = resolve_stable_release(remote, args.version)
-    roots, fingerprints = installation_fingerprints(target, installation)
+    roots, fingerprints, foreign_skill_directories = installation_fingerprints(
+        target, installation, infer_legacy_skill_ownership=reconstructed
+    )
     payload: dict[str, Any] = {
         "schema_version": 1,
         "created_at": dt.datetime.now(dt.timezone.utc).isoformat(),
@@ -1658,6 +1725,7 @@ def cmd_update_plan(args: argparse.Namespace) -> int:
         "release": release,
         "installation": installation,
         "fingerprints": fingerprints,
+        "foreign_skill_directories": foreign_skill_directories,
         "proposed_changes": [],
         "preserved_foreign_content": [
             "Content outside AgentSmith-managed markers and owned configuration remains in place.",
@@ -1705,10 +1773,11 @@ def validated_plan(path: Path) -> dict[str, Any]:
     allowed = {
         "schema_version", "created_at", "scope", "target", "roots", "remote", "release",
         "installation", "fingerprints", "proposed_changes", "preserved_foreign_content",
-        "migration_warnings", "verification", "integrity",
+        "foreign_skill_directories", "migration_warnings", "verification", "integrity",
     }
+    required = allowed - {"foreign_skill_directories"}
     unknown = sorted(set(plan) - allowed)
-    missing = sorted(allowed - set(plan))
+    missing = sorted(required - set(plan))
     if unknown or missing:
         detail = f"unknown: {', '.join(unknown)}" if unknown else f"missing: {', '.join(missing)}"
         raise CliError(f"Plan fields are not supported ({detail})")
@@ -1749,6 +1818,33 @@ def validated_plan(path: Path) -> dict[str, Any]:
             raise CliError("Plan fingerprint hash is malformed")
         if item["mode"] is not None and (not isinstance(item["mode"], int) or not 0 <= item["mode"] <= 0o777):
             raise CliError("Plan fingerprint mode is malformed")
+    foreign_skill_directories = plan.get("foreign_skill_directories", [])
+    if not isinstance(foreign_skill_directories, list):
+        raise CliError("Plan foreign skill directories must be a list")
+    foreign_paths: set[tuple[str, str]] = set()
+    for item in foreign_skill_directories:
+        if not isinstance(item, dict) or set(item) != {"root", "path"}:
+            raise CliError("Plan contains a malformed foreign skill directory")
+        root_name, relative = item["root"], item["path"]
+        if root_name not in {"target", "home"} or not isinstance(relative, str):
+            raise CliError("Plan foreign skill directory has an unknown root or path")
+        expected_root_name = "home" if plan["scope"] == "global" else "target"
+        relative_path = Path(relative)
+        parts = relative_path.parts
+        if root_name != expected_root_name:
+            raise CliError("Plan foreign skill directory has the wrong scope root")
+        if (
+            relative_path.is_absolute()
+            or ".." in parts
+            or len(parts) != 3
+            or tuple(parts[:2]) not in {(".agents", "skills"), (".claude", "skills")}
+            or (parts[0] == ".claude" and "claude" not in installation["agents"])
+        ):
+            raise CliError("Plan foreign skill directory is outside the skill roots")
+        identity = (root_name, relative)
+        if identity in foreign_paths:
+            raise CliError("Plan contains a duplicate foreign skill directory")
+        foreign_paths.add(identity)
     if not isinstance(plan["proposed_changes"], list):
         raise CliError("Plan proposed changes must be a list")
     proposed_paths: set[tuple[str, str]] = set()
@@ -1788,6 +1884,10 @@ def recheck_plan_fingerprints(plan: dict[str, Any]) -> None:
         actual_mode = path.stat().st_mode & 0o777 if path.is_file() else None
         if actual != item["sha256"] or actual_mode != item["mode"]:
             raise CliError(f"Update refused: {item['root']}:{item['path']} changed after planning")
+    for item in plan.get("foreign_skill_directories", []):
+        path = Path(plan["roots"][item["root"]]).joinpath(item["path"])
+        if not path.exists():
+            raise CliError(f"Update refused: foreign skill collision disappeared after planning: {item['path']}")
 
 
 def copy_plan_inputs_to_shadow(plan: dict[str, Any], shadow_roots: dict[str, Path]) -> None:
@@ -1809,6 +1909,13 @@ def copy_plan_inputs_to_shadow(plan: dict[str, Any], shadow_roots: dict[str, Pat
             destination.write_bytes(translated)
 
 
+def preserve_foreign_skill_collisions(plan: dict[str, Any], shadow_roots: dict[str, Path]) -> None:
+    """Represent authenticated foreign top-level names without reading or copying their contents."""
+    for item in plan.get("foreign_skill_directories", []):
+        destination = safe_update_path(shadow_roots[item["root"]], item["path"])
+        destination.mkdir(parents=True, exist_ok=True)
+
+
 def prepare_owned_skills(plan: dict[str, Any], shadow_roots: dict[str, Path]) -> set[tuple[str, str]]:
     inventory = plan["installation"].get("managed_files", [])
     grouped: dict[tuple[str, str], list[dict[str, str]]] = {}
@@ -1827,11 +1934,9 @@ def prepare_owned_skills(plan: dict[str, Any], shadow_roots: dict[str, Path]) ->
         recorded = {item["path"]: item["sha256"] for item in items}
         current: dict[str, str] = {}
         if actual_root.is_dir():
-            for path in actual_root.rglob("*"):
-                relative = path.relative_to(source_root)
-                checked = safe_update_path(source_root, relative)
-                if checked.is_file():
-                    current[relative.as_posix()] = file_sha256(checked)
+            for checked in inventory_files(source_root, actual_root):
+                relative = checked.relative_to(source_root)
+                current[relative.as_posix()] = file_sha256(checked)
         shadow_skill = safe_update_path(shadow_roots[root_name], prefix)
         if current == recorded:
             if shadow_skill.exists():
@@ -1862,6 +1967,39 @@ def retain_customized_skill_baselines(
         if any(item.get("root") == root_name and item.get("path", "").startswith(prefix + "/") for root_name, prefix in preserved)
     ]
     installation["managed_files"] = [*kept_new, *kept_prior]
+    atomic_write(state_path(state_root), json.dumps(state, indent=2, ensure_ascii=False) + "\n")
+
+
+def retain_reconstructed_skill_baselines(plan: dict[str, Any], shadow_roots: dict[str, Path]) -> None:
+    reconstructed = any(
+        isinstance(warning, str) and warning.startswith("Pre-manifest installation choices were reconstructed")
+        for warning in plan["migration_warnings"]
+    )
+    if not reconstructed or not plan["installation"]["capabilities"].get("skills"):
+        return
+    state_root = shadow_roots["home"] if plan["scope"] == "global" else shadow_roots["target"]
+    state = load_state(state_root)
+    installation = state.get("installation")
+    if not isinstance(installation, dict):
+        raise CliError("Staged installer did not write an installation manifest")
+    inventory = installation.get("managed_files", [])
+    existing = {
+        (item.get("root"), item.get("path"))
+        for item in inventory
+        if isinstance(item, dict)
+    }
+    for item in plan["fingerprints"]:
+        parts = Path(item["path"]).parts
+        identity = (item["root"], item["path"])
+        if (
+            item["sha256"] is not None
+            and len(parts) >= 4
+            and tuple(parts[:2]) in {(".agents", "skills"), (".claude", "skills")}
+            and identity not in existing
+        ):
+            inventory.append({"root": item["root"], "path": item["path"], "sha256": item["sha256"]})
+            existing.add(identity)
+    installation["managed_files"] = sorted(inventory, key=lambda item: (item["root"], item["path"]))
     atomic_write(state_path(state_root), json.dumps(state, indent=2, ensure_ascii=False) + "\n")
 
 
@@ -2054,6 +2192,7 @@ def stage_planned_update(
         root.mkdir(parents=True, exist_ok=True)
     copy_plan_inputs_to_shadow(plan, shadow_roots)
     preserved_skills = prepare_owned_skills(plan, shadow_roots)
+    preserve_foreign_skill_collisions(plan, shadow_roots)
     shadow_env = {
         "HOME": str(shadow_roots["home"]),
         "USERPROFILE": str(shadow_roots["home"]),
@@ -2084,6 +2223,7 @@ def stage_planned_update(
     else:
         trusted_stage_install(checkout, plan["release"]["version"], install_arguments, shadow_env)
     retain_customized_skill_baselines(plan, shadow_roots, preserved_skills)
+    retain_reconstructed_skill_baselines(plan, shadow_roots)
     translated_files: dict[str, dict[str, tuple[bytes, int]]] = {}
     for root_name, shadow_root in shadow_roots.items():
         translated_files[root_name] = {}
@@ -2218,17 +2358,31 @@ def validate_post_update_health(plan: dict[str, Any]) -> None:
 
     if capabilities.get("skills"):
         skill_root = Path(plan["roots"]["home"]) if plan["scope"] == "global" else target
-        required_roots = [skill_root / ".agents" / "skills"]
+        inventory_root = "home" if plan["scope"] == "global" else "target"
+        required_roots = [(skill_root / ".agents" / "skills", ".agents/skills/")]
         if "claude" in installation["agents"]:
-            required_roots.append(skill_root / ".claude" / "skills")
-        if any(not root.is_dir() or not any(root.rglob("SKILL.md")) for root in required_roots):
-            raise CliError("Post-update health check failed: a managed skill root is missing or empty")
+            required_roots.append((skill_root / ".claude" / "skills", ".claude/skills/"))
         inventory = installed.get("managed_files", [])
         if not inventory or any(
             not safe_update_path(Path(plan["roots"][item["root"]]), item["path"]).is_file()
             for item in inventory
         ):
             raise CliError("Post-update health check failed: managed skill inventory is missing a file")
+        for root, prefix in required_roots:
+            owned = [
+                item for item in inventory
+                if item.get("root") == inventory_root
+                and isinstance(item.get("path"), str)
+                and item["path"].startswith(prefix)
+                and item["path"].endswith("/SKILL.md")
+            ]
+            if not root.is_dir() or not owned:
+                raise CliError(f"Post-update health check failed: managed skill inventory is missing for {prefix}")
+            if any(
+                not safe_update_path(Path(plan["roots"][item["root"]]), item["path"]).is_file()
+                for item in owned
+            ):
+                raise CliError(f"Post-update health check failed: managed skill inventory is stale for {prefix}")
 
     requested_mcp = set(capabilities.get("mcp", []))
     if requested_mcp and plan["scope"] == "global":
@@ -3264,41 +3418,56 @@ def inspect_instructions(agent_id: str, agent: dict[str, Any], target: Path) -> 
     }, warnings
 
 
-def directory_snapshot(path: Path) -> dict[Path, bytes]:
-    return {item.relative_to(path): item.read_bytes() for item in path.rglob("*") if item.is_file()} if path.is_dir() else {}
+def directory_snapshot(path: Path, root: Path | None = None) -> dict[Path, bytes]:
+    if not path.is_dir():
+        return {}
+    boundary = root.resolve() if root is not None else path.resolve()
+    return {item.relative_to(path): item.read_bytes() for item in inventory_files(boundary, path)}
 
 
-def inspect_skills(agent_id: str, agent: dict[str, Any], target: Path) -> dict[str, Any]:
+def classify_skill_directories(
+    agent_id: str,
+    target: Path,
+    installation: dict[str, Any] | None = None,
+    *,
+    infer_bundled_ownership: bool | None = None,
+) -> dict[Path, dict[str, set[str]]]:
     roots = [target / ".agents" / "skills"]
     if agent_id == "claude":
         roots.append(target / ".claude" / "skills")
     bundled_root = ROOT / "skills"
     bundled = (
-        {path.name: directory_snapshot(path) for path in bundled_root.iterdir() if path.is_dir()}
+        {path.name: directory_snapshot(path, bundled_root) for path in bundled_root.iterdir() if path.is_dir()}
         if bundled_root.is_dir()
         else None
     )
-    installation = load_state(target).get("installation", {})
+    if installation is None:
+        stored_installation = load_state(target).get("installation")
+        if infer_bundled_ownership is None:
+            infer_bundled_ownership = not isinstance(stored_installation, dict)
+        installation = stored_installation
+    if infer_bundled_ownership is None:
+        infer_bundled_ownership = False
     installation = installation if isinstance(installation, dict) else {}
     inventory = installation.get("managed_files", [])
     inventory = inventory if isinstance(inventory, list) else []
     inventory_root = "home" if installation.get("scope") == "global" else "target"
-    managed_names: set[str] = set()
-    stale_names: set[str] = set()
-    foreign_names: set[str] = set()
+    result: dict[Path, dict[str, set[str]]] = {}
     for root in roots:
+        groups = {"managed": set(), "stale": set(), "foreign": set()}
+        result[root] = groups
         if not root.is_dir():
             continue
         for installed in root.iterdir():
             if not installed.is_dir():
                 continue
-            if bundled is not None:
+            if infer_bundled_ownership and bundled is not None:
                 if installed.name not in bundled:
-                    foreign_names.add(installed.name)
-                elif directory_snapshot(installed) == bundled[installed.name]:
-                    managed_names.add(installed.name)
+                    groups["foreign"].add(installed.name)
+                elif directory_snapshot(installed, target) == bundled[installed.name]:
+                    groups["managed"].add(installed.name)
                 else:
-                    stale_names.add(installed.name)
+                    groups["stale"].add(installed.name)
             else:
                 prefix = installed.relative_to(target).as_posix() + "/"
                 recorded = {
@@ -3312,15 +3481,23 @@ def inspect_skills(agent_id: str, agent: dict[str, Any], target: Path) -> dict[s
                 }
                 current = {
                     path.relative_to(target).as_posix(): file_sha256(path)
-                    for path in installed.rglob("*")
-                    if path.is_file()
+                    for path in inventory_files(target, installed)
                 }
                 if not recorded:
-                    foreign_names.add(installed.name)
+                    groups["foreign"].add(installed.name)
                 elif current == recorded:
-                    managed_names.add(installed.name)
+                    groups["managed"].add(installed.name)
                 else:
-                    stale_names.add(installed.name)
+                    groups["stale"].add(installed.name)
+    return result
+
+
+def inspect_skills(agent_id: str, agent: dict[str, Any], target: Path) -> dict[str, Any]:
+    classifications = classify_skill_directories(agent_id, target)
+    roots = list(classifications)
+    managed_names = set().union(*(groups["managed"] for groups in classifications.values()))
+    stale_names = set().union(*(groups["stale"] for groups in classifications.values()))
+    foreign_names = set().union(*(groups["foreign"] for groups in classifications.values()))
     state = "stale" if stale_names else ("managed" if managed_names else ("foreign" if foreign_names else "missing"))
     return {
         "declared": str(agent.get("skills_tools", {}).get("agent_skills", {}).get("client_support", "unverified")),

--- a/config/plugins.md
+++ b/config/plugins.md
@@ -27,10 +27,11 @@ let `setup.sh` do it.
 | **code-review** | On-demand diff review at adjustable effort. The everyday evaluation gate. |
 | **codex** | A *second, independent* model that reviews **and independently tests** your work adversarially — it reads the diff for a second opinion, and can write/run its own tests or reproduce the bug (a checker that *measures* beats one that only reads). The strongest cheap "eval" you can add before shipping anything risky. Optional (needs the Codex CLI), but recommended. |
 
-## Built-in skills worth knowing (no install needed)
+## Environment-provided skills worth knowing
 
-- **deep-research** — the engine for the *deep-research* profile.
-- **excalidraw-diagram** — clean diagrams for the *creative-design* profile.
+- **deep-research** — the engine for the *deep-research* profile when the host provides it.
+- **excalidraw-diagram** — clean diagrams for the *creative-design* profile when installed separately;
+  AgentSmith does not bundle it.
 - Plus whatever ships with your Claude Code build (`/run`, `/verify`, `/code-review`, …).
 
 ## By-profile, opt-in

--- a/docs/feedback/0023-update-inventoried-foreign-skill-trees.md
+++ b/docs/feedback/0023-update-inventoried-foreign-skill-trees.md
@@ -1,0 +1,74 @@
+# Feedback 0023: update inventoried foreign skill trees
+
+> A harness post-incident. The point is not to fix THIS bug — it is to change the
+> SYSTEM so this CLASS of mistake is less likely next time (core/60). Keep it small,
+> specific, and traceable to the incident. Never delete this; archive if obsolete (R9).
+
+- **Date:** 2026-08-30
+- **Status:** applied
+- **Fixed release:** unreleased
+- **Cost:** The third stable release in the legacy global update chain still could not complete
+  a plan. Once skill detection and global MCP ownership were corrected, the updater entered a
+  third-party skill's Python virtual environment and rejected its normal `lib64 -> lib` link.
+
+## 1. Evidence / symptom
+
+A pre-manifest Claude global installation has skills only under `~/.claude/skills`, plus a
+third-party `excalidraw-diagram` skill containing a Linux virtual environment. Although that skill
+is not bundled or managed by AgentSmith, `update plan --global` recursively inventories it and
+fails with `Update refused to follow symbolic link .../.venv/lib64`.
+
+The regression fixture reproduced that exact failure before the production edit. The foreign
+skill contained one regular file and the contained `lib64 -> lib` directory link; planning exited
+2 before writing a plan.
+
+## 2. Failure mechanism
+
+Capability detection answered whether any skill root existed, while fingerprinting recursively
+walked the entire root. It did not reuse the managed/stale/foreign classification already used by
+inspection. The read-only inventory also reused the write-target path guard, which rejects every
+link rather than enforcing the actual read boundary: the resolved path must remain inside its
+declared root.
+
+Filtering foreign trees alone exposed a second ownership edge: a future release could introduce a
+bundled name that collides with a foreign directory. If the foreign top-level name is absent from
+the staging shadow, the candidate installer sees it as free and proposes replacing the user's
+files.
+
+## 3. Bounded edit
+
+Use one skill-directory classifier for inspection and update inventory. Fingerprint only managed
+or stale bundled names, and use a read-only containment helper that ignores contained link aliases
+but rejects links resolving outside the root. Keep the unconditional link rejection on paths the
+updater may write.
+
+Authenticate foreign top-level names separately from fingerprints and materialize only empty
+collision sentinels in the staging shadow. This preserves candidate-name collisions without
+reading or copying foreign contents. Reconstructed legacy owned-skill fingerprints become the
+schema-v1 manifest baseline so post-update health can require owned inventory in every required
+skill root.
+
+## 4. Named surface
+
+- Ownership and containment: `safe_inventory_path()`, `inventory_files()`,
+  `classify_skill_directories()`, and `installation_fingerprints()` in `agentsmith.py`.
+- Explicit plan/apply boundary: authenticated `foreign_skill_directories` plan metadata and
+  `preserve_foreign_skill_collisions()` in `agentsmith.py`; schema version remains 1.
+- Deterministic guards: legacy global, contained/escaping link, future-name collision, manifest,
+  and post-update health fixtures in `scripts/test-update.py`.
+- Documentation correction: `skills/RECOMMENDED.md` and `config/plugins.md` no longer describe
+  the unbundled `excalidraw-diagram` skill as built in.
+
+## 5. Non-regression validation
+
+The released behavior failed first at the contained `lib64 -> lib` link. With the bounded edit,
+all 41 updater tests pass, including the real legacy global Claude + foreign MCP + foreign
+virtual-environment shape, internal versus escaping links, existing same-name collisions, a newly
+bundled collision across two consecutive source releases, customized owned skills, authenticated
+apply, foreign-byte preservation, complete managed-file health, and per-root managed inventory.
+
+The full 19-phase verification gate passes, including compile, conformance, updater, assembly,
+secret, leak, hook, and runtime checks. A fresh independent review found two follow-up gaps—the
+second-release ownership classification and auxiliary managed-file health check—which received
+their own failing fixtures and fixes. The reviewer's final pass found no remaining code or test
+issues.

--- a/scripts/test-update.py
+++ b/scripts/test-update.py
@@ -599,6 +599,18 @@ class UpdateCheckTests(unittest.TestCase):
         rejected = self.run_core("update", "apply", "--plan", str(plan_path), env=environment)
         self.assertNotEqual(rejected.returncode, 0)
         self.assertIn("not supported", rejected.stderr)
+        malformed_foreign = json.loads(original)
+        malformed_foreign["foreign_skill_directories"] = [
+            {"root": "target", "path": ".agents/skills/.."}
+        ]
+        malformed_foreign["integrity"] = integrity(
+            malformed_foreign,
+            (Path(environment["HOME"]) / ".agentsmith" / "update-integrity.key").read_bytes(),
+        )
+        plan_path.write_text(json.dumps(malformed_foreign, indent=2) + "\n", encoding="utf-8")
+        rejected = self.run_core("update", "apply", "--plan", str(plan_path), env=environment)
+        self.assertNotEqual(rejected.returncode, 0)
+        self.assertIn("outside the skill roots", rejected.stderr)
         mismatched = json.loads(original)
         mismatched["proposed_changes"][0]["after_sha256"] = "0" * 64
         mismatched["integrity"] = integrity(
@@ -687,6 +699,18 @@ class UpdateCheckTests(unittest.TestCase):
             json.dumps({"mcpServers": {"gemini": {"command": "user-owned-gemini"}}}, indent=2) + "\n",
             encoding="utf-8",
         )
+        foreign_skill = home / ".claude" / "skills" / "excalidraw-diagram"
+        foreign_venv_lib = foreign_skill / "references" / ".venv" / "lib"
+        foreign_venv_lib.mkdir(parents=True)
+        foreign_probe = foreign_venv_lib / "foreign.py"
+        foreign_probe.write_text("# user-owned virtual environment\n", encoding="utf-8")
+        foreign_lib64 = foreign_venv_lib.parent / "lib64"
+        try:
+            foreign_lib64.symlink_to("lib", target_is_directory=True)
+        except (NotImplementedError, OSError):
+            # The ownership assertions below remain portable when the test host
+            # does not permit unprivileged symbolic-link creation.
+            foreign_lib64 = None
 
         with mock.patch.dict(os.environ, environment, clear=False):
             reconstructed = runtime.reconstruct_pre_manifest_installation(home.resolve(), "global", legacy_state)
@@ -707,15 +731,100 @@ class UpdateCheckTests(unittest.TestCase):
         plan = json.loads(plan_path.read_text(encoding="utf-8"))
         self.assertEqual(plan["schema_version"], 1)
         self.assertEqual(plan["installation"]["capabilities"]["mcp"], [])
+        self.assertTrue(plan["installation"]["capabilities"]["skills"])
+        foreign_prefix = ".claude/skills/excalidraw-diagram/"
+        self.assertFalse(
+            any(
+                item["root"] == "home" and item["path"].startswith(foreign_prefix)
+                for item in plan["fingerprints"]
+            )
+        )
+        self.assertFalse(
+            any(
+                item["root"] == "home" and item["path"].startswith(foreign_prefix)
+                for item in plan["proposed_changes"]
+            )
+        )
+        self.assertIn(
+            {"root": "home", "path": ".claude/skills/excalidraw-diagram"},
+            plan["foreign_skill_directories"],
+        )
+        self.assertTrue(
+            any(
+                item["root"] == "home" and item["path"] == ".agents/skills/handoff/SKILL.md"
+                for item in plan["proposed_changes"]
+            )
+        )
         self.assertEqual(state_path.read_bytes(), before)
 
         applied = self.run_core("update", "apply", "--plan", str(plan_path), env=environment)
 
         self.assertEqual(applied.returncode, 0, applied.stdout + applied.stderr)
         self.assertEqual((home / ".claude.json").read_bytes(), foreign_mcp_before)
+        self.assertEqual(foreign_probe.read_text(encoding="utf-8"), "# user-owned virtual environment\n")
+        if foreign_lib64 is not None:
+            self.assertTrue(foreign_lib64.is_symlink())
         updated = json.loads(state_path.read_text(encoding="utf-8"))
         self.assertEqual(updated["schema_version"], 1)
         self.assertEqual(updated["installation"]["capabilities"]["mcp"], [])
+        updated_inventory = updated["installation"]["managed_files"]
+        self.assertTrue(any(item["path"].startswith(".agents/skills/") for item in updated_inventory))
+        self.assertTrue(any(item["path"].startswith(".claude/skills/") for item in updated_inventory))
+        self.assertFalse(any(item["path"].startswith(foreign_prefix) for item in updated_inventory))
+
+    def test_legacy_global_skill_inventory_allows_contained_links_but_rejects_escaping_links(self) -> None:
+        self.commit_and_tag(CURRENT_VERSION)
+        self.commit_and_tag(NEXT_VERSION)
+        cloned = subprocess.run(
+            ["git", "clone", "-q", "--bare", str(self.seed), str(self.remote)],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(cloned.returncode, 0, cloned.stdout + cloned.stderr)
+        home = self.root / "legacy-link-home"
+        environment = {
+            **os.environ,
+            "HOME": str(home),
+            "CODEX_HOME": str(self.root / "legacy-link-codex"),
+        }
+        installed = self.run_core("install", "--agent", "claude", "--global", "--with-skills", env=environment)
+        self.assertEqual(installed.returncode, 0, installed.stdout + installed.stderr)
+        state_path = home / ".agentsmith" / "state.json"
+        legacy_state = json.loads(state_path.read_text(encoding="utf-8"))
+        legacy_state.pop("schema_version")
+        legacy_state.pop("installation")
+        state_path.write_text(json.dumps(legacy_state, indent=2) + "\n", encoding="utf-8")
+        shutil.rmtree(home / ".agents")
+        owned_skill = home / ".claude" / "skills" / "handoff"
+        contained_link = owned_skill / "contained-skill-link.md"
+        try:
+            contained_link.symlink_to("SKILL.md")
+        except (NotImplementedError, OSError) as exc:
+            self.skipTest(f"symbolic links are unavailable: {exc}")
+        contained_plan = self.root / "contained-link-plan.json"
+
+        planned = self.run_core(
+            "update", "plan", "--global", "--version", NEXT_TAG,
+            "--from", str(self.remote), "--save", str(contained_plan), env=environment,
+        )
+
+        self.assertEqual(planned.returncode, 0, planned.stdout + planned.stderr)
+        plan = json.loads(contained_plan.read_text(encoding="utf-8"))
+        self.assertTrue(plan["installation"]["capabilities"]["skills"])
+        self.assertFalse(any(item["path"].endswith("contained-skill-link.md") for item in plan["fingerprints"]))
+
+        contained_link.unlink()
+        outside = self.root / "outside-skill-file.md"
+        outside.write_text("outside the installation root\n", encoding="utf-8")
+        (owned_skill / "escaping-skill-link.md").symlink_to(outside)
+        escaping = self.run_core(
+            "update", "plan", "--global", "--version", NEXT_TAG,
+            "--from", str(self.remote), env=environment,
+        )
+
+        self.assertNotEqual(escaping.returncode, 0)
+        self.assertIn("inventory path escapes its declared root", escaping.stderr)
 
     def test_global_foreign_mcp_files_are_not_parsed_during_reconstruction(self) -> None:
         for agent_id in ("claude", "codex"):
@@ -908,6 +1017,13 @@ class UpdateCheckTests(unittest.TestCase):
         installation["capabilities"]["skills"] = True
         state_path.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
         with mock.patch.dict(os.environ, environment, clear=False):
+            runtime.validate_post_update_health(plan)
+
+        auxiliary = home / ".agents" / "skills" / "writing-rules" / "HARNESS-SURFACES.md"
+        auxiliary.unlink()
+        with mock.patch.dict(os.environ, environment, clear=False), self.assertRaisesRegex(
+            runtime.CliError, "managed skill inventory is missing a file"
+        ):
             runtime.validate_post_update_health(plan)
 
     def test_assemble_only_is_preserved_for_project_and_global_updates(self) -> None:
@@ -1295,6 +1411,80 @@ class UpdateCheckTests(unittest.TestCase):
         self.assertTrue(all(
             path.relative_to(force_target).as_posix() in forced_inventory for path in forced_collisions
         ))
+
+    def test_update_preserves_a_foreign_name_that_a_future_release_bundles(self) -> None:
+        self.commit_and_tag(CURRENT_VERSION)
+        future_source = self.seed / "skills" / "future-collision" / "SKILL.md"
+        future_source.parent.mkdir(parents=True)
+        future_source.write_text("# Candidate-owned version\n", encoding="utf-8")
+        self.commit_and_tag(NEXT_VERSION)
+        cloned = subprocess.run(
+            ["git", "clone", "-q", "--bare", str(self.seed), str(self.remote)],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(cloned.returncode, 0, cloned.stdout + cloned.stderr)
+        target = self.root / "future-collision-project"
+        target.mkdir()
+        environment = {
+            **os.environ,
+            "HOME": str(self.root / "future-collision-home"),
+            "CODEX_HOME": str(self.root / "future-collision-codex"),
+        }
+        foreign = target / ".agents" / "skills" / "future-collision" / "SKILL.md"
+        foreign.parent.mkdir(parents=True)
+        foreign.write_text("# User-owned version\n", encoding="utf-8")
+        installed = self.run_core(
+            "install", "--agent", "codex", "--profile", "software-dev", "--target", str(target),
+            "--with-skills", env=environment,
+        )
+        self.assertEqual(installed.returncode, 0, installed.stdout + installed.stderr)
+        before = foreign.read_bytes()
+        plan_path = self.root / "future-collision-plan.json"
+
+        planned = self.run_core(
+            "update", "plan", "--target", str(target), "--version", NEXT_TAG,
+            "--from", str(self.remote), "--save", str(plan_path), env=environment,
+        )
+
+        self.assertEqual(planned.returncode, 0, planned.stdout + planned.stderr)
+        plan = json.loads(plan_path.read_text(encoding="utf-8"))
+        foreign_path = ".agents/skills/future-collision"
+        self.assertIn({"root": "target", "path": foreign_path}, plan["foreign_skill_directories"])
+        self.assertFalse(any(item["path"].startswith(foreign_path + "/") for item in plan["fingerprints"]))
+        self.assertFalse(any(item["path"].startswith(foreign_path + "/") for item in plan["proposed_changes"]))
+
+        applied = self.run_core("update", "apply", "--plan", str(plan_path), env=environment)
+
+        self.assertEqual(applied.returncode, 0, applied.stdout + applied.stderr)
+        self.assertEqual(foreign.read_bytes(), before)
+        inventory = json.loads(
+            (target / ".agentsmith" / "state.json").read_text(encoding="utf-8")
+        )["installation"]["managed_files"]
+        self.assertFalse(any(item["path"].startswith(foreign_path + "/") for item in inventory))
+
+        second_plan_path = self.root / "future-collision-second-plan.json"
+        second_planned = subprocess.run(
+            [
+                sys.executable, str(self.seed / "agentsmith.py"),
+                "update", "plan", "--target", str(target), "--version", NEXT_TAG,
+                "--from", str(self.remote), "--save", str(second_plan_path),
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+            env=environment,
+        )
+        self.assertEqual(second_planned.returncode, 0, second_planned.stdout + second_planned.stderr)
+        second_plan = json.loads(second_plan_path.read_text(encoding="utf-8"))
+        self.assertIn({"root": "target", "path": foreign_path}, second_plan["foreign_skill_directories"])
+        self.assertFalse(
+            any(item["path"].startswith(foreign_path + "/") for item in second_plan["fingerprints"])
+        )
+        self.assertFalse(
+            any(item["path"].startswith(foreign_path + "/") for item in second_plan["proposed_changes"])
+        )
 
     def test_project_mcp_is_authenticated_updated_and_rolled_back_with_foreign_servers(self) -> None:
         self.commit_and_tag(CURRENT_VERSION)

--- a/skills/RECOMMENDED.md
+++ b/skills/RECOMMENDED.md
@@ -86,8 +86,8 @@ updates arrive free, and the harness owns none of it (R10). It installs as one p
 
 ## creative-design
 <!-- MAP creative-design | packs: - | skills: excalidraw-diagram,ui-ux-pro-max -->
-- **excalidraw-diagram** — built in. Clean diagrams. (Pairs with the excalidraw MCP — see
-  `../config/mcp.example.json`.)
+- **excalidraw-diagram** — third-party and not bundled with AgentSmith. Install it separately when
+  clean diagrams are part of the work. (Pairs with the excalidraw MCP — see `../config/mcp.example.json`.)
 - **ui-ux-pro-max** — third-party (MIT), for real interface work: design systems, colour/type
   pairing, layout rules. Not bundled here and deliberately so — it needs **Python 3**, which
   nothing else in this harness does, and it is only useful if you are actually designing a UI.


### PR DESCRIPTION
## Why
Legacy global updates still failed after v0.2.3 because installation fingerprinting recursively entered every directory under the Claude skill root, including foreign Python virtual environments. A normal contained lib64 -> lib link therefore blocked planning.

## What changed
- classify skill directories once and fingerprint only manifest-owned or explicitly reconstructed legacy skills
- separate read-only containment from the strict write-target symlink guard
- authenticate foreign top-level skill names without copying their contents, preserving future bundled-name collisions
- persist reconstructed owned-skill baselines in schema-v1 state and strengthen per-root health validation
- correct the unbundled excalidraw-diagram documentation
- record the two separate deferred installer defects in KNOWN-ISSUES.md

## Evidence
- reproduced the released failure at the exact foreign .venv/lib64 link before the fix
- 41 updater tests pass, including foreign MCP + venv, contained/escaping links, two-release name collisions, and complete managed-file health
- all 19 repository verification phases pass
- fresh independent review completed with no remaining code or test findings