### PR TITLE
Add verification receipts and autonomous collision guards

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -28,16 +28,17 @@ jobs:
         with:
           python-version: '3.13'
       - name: Python core compiles
-        run: python -m py_compile agentsmith.py native_launcher.py evaluate.py config/statusline.py scripts/autonomous-run.py scripts/test-agent-conformance.py scripts/test-autonomous-state.py scripts/test-doctor.py scripts/test-evaluate.py scripts/test-secret-scan.py scripts/test-statusline.py scripts/test-tracker-consent.py scripts/test-update.py compatibility/test_registry.py
+        run: python -m py_compile agentsmith.py native_launcher.py evaluate.py config/statusline.py scripts/autonomous-run.py scripts/test-agent-conformance.py scripts/test-autonomous-state.py scripts/test-doctor.py scripts/test-evaluate.py scripts/test-secret-scan.py scripts/test-statusline.py scripts/test-tracker-consent.py scripts/test-update.py scripts/test-verify-receipts.py compatibility/test_registry.py
       - name: Registry schema and contract
         run: python compatibility/test_registry.py
       - name: Strict cross-platform conformance
         run: python scripts/test-agent-conformance.py --strict
       - name: Stable release updater
         run: python scripts/test-update.py
-      - name: Cross-platform scanner, consent, state ownership, doctor, and evaluation fixtures
+      - name: Cross-platform receipts, scanner, consent, state ownership, doctor, and evaluation fixtures
         run: |
           python scripts/test-secret-scan.py
+          python scripts/test-verify-receipts.py
           python scripts/test-tracker-consent.py
           python scripts/test-autonomous-state.py
           python scripts/test-doctor.py

--- a/.harness/verify.conf
+++ b/.harness/verify.conf
@@ -11,7 +11,7 @@
 # CI runs the Python conformance/registry phases natively on all three operating systems and the
 # remaining POSIX guardrail phases on Ubuntu. This local file remains the superset release gate.
 
-python-core :: python3 -m py_compile agentsmith.py native_launcher.py evaluate.py config/statusline.py scripts/autonomous-run.py scripts/test-agent-conformance.py scripts/test-autonomous-state.py scripts/test-doctor.py scripts/test-evaluate.py scripts/test-secret-scan.py scripts/test-statusline.py scripts/test-tracker-consent.py scripts/test-update.py compatibility/test_registry.py
+python-core :: python3 -m py_compile agentsmith.py native_launcher.py evaluate.py config/statusline.py scripts/autonomous-run.py scripts/test-agent-conformance.py scripts/test-autonomous-state.py scripts/test-doctor.py scripts/test-evaluate.py scripts/test-secret-scan.py scripts/test-statusline.py scripts/test-tracker-consent.py scripts/test-update.py scripts/test-verify-receipts.py compatibility/test_registry.py
 agent-conformance :: python3 scripts/test-agent-conformance.py --strict
 update :: python3 scripts/test-update.py
 registry :: python3 compatibility/test_registry.py
@@ -23,6 +23,7 @@ assemble :: bash scripts/test-assemble.sh
 tracker-consent :: python3 scripts/test-tracker-consent.py
 operator-identity :: bash scripts/test-operator-identity.sh
 secret-scan :: python3 scripts/test-secret-scan.py
+verify-receipts :: python3 scripts/test-verify-receipts.py
 leak-gate  :: bash scripts/test-leak-gate.sh
 wayfinder-spec :: bash scripts/test-wayfinder-spec.sh
 ui-design-hook :: bash scripts/test-ui-design-reminder.sh

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -172,6 +172,7 @@ Set `HARNESS_ORG_DIR` to an explicit directory for fleet packaging or a non-priv
 ```bash
 agentsmith verify --list
 agentsmith verify
+agentsmith verify --record .harness/receipts/my-check
 agentsmith handoff ITEM-123
 agentsmith new-research "topic"
 agentsmith new-feedback "symptom"
@@ -194,7 +195,9 @@ normalized schema-v2 records. Review every failure and secret-scan the records b
 
 Project verification phases live in `.harness/verify.conf` and run with the native OS shell.
 Replace the failing `unwired` placeholder with real build, lint, test, render, or evaluation
-commands before calling the project verified.
+commands before calling the project verified. `verify --record <directory>` resolves a relative
+directory from the project target, refuses to overwrite it, and stores an atomic command receipt
+plus redacted per-phase output. Receipts remain local unless you deliberately move them.
 
 ## 7. Evidence and migration
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Claude-only `--org-policy` manages the OS policy directory with backup/restore o
 ```bash
 agentsmith verify --list
 agentsmith verify
+agentsmith verify --record .harness/receipts/my-check
 agentsmith handoff ITEM-123
 agentsmith new-research "topic"
 agentsmith new-feedback "observed failure"
@@ -171,7 +172,9 @@ printf '%s\n' "text to inspect" | agentsmith secret-scan -
 
 An installed project carries the Python runtime and command shims under `.agentsmith/`, so hooks
 and skills resolve the same CLI on macOS, Linux, and Windows. Verification phases are
-project-owned and run with the native OS shell.
+project-owned and run with the native OS shell. `--record` adds a local, durable `receipt.json`
+and redacted stdout/stderr sidecars; it refuses an existing destination instead of overwriting
+earlier evidence.
 
 The default secret scan examines only added lines in the staged Git diff, which is the pre-commit
 contract. `--all` scans the tracked working tree; file arguments and `-` select explicit files or

--- a/agentsmith.py
+++ b/agentsmith.py
@@ -17,6 +17,7 @@ import io
 import json
 import os
 from pathlib import Path
+import platform
 import re
 import secrets
 import shlex
@@ -25,6 +26,7 @@ import subprocess
 import sys
 import tempfile
 import textwrap
+import threading
 import time
 import tomllib
 from typing import Any, Iterable
@@ -86,6 +88,9 @@ SECRET_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
             re.IGNORECASE,
         ),
     ),
+)
+PEM_PRIVATE_KEY_BEGIN = re.compile(
+    r"-----BEGIN (?P<label>[A-Z0-9 ]*PRIVATE KEY)-----"
 )
 
 
@@ -4081,15 +4086,324 @@ def parse_verify_conf(path: Path) -> list[tuple[str, str]]:
     return phases
 
 
+def verify_timestamp() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def pem_private_key_label(match: re.Match[str]) -> str:
+    return match.group("label")
+
+
+def pem_private_key_end(label: str) -> re.Pattern[str]:
+    return re.compile(
+        rf"^[ \t]*-----END {re.escape(label)}-----[ \t]*(?:\r?\n|\Z)",
+        re.MULTILINE,
+    )
+
+
+def redact_pem_private_keys(value: str) -> tuple[str, int]:
+    output: list[str] = []
+    cursor = 0
+    count = 0
+    while begin := PEM_PRIVATE_KEY_BEGIN.search(value, cursor):
+        output.extend((value[cursor:begin.start()], "[REDACTED]"))
+        count += 1
+        end = pem_private_key_end(pem_private_key_label(begin)).search(value, begin.end())
+        if end is None:
+            cursor = len(value)
+            break
+        cursor = end.end()
+    output.append(value[cursor:])
+    return "".join(output), count
+
+
+def redact_secret_text(value: str) -> tuple[str, list[str]]:
+    redacted, pem_count = redact_pem_private_keys(value)
+    categories: list[str] = []
+    if pem_count:
+        categories.append("PEM private key")
+    for category, pattern in SECRET_PATTERNS:
+        redacted, count = pattern.subn("[REDACTED]", redacted)
+        if count:
+            categories.append(category)
+    return redacted, categories
+
+
+def verification_git_metadata(root: Path) -> dict[str, Any]:
+    available = shutil.which("git") is not None
+    result: dict[str, Any] = {"available": available, "head": None, "branch": None, "dirty": None}
+    if not available:
+        return result
+    inside = subprocess.run(
+        ["git", "-C", str(root), "rev-parse", "--is-inside-work-tree"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    if inside.returncode or inside.stdout.strip() != "true":
+        return result
+
+    def git_value(*arguments: str) -> str | None:
+        observed = subprocess.run(
+            ["git", "-C", str(root), *arguments],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+        )
+        value = observed.stdout.strip()
+        return value if observed.returncode == 0 and value else None
+
+    result["head"] = git_value("rev-parse", "HEAD")
+    result["branch"] = git_value("symbolic-ref", "--quiet", "--short", "HEAD")
+    status = subprocess.run(
+        ["git", "-C", str(root), "status", "--porcelain"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    result["dirty"] = bool(status.stdout) if status.returncode == 0 else None
+    return result
+
+
+def write_verification_receipt(path: Path, receipt: dict[str, Any]) -> None:
+    receipt["updated_at"] = verify_timestamp()
+    rendered = json.dumps(receipt, indent=2, ensure_ascii=False) + "\n"
+    rendered, late_categories = redact_secret_text(rendered)
+    if late_categories:
+        receipt["redactions"] = sorted(set(receipt.get("redactions", [])) | set(late_categories))
+        rendered, _ = redact_secret_text(json.dumps(receipt, indent=2, ensure_ascii=False) + "\n")
+    payload = rendered.encode("utf-8")
+    atomic_write_bytes(path, payload)
+
+
+def stream_redacted_output(source: Any, destination: Any, display: Any,
+                           categories: set[str], failures: list[BaseException]) -> None:
+    pem_label: str | None = None
+    try:
+        for chunk in iter(source.readline, ""):
+            output: list[str] = []
+            remaining = chunk
+            while remaining:
+                if pem_label is not None:
+                    end = pem_private_key_end(pem_label).search(remaining)
+                    if end is None:
+                        remaining = ""
+                        continue
+                    remaining = remaining[end.end():]
+                    pem_label = None
+                begin = PEM_PRIVATE_KEY_BEGIN.search(remaining)
+                if begin is None:
+                    safe, found = redact_secret_text(remaining)
+                    output.append(safe)
+                    categories.update(found)
+                    remaining = ""
+                    continue
+                safe_prefix, found = redact_secret_text(remaining[:begin.start()])
+                output.extend((safe_prefix, "[REDACTED]"))
+                categories.update(found)
+                categories.add("PEM private key")
+                after_begin = remaining[begin.end():]
+                pem_label = pem_private_key_label(begin)
+                end = pem_private_key_end(pem_label).search(after_begin)
+                if end is None:
+                    if chunk.endswith("\n"):
+                        output.append("\n")
+                    remaining = ""
+                else:
+                    remaining = after_begin[end.end():]
+                    pem_label = None
+            redacted = "".join(output)
+            destination.write(redacted)
+            destination.flush()
+            display.write(redacted)
+            display.flush()
+    except BaseException as exc:  # propagated on the controller thread after both streams close
+        failures.append(exc)
+    finally:
+        source.close()
+
+
+def recorded_verify_phase(command: str, root: Path, stdout_path: Path,
+                          stderr_path: Path) -> tuple[int, set[str]]:
+    categories: set[str] = set()
+    failures: list[BaseException] = []
+    process: subprocess.Popen[str] | None = None
+    with (
+        stdout_path.open("w", encoding="utf-8", newline="") as stdout_file,
+        stderr_path.open("w", encoding="utf-8", newline="") as stderr_file,
+    ):
+        process = subprocess.Popen(
+            command,
+            cwd=root,
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            bufsize=1,
+        )
+        assert process.stdout is not None and process.stderr is not None
+        workers = [
+            threading.Thread(
+                target=stream_redacted_output,
+                args=(process.stdout, stdout_file, sys.stdout, categories, failures),
+                daemon=True,
+            ),
+            threading.Thread(
+                target=stream_redacted_output,
+                args=(process.stderr, stderr_file, sys.stderr, categories, failures),
+                daemon=True,
+            ),
+        ]
+        for worker in workers:
+            worker.start()
+        try:
+            return_code = process.wait()
+        except KeyboardInterrupt:
+            process.terminate()
+            process.wait()
+            for worker in workers:
+                worker.join()
+            raise
+        for worker in workers:
+            worker.join()
+        if failures:
+            raise RuntimeError(f"could not capture verification output: {failures[0]}")
+        stdout_file.flush()
+        stderr_file.flush()
+        os.fsync(stdout_file.fileno())
+        os.fsync(stderr_file.fileno())
+    return return_code, categories
+
+
 def cmd_verify(args: argparse.Namespace) -> int:
     root = Path(args.target or os.getcwd()).resolve()
     conf = root / ".harness" / "verify.conf"
     if not conf.exists():
         raise CliError(f"No verification config at {conf}")
     phases = [(label, cmd) for label, cmd in parse_verify_conf(conf) if not args.only or args.only in label]
+    if args.record and args.list:
+        raise CliError("--record cannot be combined with --list")
     if args.list:
         for index, (label, command) in enumerate(phases, 1):
             print(f"{index}. {label} :: {command}")
+        return 0
+    if args.record:
+        record_dir = Path(args.record).expanduser()
+        if not record_dir.is_absolute():
+            record_dir = root / record_dir
+        record_dir = record_dir.resolve()
+        if record_dir.exists():
+            raise CliError(f"Refusing to overwrite existing verification receipt destination {record_dir}")
+        configuration_sha256 = file_sha256(conf)
+        git_metadata = verification_git_metadata(root)
+        try:
+            record_dir.parent.mkdir(parents=True, exist_ok=True)
+            record_dir.mkdir()
+        except FileExistsError as exc:
+            raise CliError(f"Refusing to overwrite existing verification receipt destination {record_dir}") from exc
+        except OSError as exc:
+            raise CliError(f"Cannot create verification receipt destination {record_dir}: {exc}") from exc
+
+        receipt_path = record_dir / "receipt.json"
+        started_at = verify_timestamp()
+        receipt_phases: list[dict[str, Any]] = []
+        for index, (label, command) in enumerate(phases, 1):
+            stdout_name = f"phase-{index:03d}.stdout.txt"
+            stderr_name = f"phase-{index:03d}.stderr.txt"
+            safe_label, label_categories = redact_secret_text(label)
+            safe_command, command_categories = redact_secret_text(command)
+            receipt_phases.append({
+                "index": index,
+                "label": safe_label,
+                "command": safe_command,
+                "status": "pending",
+                "started_at": None,
+                "completed_at": None,
+                "duration_seconds": None,
+                "exit_code": None,
+                "output_paths": {"stdout": stdout_name, "stderr": stderr_name},
+                "output_hashes": {},
+                "redactions": sorted(set(label_categories) | set(command_categories)),
+            })
+        safe_only, _ = redact_secret_text(args.only or "")
+        receipt: dict[str, Any] = {
+            "schema_version": 1,
+            "status": "running",
+            "started_at": started_at,
+            "updated_at": started_at,
+            "completed_at": None,
+            "target": str(root),
+            "only": safe_only if args.only is not None else None,
+            "configuration": {"path": str(conf.resolve()), "sha256": configuration_sha256},
+            "git": git_metadata,
+            "platform": {"os": platform.system(), "python_version": platform.python_version()},
+            "phases": receipt_phases,
+        }
+        write_verification_receipt(receipt_path, receipt)
+        active_phase: dict[str, Any] | None = None
+        try:
+            for index, ((label, command), phase) in enumerate(zip(phases, receipt_phases), 1):
+                active_phase = phase
+                phase_started = time.monotonic()
+                safe_label, label_categories = redact_secret_text(label)
+                safe_command, command_categories = redact_secret_text(command)
+                print(f"[{index}/{len(phases)}] {safe_label}\n  {safe_command}")
+                phase["redactions"] = sorted(
+                    set(phase["redactions"]) | set(label_categories) | set(command_categories)
+                )
+                phase["status"] = "running"
+                phase["started_at"] = verify_timestamp()
+                write_verification_receipt(receipt_path, receipt)
+                stdout_path = record_dir / phase["output_paths"]["stdout"]
+                stderr_path = record_dir / phase["output_paths"]["stderr"]
+                return_code, output_categories = recorded_verify_phase(
+                    command, root, stdout_path, stderr_path
+                )
+                phase["completed_at"] = verify_timestamp()
+                phase["duration_seconds"] = round(time.monotonic() - phase_started, 6)
+                phase["exit_code"] = return_code
+                phase["status"] = "passed" if return_code == 0 else "failed"
+                phase["redactions"] = sorted(set(phase["redactions"]) | output_categories)
+                phase["output_hashes"] = {
+                    "stdout": file_sha256(stdout_path),
+                    "stderr": file_sha256(stderr_path),
+                }
+                if return_code:
+                    receipt["status"] = "failed"
+                    receipt["completed_at"] = verify_timestamp()
+                    write_verification_receipt(receipt_path, receipt)
+                    warn(f"verification phase '{safe_label}' failed with exit {return_code}")
+                    return return_code
+                write_verification_receipt(receipt_path, receipt)
+                active_phase = None
+        except KeyboardInterrupt:
+            raise
+        except Exception as exc:
+            if active_phase is not None:
+                active_phase["status"] = "error"
+                active_phase["completed_at"] = verify_timestamp()
+                active_phase["duration_seconds"] = round(time.monotonic() - phase_started, 6)
+                for stream, stored_path in active_phase["output_paths"].items():
+                    output_path = record_dir / stored_path
+                    if output_path.is_file():
+                        active_phase["output_hashes"][stream] = file_sha256(output_path)
+            receipt["status"] = "error"
+            receipt["completed_at"] = verify_timestamp()
+            write_verification_receipt(receipt_path, receipt)
+            safe_error, _ = redact_secret_text(str(exc))
+            raise CliError(f"Verification recording failed: {safe_error}") from exc
+        receipt["status"] = "passed"
+        receipt["completed_at"] = verify_timestamp()
+        write_verification_receipt(receipt_path, receipt)
+        ok(f"all {len(phases)} verification phases passed")
         return 0
     for index, (label, command) in enumerate(phases, 1):
         print(f"[{index}/{len(phases)}] {label}\n  {command}")
@@ -4468,6 +4782,7 @@ def parser() -> argparse.ArgumentParser:
     verify.add_argument("--target")
     verify.add_argument("--only")
     verify.add_argument("--list", action="store_true")
+    verify.add_argument("--record", metavar="DIRECTORY")
     for name in ("handoff", "new-feedback", "new-research"):
         scaffold = sub.add_parser(name)
         scaffold.add_argument("name", nargs="?")

--- a/docs/03-verify-means-evidence.md
+++ b/docs/03-verify-means-evidence.md
@@ -85,3 +85,14 @@ you wire real phases**. Replacing that line with your build/test/checks is the h
 five minutes in the whole setup ([`02-your-first-hour.md`](02-your-first-hour.md) walks it). From then
 on, "done" has a definition that's versioned with your repo — and the agent's claim and your
 gate are the same command.
+
+Use `agentsmith verify --record <directory>` when the command evidence must survive the terminal
+session. The optional receipt starts in `running`, is replaced atomically after each phase, and
+finishes as `passed`, `failed`, or `error`. It records the config hash, Git/platform context,
+selected filter, phase timing and exit codes, plus SHA-256 hashes of deterministic UTF-8 stdout and
+stderr sidecars. Secret-shaped text is replaced before it reaches either the terminal or disk.
+The destination must not already exist, so a later run cannot silently rewrite earlier evidence.
+
+A command receipt proves only the deterministic phases it captured. Browser screenshots, videos,
+manual assertions, deployed-service checks, and other runtime or visual evidence stay separate;
+reference those artifacts alongside the receipt when the work's end-to-end gate requires them.

--- a/docs/12-whats-built-in.md
+++ b/docs/12-whats-built-in.md
@@ -44,7 +44,7 @@ emulate hooks or MCP to make matrix cells green.
 
 | Command | Purpose |
 |---|---|
-| `agentsmith verify` | Run `.harness/verify.conf` phases with the native OS shell. |
+| `agentsmith verify [--record <directory>]` | Run `.harness/verify.conf` phases with the native OS shell; optionally retain a local redacted command receipt. |
 | `agentsmith handoff` | Scaffold durable session memory with branch/HEAD/dirty facts. |
 | `agentsmith new-research` | Create a durable research note that is archived, never silently deleted. |
 | `agentsmith new-feedback` | Create the five-stage post-incident record. |

--- a/docs/12-whats-built-in.md
+++ b/docs/12-whats-built-in.md
@@ -62,7 +62,8 @@ not the directory in which a skill happened to be installed.
 
 The autonomous-run controller remains constrained to macOS/Linux because its isolation layer uses
 `sandbox-exec` or Bubblewrap. That limitation is declared rather than hidden behind a generic
-Windows compatibility claim.
+Windows compatibility claim. Concurrent local controllers also reserve conservative path prefixes
+and optional manifest resource keys under a repository coordination lock before execution begins.
 
 ## Verification and CI
 

--- a/docs/18-influences.md
+++ b/docs/18-influences.md
@@ -157,6 +157,13 @@ maker structurally cannot fake** — an LLM second opinion cannot catch an overf
 the backtest *is* the overfit artifact.
 → [loop-engineering](https://github.com/cobusgreyling/loop-engineering) · [the essay](https://cobusgreyling.substack.com/p/loop-engineering)
 
+**Michael Shimeles — `evidence-driven-testing` and `new-feature`** — prompted two bounded additions:
+durable command evidence tied to the tested revision/environment, and local collision checks that
+account for both file scope and shared resources outside a worktree. AgentSmith independently adapts
+the concepts; the pinned snapshot has no repository-wide license, so no upstream code was copied and
+its recorder, publishing, and GitHub-query workflows were not adopted.
+→ [evidence skill](https://github.com/michaelshimeles/skills/blob/5d403ea66775c04df222a1e9b302ef64ae45c712/evidence-driven-testing/SKILL.md) · [worktree skill](https://github.com/michaelshimeles/skills/blob/5d403ea66775c04df222a1e9b302ef64ae45c712/new-feature/SKILL.md) · [pinned commit](https://github.com/michaelshimeles/skills/commit/5d403ea66775c04df222a1e9b302ef64ae45c712)
+
 ## Complementary work (not influences)
 
 These shaped nothing in `core/` — they sit *alongside* it, at a different layer.

--- a/docs/19-glossary.md
+++ b/docs/19-glossary.md
@@ -101,6 +101,10 @@ an expert developer, most of the friction here is words — clear that, and the 
 - **Autonomous run** — one finite, accepted implementation ticket executed by a local controller:
   fresh maker → deterministic verifier → fresh checker → accept, retry, or escalate. Its v1
   authority ends at local commits. → [`21-autonomous-runs.md`](21-autonomous-runs.md)
+- **Run scope / resource key** — the path prefixes and optional lowercase `<kind>:<identifier>`
+  values a live autonomous controller reserves against other cooperating runs. This prevents local
+  collisions but provides neither operating-system resource isolation nor adversarial isolation
+  between makers that share repository Git metadata.
 - **Loop** — a harness plus a schedule, durable state, and a verification chain; work that lands
   with no human watching. → [`05-operating-modes.md`](05-operating-modes.md), `profiles/autonomous-loops.md`
 - **Maker / checker** — the mandatory split: the agent that did the work never judges it; a

--- a/docs/19-glossary.md
+++ b/docs/19-glossary.md
@@ -91,7 +91,10 @@ an expert developer, most of the friction here is words — clear that, and the 
 - **Hook** — code that runs at a lifecycle point (pre-commit, pre-tool-call) and can block the
   action. The strongest kind of guard. Codex user hooks require review/trust through `/hooks`.
 - **`agentsmith verify` / `verify.conf`** — the project's "is this shippable?" gate and its definition:
-  `label :: command` phases, run in order, first failure stops.
+  `label :: command` phases, run in order, first failure stops. `--record <directory>` preserves
+  deterministic command evidence without replacing separate runtime or visual evidence.
+- **Verification receipt** — an opt-in, local `receipt.json` plus redacted stdout/stderr sidecars.
+  It ties phase exits and output hashes to the verification config, Git state, platform, and time.
 
 ## Loops (unattended work)
 

--- a/docs/21-autonomous-runs.md
+++ b/docs/21-autonomous-runs.md
@@ -18,7 +18,9 @@ until the operator posts it; naming Linear never grants the run a connector.
 Copy `templates/autonomous-run.json` through the controller's `prepare` command. The manifest pins
 the spec hash, ticket, base ref, maker/checker runtime and model, path boundary, verifier, attempt
 cap, wall-clock budget, and git/external-write policy. It must be reviewed and committed before
-`start` will accept it.
+`start` will accept it. `scope.resources` optionally names local coordination keys such as
+`port:3000`, `db:local/test`, or `service:redis`; omit it in an older manifest or use an empty list
+when the run reserves none.
 
 ## What runs overnight
 
@@ -44,6 +46,16 @@ The v1 boundary is deliberately narrow:
 - maximum three attempts, then escalation;
 - one immutable wall-clock deadline across stop/resume;
 - no automatic context-percentage rollover.
+
+Worktrees isolate tracked files, not every local dependency. Before creating a branch, worktree, or
+run state, the controller compares each live run's declared scope under a short repository-wide
+coordination lock. It derives a conservative literal prefix from each `allowed_paths` glob: parent
+and child prefixes conflict, and a pattern with no literal prefix reserves the whole repository.
+An exact shared resource key also conflicts. These declarations coordinate cooperating AgentSmith
+runs; they do not bind a port or isolate a database at the operating-system level. Concurrent
+worktrees also share writable Git metadata needed for local commits. The controller verifies live
+peer identity before accounting for peer Git artifacts, but this is collision coordination, not
+adversarial isolation: do not run mutually untrusted makers concurrently in one repository.
 
 Codex receives the manifest objective and remaining native goal token budget. Claude receives only
 the remaining run-wide USD allowance. The controller accumulates usage reported by both CLIs and
@@ -74,7 +86,11 @@ Wayfinder spec flow remains available to every work type.
 
 `status <id>` reads controller state from the repository's git-common directory. `start` and
 `resume` hold one per-run lifecycle lock, so a second live controller is refused; a dead owner's
-lock is reclaimed only after its PID is demonstrably gone. `stop <id>` atomically writes a stop
+lock is reclaimed only after its PID is demonstrably gone. While starting or resuming, the short
+repository coordination lock serializes the live-scope scan and lifecycle-state transition, then
+releases before model execution. A conflict names the other run and overlapping path prefix or
+resource. Malformed live scope fails closed; a demonstrably dead controller and a stopped run do
+not block new work. `stop <id>` atomically writes a stop
 request, signals the active controller and child, then waits up to five seconds for the controller
 to persist `interrupted`. It never writes `state.json` itself. If the controller has already died,
 the request remains in place and `resume` reconciles the interruption after acquiring the stale

--- a/docs/research/agentsmith-influences-and-credits.md
+++ b/docs/research/agentsmith-influences-and-credits.md
@@ -155,6 +155,39 @@ surrounding prose in the harness voice with R-number cross-references.
 
 ---
 
+## 8. Michael Shimeles — durable evidence and worktree collision awareness
+
+**Who/source:** Michael Shimeles's `skills` repository, inspected at pinned commit
+[`5d403ea66775c04df222a1e9b302ef64ae45c712`](https://github.com/michaelshimeles/skills/commit/5d403ea66775c04df222a1e9b302ef64ae45c712)
+on 2026-09-02.
+
+- **Evidence provenance.** [`evidence-driven-testing`](https://github.com/michaelshimeles/skills/blob/5d403ea66775c04df222a1e9b302ef64ae45c712/evidence-driven-testing/SKILL.md)
+  binds an evidence manifest/report to the revision or deployment, environment, and named
+  assertions. AgentSmith adapts that provenance idea into optional deterministic command receipts:
+  phase output, timestamps, exit codes, hashes, config identity, Git state, and runtime environment.
+  Screenshots, video, manual assertions, and publishing remain separate evidence rather than fields
+  in the v1 receipt. *Confidence: high* on the source and conceptual lineage; the implementation is
+  independent.
+- **Collision awareness beyond worktrees.** [`new-feature`](https://github.com/michaelshimeles/skills/blob/5d403ea66775c04df222a1e9b302ef64ae45c712/new-feature/SKILL.md)
+  checks changed-file overlap before creating a worktree and warns that ports and databases remain
+  shared. AgentSmith adapts that observation into a local controller guard over conservative path
+  prefixes and declared resource keys, serialized while initial lifecycle state is created.
+  *Confidence: high* on the source and conceptual lineage; AgentSmith does not query pull requests.
+
+**Boundaries:** the FFmpeg recorder, screenshots/video, annotations, uploads, PR/tracker comments,
+`git fetch`, `gh pr list`/`gh pr diff`, dependency installation, and branch/worktree cleanup were not
+adopted. They add dependencies, network or external-write authority, or lifecycle policy beyond the
+two bounded changes.
+
+**Licence and tests:** the pinned repository root contains no `LICENSE`, `LICENSE.md`, or `COPYING`
+file. AgentSmith therefore copied no upstream code and independently implemented concepts only.
+The pinned tree contains a synthetic recorder smoke test (`tests/test_evidence.py`) but no test for
+the `new-feature` procedure; that upstream coverage does not establish real visual-session,
+publishing, or collision-guard behavior. Detailed assessment:
+[`michaelshimeles-skills-assessment.md`](michaelshimeles-skills-assessment.md).
+
+---
+
 ## Mapping at a glance (harness principle → primary source)
 | Harness principle | Strongest source |
 |---|---|
@@ -168,6 +201,8 @@ surrounding prose in the harness voice with R-number cross-references.
 | Writing rules: no-op test, single source of truth, leading words | Matt Pocock, *writing-for-agents* (#7) |
 | Context pointers: a skill description == a CLAUDE.md line naming a doc | Matt Pocock (#7) |
 | Shared architectural language and the risk of locally-correct drift | Armin Ronacher, *The Tower Keeps Rising* (#6); OpenAI Codex harness as complementary implementation evidence |
+| Durable verification evidence tied to revision and environment | Michael Shimeles, `evidence-driven-testing` (#8) |
+| Concurrent worktree collision awareness, including shared local resources | Michael Shimeles, `new-feature` (#8) |
 
 ## All source URLs (flat list)
 - https://x.com/karpathy/status/1937902205765607626
@@ -203,3 +238,6 @@ surrounding prose in the harness voice with R-number cross-references.
 - https://addyosmani.com/blog/agentic-code-quality/
 - https://www.youtube.com/watch?v=96jN2OCOfLs
 - https://lucumr.pocoo.org/2026/7/13/the-tower-keeps-rising/
+- https://github.com/michaelshimeles/skills/commit/5d403ea66775c04df222a1e9b302ef64ae45c712
+- https://github.com/michaelshimeles/skills/blob/5d403ea66775c04df222a1e9b302ef64ae45c712/evidence-driven-testing/SKILL.md
+- https://github.com/michaelshimeles/skills/blob/5d403ea66775c04df222a1e9b302ef64ae45c712/new-feature/SKILL.md

--- a/docs/research/michaelshimeles-skills-assessment.md
+++ b/docs/research/michaelshimeles-skills-assessment.md
@@ -1,0 +1,76 @@
+# Michael Shimeles skills assessment
+
+> Source material is retained under R9. If this note becomes obsolete, move it to
+> `docs/research/_archive/`; do not delete it.
+
+## Question / scope
+
+Which ideas in `michaelshimeles/skills` can sharpen AgentSmith's deterministic verification and
+finite autonomous-run isolation without importing an unlicensed implementation, adding network
+coordination, or widening the harness's tool surface?
+
+The assessment is pinned to commit
+[`5d403ea66775c04df222a1e9b302ef64ae45c712`](https://github.com/michaelshimeles/skills/commit/5d403ea66775c04df222a1e9b302ef64ae45c712).
+
+## Sources consulted
+
+Opened on 2026-09-02:
+
+- [`evidence-driven-testing/SKILL.md`](https://github.com/michaelshimeles/skills/blob/5d403ea66775c04df222a1e9b302ef64ae45c712/evidence-driven-testing/SKILL.md)
+  — the evidence workflow, artifact manifest, revision/environment binding, redaction cautions,
+  headless alternatives, and recorder test claim.
+- [`new-feature/SKILL.md`](https://github.com/michaelshimeles/skills/blob/5d403ea66775c04df222a1e9b302ef64ae45c712/new-feature/SKILL.md)
+  — worktree isolation, changed-file overlap checks, and the warning that ports, databases, and
+  dependency lockfiles remain shared.
+- [Pinned repository tree](https://github.com/michaelshimeles/skills/tree/5d403ea66775c04df222a1e9b302ef64ae45c712)
+  — repository layout, root licensing files, and test surface.
+
+## Findings
+
+### Ideas adapted
+
+**Durable evidence tied to the tested state.** The evidence skill produces a manifest and report
+alongside its capture, names the exact commit/branch or deployment, and records the environment and
+assertions. AgentSmith adapts that provenance principle into an opt-in `agentsmith verify` command
+receipt: deterministic phase output, timestamps, exit codes, hashes, verification-config identity,
+Git state, and runtime environment. Secret-shaped output is redacted before display or persistence.
+The receipt does not claim to contain runtime or visual proof; screenshots, videos, manual
+assertions, and publishing remain separately referenced evidence.
+
+**Isolation must cover collisions outside a worktree.** The new-feature skill checks whether open
+pull requests touch the same files and explicitly warns that worktrees do not isolate ports or
+databases. AgentSmith adapts the collision model to finite local controllers: conservative fixed
+prefixes derived from declared path globs plus explicit local resource keys are checked under a
+repository-wide coordination lock. This is local coordination only, not operating-system-level
+resource isolation.
+
+### Components rejected
+
+- The FFmpeg recorder, video encoding, screenshots, Playwright capture, annotations, and media
+  upload workflow are outside deterministic command receipts and would add dependencies.
+- Posting to pull requests or trackers is outside the local-only verification boundary and would
+  require separate external-write authorization.
+- `git fetch`, `gh pr list`, and `gh pr diff` make collision checks depend on network state and open
+  pull requests. The controller instead checks live local controller state.
+- The upstream branch naming, dependency installation, worktree cleanup, and force-deleting local
+  branches are broader lifecycle policy than this change needs.
+
+### Licensing and test caveats
+
+The pinned repository root contains no `LICENSE`, `LICENSE.md`, or `COPYING` file. Folder-specific
+licenses for vendored components do not establish a repository-wide license for these two skills.
+For that reason, only concepts were studied and the implementation was written independently.
+
+The pinned tree contains `tests/test_evidence.py`, described upstream as a synthetic-source smoke
+test for the recorder. It does not validate real visual sessions, publishing, or the `new-feature`
+worktree procedure; no tests for that procedure appear in the pinned tree. AgentSmith therefore
+relies on its own cross-platform receipt suite and autonomous-controller integration/state tests.
+
+## Open questions / what was not checked
+
+- Later upstream commits were intentionally excluded; this assessment describes only the pinned
+  snapshot.
+- Real recorder behavior, display permissions, media uploads, and authenticated GitHub operations
+  were not executed because none is part of the adaptation.
+- The absence of a root license is an observation about the pinned tree, not legal advice or a
+  claim about rights the author may grant elsewhere.

--- a/scripts/autonomous-run.py
+++ b/scripts/autonomous-run.py
@@ -240,13 +240,66 @@ def release_lifecycle_lock(run_dir: Path, token: str) -> None:
         path.unlink(missing_ok=True)
 
 
+def coordination_lock_path(root: Path) -> Path:
+    return root / "coordination.lock"
+
+
+def read_coordination_lock(root: Path) -> dict[str, Any] | None:
+    path = coordination_lock_path(root)
+    if not path.exists():
+        return None
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RunError(f"cannot verify repository coordination lock {path}: {exc}") from exc
+    if not isinstance(value, dict) or not isinstance(value.get("pid"), int):
+        raise RunError(f"cannot verify repository coordination lock {path}: malformed owner metadata")
+    return value
+
+
 @contextlib.contextmanager
-def lifecycle_lock(run_dir: Path, run_id: str):
-    token = acquire_lifecycle_lock(run_dir, run_id)
+def coordination_lock(root: Path):
+    root.mkdir(parents=True, exist_ok=True)
+    path = coordination_lock_path(root)
+    token = uuid.uuid4().hex
+    record = {"pid": os.getpid(), "run_id": "coordination", "started_at": now(), "token": token}
+    encoded = (json.dumps(record, sort_keys=True) + "\n").encode()
+    deadline = time.monotonic() + 10
+    while True:
+        try:
+            descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        except FileExistsError:
+            existing = read_coordination_lock(root)
+            if existing is None:
+                continue
+            if process_is_live(existing["pid"]):
+                if time.monotonic() >= deadline:
+                    raise RunError(
+                        f"repository coordination is still held by live process {existing['pid']}"
+                    )
+                time.sleep(0.02)
+                continue
+            try:
+                before = path.read_bytes()
+                if path.read_bytes() == before:
+                    path.unlink(missing_ok=True)
+            except FileNotFoundError:
+                pass
+            continue
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+        break
     try:
         yield
     finally:
-        release_lifecycle_lock(run_dir, token)
+        try:
+            existing = read_coordination_lock(root)
+        except RunError:
+            existing = None
+        if existing and existing.get("token") == token:
+            path.unlink(missing_ok=True)
 
 
 def create_stop_request(run_dir: Path) -> None:
@@ -271,6 +324,64 @@ def state_root(repo: Path) -> Path:
 
 def state_path(repo: Path, run_id: str) -> Path:
     return state_root(repo) / run_id / "state.json"
+
+
+def live_run_scope(repo: Path, run_dir: Path, owner: dict[str, Any]) -> tuple[str, dict[str, list[str]]]:
+    run_id = run_dir.name
+    try:
+        if owner.get("run_id") != run_id:
+            raise RunError("lifecycle lock run_id does not match its directory")
+        state_file = run_dir / "state.json"
+        state = load_json(state_file)
+        if state.get("run_id") != run_id:
+            raise RunError("state run_id does not match its directory")
+        if state.get("controller_pid") != owner.get("pid"):
+            raise RunError("lifecycle lock pid does not match durable state")
+        token = owner.get("token")
+        if not isinstance(token, str) or not token or state.get("controller_token") != token:
+            raise RunError("lifecycle lock token does not match durable state")
+        manifest_value = state.get("manifest_path")
+        if not isinstance(manifest_value, str):
+            raise RunError("state has no manifest_path")
+        manifest_path = Path(manifest_value).resolve()
+        if not manifest_path.is_relative_to(repo):
+            raise RunError("manifest path is outside the repository")
+        expected_hash = state.get("manifest_sha256")
+        if not isinstance(expected_hash, str) or not re.fullmatch(r"[0-9a-f]{64}", expected_hash):
+            raise RunError("state has no valid manifest hash")
+        if not manifest_path.is_file() or hashlib.sha256(manifest_path.read_bytes()).hexdigest() != expected_hash:
+            raise RunError("manifest no longer matches durable state")
+        manifest = load_json(manifest_path)
+        if str(manifest.get("run_id")) != run_id:
+            raise RunError("manifest run_id does not match durable state")
+        return run_id, normalized_scope(manifest.get("scope"))
+    except (OSError, RunError) as exc:
+        raise RunError(f"cannot verify scope for live run {run_id}: {exc}") from exc
+
+
+def assert_no_live_scope_conflicts(repo: Path, run_id: str, scope: Any) -> None:
+    candidate = normalized_scope(scope)
+    root = state_root(repo)
+    if not root.exists():
+        return
+    for run_dir in sorted((path for path in root.iterdir() if path.is_dir()), key=lambda path: path.name):
+        if run_dir.name == run_id:
+            continue
+        owner = read_lock(run_dir)
+        if owner is None or not process_is_live(owner["pid"]):
+            continue
+        other_id, other_scope = live_run_scope(repo, run_dir, owner)
+        collision = scope_collision(candidate, other_scope)
+        if collision is None:
+            continue
+        kind, value = collision
+        if kind == "path":
+            raise RunError(
+                f"run {run_id} conflicts with live run {other_id}: overlapping path scope '{value}'"
+            )
+        raise RunError(
+            f"run {run_id} conflicts with live run {other_id}: shared resource '{value}'"
+        )
 
 
 def event(state: dict[str, Any], kind: str, **fields: Any) -> None:
@@ -302,6 +413,80 @@ def frontmatter(text: str) -> dict[str, str]:
     return values
 
 
+RESOURCE_KEY = re.compile(r"[a-z][a-z0-9_-]*:[a-z0-9][a-z0-9._/-]*\Z")
+
+
+def scope_resources(scope: dict[str, Any]) -> list[str]:
+    resources = scope.get("resources", [])
+    if not isinstance(resources, list) or not all(isinstance(item, str) for item in resources):
+        raise RunError("scope.resources must be an array of lowercase coordination keys")
+    if any(not RESOURCE_KEY.fullmatch(item) for item in resources):
+        raise RunError("scope.resources entries must match <kind>:<identifier> in lowercase")
+    if len(resources) != len(set(resources)):
+        raise RunError("scope.resources entries must be unique")
+    return list(resources)
+
+
+def scope_paths(scope: dict[str, Any], key: str) -> list[str]:
+    paths = scope.get(key, [])
+    if not isinstance(paths, list) or not all(isinstance(item, str) and item for item in paths):
+        raise RunError(f"scope.{key} must be an array of repository-relative glob strings")
+    for pattern in paths:
+        parts = pattern.split("/")
+        if pattern.startswith("/") or "\\" in pattern or "." in parts or ".." in parts:
+            raise RunError(f"scope.{key} entries must be repository-relative POSIX globs")
+    return list(paths)
+
+
+def normalized_scope(scope: Any) -> dict[str, list[str]]:
+    if not isinstance(scope, dict):
+        raise RunError("scope must be a JSON object")
+    allowed = scope_paths(scope, "allowed_paths")
+    if not allowed:
+        raise RunError("scope.allowed_paths must reserve at least one path")
+    return {
+        "allowed_paths": allowed,
+        "denied_paths": scope_paths(scope, "denied_paths"),
+        "resources": scope_resources(scope),
+    }
+
+
+def fixed_prefix(pattern: str) -> str:
+    for index, segment in enumerate(pattern.split("/")):
+        if any(marker in segment for marker in "*?["):
+            literal = pattern.split("/")[:index]
+            return "/".join(literal) if literal else "."
+    return pattern.rstrip("/") or "."
+
+
+def prefixes_overlap(left: str, right: str) -> bool:
+    if left == "." or right == ".":
+        return True
+    left_parts = tuple(part for part in left.split("/") if part)
+    right_parts = tuple(part for part in right.split("/") if part)
+    shared = min(len(left_parts), len(right_parts))
+    return left_parts[:shared] == right_parts[:shared]
+
+
+def scope_collision(left_scope: Any, right_scope: Any) -> tuple[str, str] | None:
+    left = normalized_scope(left_scope)
+    right = normalized_scope(right_scope)
+    for left_pattern in left["allowed_paths"]:
+        left_prefix = fixed_prefix(left_pattern)
+        for right_pattern in right["allowed_paths"]:
+            right_prefix = fixed_prefix(right_pattern)
+            if prefixes_overlap(left_prefix, right_prefix):
+                if "." in {left_prefix, right_prefix}:
+                    return "path", "."
+                left_parts = left_prefix.split("/")
+                right_parts = right_prefix.split("/")
+                return "path", left_prefix if len(left_parts) <= len(right_parts) else right_prefix
+    shared_resources = sorted(set(left["resources"]) & set(right["resources"]))
+    if shared_resources:
+        return "resource", shared_resources[0]
+    return None
+
+
 def validate_manifest(manifest: dict[str, Any], repo: Path) -> tuple[Path, str]:
     required = ["schema_version", "run_id", "spec_path", "implementation_ticket", "base_ref",
                 "roles", "scope", "verify", "limits", "git", "external_writes"]
@@ -317,6 +502,7 @@ def validate_manifest(manifest: dict[str, Any], repo: Path) -> tuple[Path, str]:
         raise RunError("implementation_ticket is required; a decision ticket is not executable work")
     if manifest["external_writes"] is not False:
         raise RunError("v1 requires external_writes=false")
+    normalized_scope(manifest["scope"])
     git_policy = manifest["git"]
     expected = {"local_commits": True, "push": False, "merge": False, "history_rewrite": False}
     if any(git_policy.get(k) != v for k, v in expected.items()):
@@ -404,10 +590,64 @@ def resolved_git_path(repo: Path, argument: str) -> Path:
     return raw.resolve() if raw.is_absolute() else (repo / raw).resolve()
 
 
+def registered_run_git_artifacts(common: Path, active_ref: str) -> tuple[set[str], set[Path], set[Path]]:
+    other_refs: set[str] = set()
+    branch_logs: set[Path] = set()
+    worktree_admin: set[Path] = set()
+    runs = common / "agentsmith-runs"
+    if not runs.is_dir():
+        return other_refs, branch_logs, worktree_admin
+    for state_file in runs.glob("*/state.json"):
+        try:
+            state = load_json(state_file)
+            run_id = state_file.parent.name
+            owner = read_lock(state_file.parent)
+            if owner is None or not process_is_live(owner["pid"]):
+                continue
+            repo_value = state.get("repo")
+            if not isinstance(repo_value, str):
+                continue
+            recorded_repo = Path(repo_value).resolve()
+            if state_root(recorded_repo).resolve() != runs.resolve():
+                continue
+            verified_run_id, _ = live_run_scope(recorded_repo, state_file.parent, owner)
+            if verified_run_id != run_id:
+                continue
+            branch = state.get("branch")
+            if state.get("run_id") != run_id or branch != f"agentsmith/{run_id}":
+                continue
+            ref = f"refs/heads/{branch}"
+            if ref != active_ref:
+                other_refs.add(ref)
+                branch_logs.add(Path("logs") / ref)
+            candidates = [state.get("worktree"), state.get("checker_worktree")]
+            for candidate in candidates:
+                if not isinstance(candidate, str):
+                    continue
+                dot_git = Path(candidate) / ".git"
+                if not dot_git.is_file():
+                    continue
+                marker = dot_git.read_text(encoding="utf-8", errors="replace").strip()
+                if not marker.startswith("gitdir: "):
+                    continue
+                git_dir = Path(marker[8:]).resolve()
+                if git_dir.is_relative_to(common):
+                    worktree_admin.add(git_dir.relative_to(common))
+        except (OSError, RunError):
+            # Unverifiable state earns no exclusion. Its Git changes therefore remain protected
+            # and make the caller fail closed instead of being mistaken for controller activity.
+            continue
+    return other_refs, branch_logs, worktree_admin
+
+
 def git_metadata(repo: Path) -> dict[str, Any]:
     common = resolved_git_path(repo, "--git-common-dir")
     active = resolved_git_path(repo, "--git-dir")
     active_rel = active.relative_to(common) if active.is_relative_to(common) else None
+    branch_ref = git(repo, "symbolic-ref", "-q", "HEAD", check=False)
+    other_run_refs, run_branch_logs, run_worktree_admin = registered_run_git_artifacts(
+        common, branch_ref
+    )
     hooks: list[tuple[str, str]] = []
     hooks_dir = common / "hooks"
     if hooks_dir.is_dir():
@@ -415,7 +655,6 @@ def git_metadata(repo: Path) -> dict[str, Any]:
             hooks.append((str(path.relative_to(hooks_dir)), file_digest(path)))
     protected: list[tuple[str, str]] = []
     objects: list[tuple[str, str]] = []
-    branch_ref = git(repo, "symbolic-ref", "-q", "HEAD", check=False)
     branch_log = Path("logs") / branch_ref if branch_ref else None
     for path in sorted(item for item in common.rglob("*") if item.is_file()):
         rel = path.relative_to(common)
@@ -424,12 +663,17 @@ def git_metadata(repo: Path) -> dict[str, Any]:
         if rel.parts[0] == "objects":
             objects.append((rel.as_posix(), file_digest(path)))
             continue
-        if rel.parts[0] == "refs" or (branch_log and rel == branch_log):
+        if rel.parts[0] == "refs" or (branch_log and rel == branch_log) or rel in run_branch_logs:
             continue
         if active_rel and (rel == active_rel or active_rel in rel.parents):
             continue
+        if any(rel == admin or admin in rel.parents for admin in run_worktree_admin):
+            continue
         protected.append((rel.as_posix(), file_digest(path)))
-    refs = git(repo, "for-each-ref", "--format=%(refname) %(objectname)").splitlines()
+    refs = [
+        line for line in git(repo, "for-each-ref", "--format=%(refname) %(objectname)").splitlines()
+        if line.split(" ", 1)[0] not in other_run_refs
+    ]
     return {
         "refs": refs,
         "config": file_digest(common / "config"),
@@ -771,9 +1015,13 @@ def execute(state: dict[str, Any], manifest: dict[str, Any]) -> int:
         checker_worktree = worktree.with_name(f"{worktree.name}-check-{state['attempt']}")
         if checker_worktree.exists():
             raise RunError(f"refusing to overwrite checker worktree {checker_worktree}")
+        state["checker_worktree"] = str(checker_worktree)
+        save_state(state)
         added = run(["git", "worktree", "add", "--detach", str(checker_worktree), checker_head],
                     Path(state["repo"]))
         if added.returncode:
+            state.pop("checker_worktree", None)
+            save_state(state)
             raise RunError(added.stderr.strip() or "checker worktree creation failed")
         try:
             verify = sandboxed_verify(manifest["verify"]["command"], checker_worktree,
@@ -811,6 +1059,8 @@ def execute(state: dict[str, Any], manifest: dict[str, Any]) -> int:
                 event(state, "checker_worktree_cleanup_failed", path=str(checker_worktree),
                       error=removed.stderr.strip())
                 raise RunError(f"could not remove disposable checker worktree: {removed.stderr.strip()}")
+            state.pop("checker_worktree", None)
+            save_state(state)
         if verify.returncode == 0 and checker["status"] == "accepted":
             state["status"] = "accepted"
             state["accepted_commit"] = checker_head
@@ -881,44 +1131,59 @@ def start(args: argparse.Namespace) -> int:
     path = state_path(repo, name)
     if path.exists():
         raise RunError(f"run {name} already exists; use resume or choose another run_id")
-    with lifecycle_lock(path.parent, name):
-        if path.exists():
-            raise RunError(f"run {name} already exists; use resume or choose another run_id")
-        base_head = git(repo, "rev-parse", str(manifest["base_ref"]))
-        if (not git(repo, "config", "user.name", check=False)
-                or not git(repo, "config", "user.email", check=False)):
-            raise RunError("git user.name and user.email must be configured before local commits")
-        branch = f"agentsmith/{name}"
-        default_worktree = repo.parent / f"{repo.name}-{name}"
-        worktree = Path(manifest.get("worktree_path") or default_worktree).resolve()
-        if worktree.exists() or git(repo, "show-ref", "--verify", f"refs/heads/{branch}", check=False):
-            raise RunError(f"refusing to overwrite existing branch/worktree for {name}")
-        created = run(["git", "worktree", "add", "-b", branch, str(worktree), base_head], repo)
-        if created.returncode:
-            raise RunError(created.stderr.strip() or "git worktree creation failed")
-        state = {
-            "schema_version": SCHEMA_VERSION,
-            "run_id": name,
-            "status": "prepared",
-            "attempt": 0,
-            "repo": str(repo),
-            "worktree": str(worktree),
-            "branch": branch,
-            "base_head": base_head,
-            "spec_path": spec_rel.as_posix(),
-            "spec_sha256": spec_hash,
-            "manifest_path": str(manifest_path),
-            "manifest_sha256": hashlib.sha256(manifest_path.read_bytes()).hexdigest(),
-            "started_at": now(),
-            "started_epoch": time.time(),
-            "deadline_epoch": time.time() + int(manifest["limits"]["wall_minutes"]) * 60,
-            "claude_cost_usd": 0.0,
-            "codex_tokens_used": 0,
-            "active_pid": None,
-            "state_path": str(path),
-        }
-        save_state(state, "run_started", branch=branch, worktree=str(worktree))
+    token: str | None = None
+    try:
+        with coordination_lock(state_root(repo)):
+            token = acquire_lifecycle_lock(path.parent, name)
+            if path.exists():
+                raise RunError(f"run {name} already exists; use resume or choose another run_id")
+            assert_no_live_scope_conflicts(repo, name, manifest["scope"])
+            base_head = git(repo, "rev-parse", str(manifest["base_ref"]))
+            if (not git(repo, "config", "user.name", check=False)
+                    or not git(repo, "config", "user.email", check=False)):
+                raise RunError("git user.name and user.email must be configured before local commits")
+            branch = f"agentsmith/{name}"
+            default_worktree = repo.parent / f"{repo.name}-{name}"
+            worktree = Path(manifest.get("worktree_path") or default_worktree).resolve()
+            if worktree.exists() or git(repo, "show-ref", "--verify", f"refs/heads/{branch}", check=False):
+                raise RunError(f"refusing to overwrite existing branch/worktree for {name}")
+            created = run(["git", "worktree", "add", "-b", branch, str(worktree), base_head], repo)
+            if created.returncode:
+                raise RunError(created.stderr.strip() or "git worktree creation failed")
+            state = {
+                "schema_version": SCHEMA_VERSION,
+                "run_id": name,
+                "status": "prepared",
+                "attempt": 0,
+                "repo": str(repo),
+                "worktree": str(worktree),
+                "branch": branch,
+                "base_head": base_head,
+                "spec_path": spec_rel.as_posix(),
+                "spec_sha256": spec_hash,
+                "manifest_path": str(manifest_path),
+                "manifest_sha256": hashlib.sha256(manifest_path.read_bytes()).hexdigest(),
+                "scope": normalized_scope(manifest["scope"]),
+                "started_at": now(),
+                "started_epoch": time.time(),
+                "deadline_epoch": time.time() + int(manifest["limits"]["wall_minutes"]) * 60,
+                "claude_cost_usd": 0.0,
+                "codex_tokens_used": 0,
+                "active_pid": None,
+                "controller_pid": os.getpid(),
+                "controller_token": token,
+                "state_path": str(path),
+            }
+            save_state(state, "run_started", branch=branch, worktree=str(worktree))
         return run_controller(state, manifest)
+    finally:
+        if token is not None:
+            release_lifecycle_lock(path.parent, token)
+            if not path.exists():
+                try:
+                    path.parent.rmdir()
+                except OSError:
+                    pass
 
 
 def status_cmd(args: argparse.Namespace) -> int:
@@ -974,34 +1239,44 @@ def resume(args: argparse.Namespace) -> int:
     if state["status"] == "accepted":
         raise RunError("accepted runs do not resume")
     run_dir = Path(state["state_path"]).parent
-    with lifecycle_lock(run_dir, args.run_id):
-        state = load_run(repo, args.run_id)
-        manifest_path = Path(state["manifest_path"])
-        manifest = load_json(manifest_path)
-        if hashlib.sha256(manifest_path.read_bytes()).hexdigest() != state["manifest_sha256"]:
-            raise RunError("manifest changed since start; create a new run for a changed contract")
-        spec_rel, spec_hash = validate_manifest(manifest, repo)
-        if str(manifest["run_id"]) != state["run_id"]:
-            raise RunError("manifest run_id no longer matches the durable run state")
-        if spec_rel.as_posix() != state["spec_path"] or spec_hash != state["spec_sha256"]:
-            raise RunError("spec changed since start; create a new run for a changed contract")
-        if git(repo, "rev-parse", str(manifest["base_ref"])) != state["base_head"]:
-            raise RunError("base_ref changed since start; create a new run for a changed contract")
-        worktree = Path(state["worktree"])
-        if not worktree.is_dir() or repo_root(worktree) != worktree.resolve():
-            raise RunError("run worktree is missing or no longer a Git worktree")
-        if git(worktree, "symbolic-ref", "--short", "HEAD") != state["branch"]:
-            raise RunError("run worktree is no longer on its recorded branch")
-        if not clean(worktree):
-            raise RunError("cannot resume a dirty worktree")
-        stop_file = run_dir / "STOP"
-        if stop_file.exists():
-            persist_interrupted(state)
-            stop_file.unlink()
-        state["status"] = "resuming"
-        state["reason"] = None
-        save_state(state, "run_resumed")
+    token: str | None = None
+    try:
+        with coordination_lock(state_root(repo)):
+            token = acquire_lifecycle_lock(run_dir, args.run_id)
+            state = load_run(repo, args.run_id)
+            manifest_path = Path(state["manifest_path"])
+            manifest = load_json(manifest_path)
+            if hashlib.sha256(manifest_path.read_bytes()).hexdigest() != state["manifest_sha256"]:
+                raise RunError("manifest changed since start; create a new run for a changed contract")
+            spec_rel, spec_hash = validate_manifest(manifest, repo)
+            if str(manifest["run_id"]) != state["run_id"]:
+                raise RunError("manifest run_id no longer matches the durable run state")
+            if spec_rel.as_posix() != state["spec_path"] or spec_hash != state["spec_sha256"]:
+                raise RunError("spec changed since start; create a new run for a changed contract")
+            if git(repo, "rev-parse", str(manifest["base_ref"])) != state["base_head"]:
+                raise RunError("base_ref changed since start; create a new run for a changed contract")
+            worktree = Path(state["worktree"])
+            if not worktree.is_dir() or repo_root(worktree) != worktree.resolve():
+                raise RunError("run worktree is missing or no longer a Git worktree")
+            if git(worktree, "symbolic-ref", "--short", "HEAD") != state["branch"]:
+                raise RunError("run worktree is no longer on its recorded branch")
+            if not clean(worktree):
+                raise RunError("cannot resume a dirty worktree")
+            assert_no_live_scope_conflicts(repo, args.run_id, manifest["scope"])
+            stop_file = run_dir / "STOP"
+            if stop_file.exists():
+                persist_interrupted(state)
+                stop_file.unlink()
+            state["status"] = "resuming"
+            state["reason"] = None
+            state["scope"] = normalized_scope(manifest["scope"])
+            state["controller_pid"] = os.getpid()
+            state["controller_token"] = token
+            save_state(state, "run_resumed")
         return run_controller(state, manifest)
+    finally:
+        if token is not None:
+            release_lifecycle_lock(run_dir, token)
 
 
 def parser() -> argparse.ArgumentParser:

--- a/scripts/test-autonomous-run.sh
+++ b/scripts/test-autonomous-run.sh
@@ -6,6 +6,8 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 pass=0; fail=0
+concurrent_run_ids=()
+concurrent_runner_pids=()
 ok()  { printf '  \033[32m✓\033[0m %s\n' "$1"; pass=$((pass+1)); }
 bad() { printf '  \033[31m✗\033[0m %s\n' "$1"; fail=$((fail+1)); }
 assert() { local label="$1"; shift; if "$@"; then ok "$label"; else bad "$label"; fi; }
@@ -47,6 +49,7 @@ make_fake() {
     '  emit "{\"status\":\"$status\",\"summary\":\"checker $status\",\"commit\":\"$(git rev-parse HEAD)\",\"changed_paths\":[\"src/change.txt\"],\"evidence\":[\"fake check\"],\"unresolved\":[],\"next_state\":\"$status\"}"' \
     'else' \
     '  if [ "$mode" = slow ]; then sleep 20; fi' \
+    '  if [ "$mode" = collision-slow ]; then sleep 60; fi' \
     '  mkdir -p src' \
     '  n=0; [ -f src/change.txt ] && n="$(<src/change.txt)"' \
     '  printf "%s\n" "$((n+1))" > src/change.txt' \
@@ -116,6 +119,87 @@ invoke() {
     AGENTSMITH_CLAUDE_BIN="$repo/../fake/bin/fake-agent" \
     CODEX_HOME="$repo/../fake/codex-home" \
     python3 "$repo/../fake/controller.py" "$@"
+}
+
+set_manifest_scope() {
+  local repo="$1" id="$2" allowed="$3" resources="$4"
+  python3 - "$repo/.harness/runs/$id.json" "$allowed" "$resources" <<'PY'
+import json, pathlib, sys
+path = pathlib.Path(sys.argv[1])
+value = json.loads(path.read_text())
+value['scope']['allowed_paths'] = [sys.argv[2]]
+if sys.argv[3] == '__legacy__':
+    value['scope'].pop('resources', None)
+else:
+    value['scope']['resources'] = json.loads(sys.argv[3])
+path.write_text(json.dumps(value, indent=2) + '\n')
+PY
+  git -C "$repo" add . && git -C "$repo" commit -qm 'test: declare collision scope'
+}
+
+wait_for_active_run() {
+  local repo="$1" id="$2" state
+  state="$repo/.git/agentsmith-runs/$id/state.json"
+  for _ in {1..50}; do
+    if [ -f "$state" ] && python3 -c 'import json,sys; raise SystemExit(0 if json.load(open(sys.argv[1])).get("active_pid") else 1)' "$state" 2>/dev/null; then
+      return 0
+    fi
+    sleep 0.05
+  done
+  return 1
+}
+
+stop_started_run() {
+  local repo="$1" id="$2"
+  if [ -f "$repo/.git/agentsmith-runs/$id/state.json" ]; then
+    (cd "$repo" && python3 "$repo/../fake/controller.py" stop "$id" >/dev/null 2>&1) || true
+  fi
+}
+
+expect_collision() {
+  local repo="$1" id="$2" label="$3" output error runner rc
+  output="$repo/../$id-out"
+  error="$repo/../$id-err"
+  (
+    cd "$repo" || exit 1
+    invoke "$repo" collision-slow start ".harness/runs/$id.json" >"$output" 2>"$error"
+  ) & runner=$!
+  for _ in {1..50}; do
+    if [ -f "$repo/.git/agentsmith-runs/$id/state.json" ] || ! kill -0 "$runner" 2>/dev/null; then break; fi
+    sleep 0.05
+  done
+  if [ -f "$repo/.git/agentsmith-runs/$id/state.json" ]; then
+    bad "$label"
+    stop_started_run "$repo" "$id"
+    wait "$runner" 2>/dev/null || true
+  else
+    wait "$runner"; rc=$?
+    if [ "$rc" -ne 0 ]; then ok "$label"; else bad "$label"; fi
+  fi
+  assert "$id rejection creates no branch" bash -c "! git -C '$repo' show-ref --verify --quiet 'refs/heads/agentsmith/$id'"
+  assert "$id rejection creates no worktree" test ! -e "$repo-$id"
+  assert "$id rejection creates no state" test ! -e "$repo/.git/agentsmith-runs/$id/state.json"
+}
+
+expect_concurrent_start() {
+  local repo="$1" id="$2" label="$3" hold="${4:-yes}" runner
+  (
+    cd "$repo" || exit 1
+    invoke "$repo" collision-slow start ".harness/runs/$id.json" >"$repo/../$id-out" 2>"$repo/../$id-err"
+  ) & runner=$!
+  if wait_for_active_run "$repo" "$id"; then
+    ok "$label"
+    if [ "$hold" = yes ]; then
+      concurrent_run_ids+=("$id")
+      concurrent_runner_pids+=("$runner")
+    else
+      stop_started_run "$repo" "$id"
+      wait "$runner" 2>/dev/null || true
+    fi
+  else
+    bad "$label"
+    wait "$runner" 2>/dev/null || true
+  fi
 }
 
 case "$(uname -s)" in
@@ -304,6 +388,143 @@ if (cd "$repo" && invoke "$repo" always-reject start .harness/runs/capped.json >
   bad 'run exceeded its rejection cap'
 else ok 'three checker rejections escalate'; fi
 assert 'attempt cap is persisted and reported' grep -q 'attempt cap reached (3)' "$repo/../err"
+
+echo 'autonomous-run — concurrent scope and resource collision protection'
+repo="$(new_repo collisions)"; make_fake "$repo/../fake"
+manifest "$repo" live-primary; set_manifest_scope "$repo" live-primary 'src/**' '["port:3000"]'
+manifest "$repo" overlap-path; set_manifest_scope "$repo" overlap-path 'src/widgets/**' '["service:widgets"]'
+manifest "$repo" shared-resource; set_manifest_scope "$repo" shared-resource 'docs/**' '["port:3000"]'
+manifest "$repo" disjoint; set_manifest_scope "$repo" disjoint 'docs/**' '["service:redis"]'
+manifest "$repo" wildcard-root; set_manifest_scope "$repo" wildcard-root '**/*.md' '["db:wide"]'
+manifest "$repo" legacy; set_manifest_scope "$repo" legacy 'tests/**' '__legacy__'
+manifest "$repo" malformed-candidate; set_manifest_scope "$repo" malformed-candidate 'tests/**' '["service:malformed-check"]'
+manifest "$repo" dead-owner-ignored; set_manifest_scope "$repo" dead-owner-ignored 'src/widgets/**' '["service:dead-check"]'
+manifest "$repo" race-a; set_manifest_scope "$repo" race-a 'packages/shared/**' '["service:race-a"]'
+manifest "$repo" race-b; set_manifest_scope "$repo" race-b 'packages/shared/sub/**' '["service:race-b"]'
+manifest "$repo" successor; set_manifest_scope "$repo" successor 'src/widgets/**' '["port:4000"]'
+(
+  cd "$repo" || exit 1
+  invoke "$repo" collision-slow start .harness/runs/live-primary.json >../primary-out 2>../primary-err
+) & primary_runner=$!
+if wait_for_active_run "$repo" live-primary; then ok 'primary collision fixture is live'
+else bad 'primary collision fixture did not become live'; fi
+
+expect_collision "$repo" overlap-path 'ancestor/descendant path overlap is rejected'
+assert 'path collision names the conflicting run and prefix' bash -c "grep -q 'live-primary' '$repo/../overlap-path-err' && grep -q 'src' '$repo/../overlap-path-err'"
+expect_collision "$repo" shared-resource 'shared declared resource is rejected'
+assert 'resource collision names the conflicting run and key' bash -c "grep -q 'live-primary' '$repo/../shared-resource-err' && grep -q 'port:3000' '$repo/../shared-resource-err'"
+expect_collision "$repo" wildcard-root 'glob without a fixed prefix reserves the repository root'
+assert 'wildcard-root collision names the conflicting run' grep -q 'live-primary' "$repo/../wildcard-root-err"
+
+mkdir -p "$repo/.git/agentsmith-runs/malformed-live"
+python3 - "$repo/.git/agentsmith-runs/malformed-live/controller.lock" <<'PY'
+import json, os, pathlib, sys
+pathlib.Path(sys.argv[1]).write_text(
+    json.dumps({'pid': os.getppid(), 'run_id': 'malformed-live', 'token': 'fixture'}) + '\n',
+    encoding='utf-8',
+)
+PY
+expect_collision "$repo" malformed-candidate 'unverifiable scope for a live owner fails closed'
+assert 'malformed live-state refusal names the run' grep -q 'malformed-live' "$repo/../malformed-candidate-err"
+python3 - "$repo/.git/agentsmith-runs/malformed-live" <<'PY'
+import pathlib, sys
+directory = pathlib.Path(sys.argv[1])
+(directory / 'controller.lock').unlink()
+directory.rmdir()
+PY
+
+expect_concurrent_start "$repo" disjoint 'disjoint paths and resources may run concurrently'
+expect_concurrent_start "$repo" legacy 'legacy manifest without resources remains valid and non-conflicting'
+
+(
+  cd "$repo" || exit 1
+  invoke "$repo" collision-slow start .harness/runs/race-a.json >../race-a-out 2>../race-a-err
+) & race_a_runner=$!
+(
+  cd "$repo" || exit 1
+  invoke "$repo" collision-slow start .harness/runs/race-b.json >../race-b-out 2>../race-b-err
+) & race_b_runner=$!
+for _ in {1..50}; do
+  race_states=0
+  [ -f "$repo/.git/agentsmith-runs/race-a/state.json" ] && race_states=$((race_states+1))
+  [ -f "$repo/.git/agentsmith-runs/race-b/state.json" ] && race_states=$((race_states+1))
+  [ "$race_states" -gt 0 ] && break
+  sleep 0.05
+done
+sleep 0.2
+race_states=0
+[ -f "$repo/.git/agentsmith-runs/race-a/state.json" ] && race_states=$((race_states+1))
+[ -f "$repo/.git/agentsmith-runs/race-b/state.json" ] && race_states=$((race_states+1))
+if [ "$race_states" -eq 1 ]; then ok 'simultaneous overlapping starts serialize to one live run'
+else bad 'simultaneous overlapping starts did not serialize to one live run'; fi
+if [ -f "$repo/.git/agentsmith-runs/race-a/state.json" ]; then
+  race_winner=race-a; race_loser=race-b
+else
+  race_winner=race-b; race_loser=race-a
+fi
+if [ "$race_states" -eq 1 ]; then
+  assert 'simultaneous-start loser creates no branch' bash -c "! git -C '$repo' show-ref --verify --quiet 'refs/heads/agentsmith/$race_loser'"
+  assert 'simultaneous-start loser creates no worktree' test ! -e "$repo-$race_loser"
+fi
+(cd "$repo" && python3 "$repo/../fake/controller.py" stop live-primary >/dev/null 2>&1)
+wait "$primary_runner" 2>/dev/null || true
+assert 'stopped primary run is durably interrupted' bash -c "cd '$repo' && python3 '$repo/../fake/controller.py' status live-primary | grep -q '\"status\": \"interrupted\"'"
+for id in "${concurrent_run_ids[@]}" race-a race-b; do
+  stop_started_run "$repo" "$id"
+done
+for runner in "${concurrent_runner_pids[@]}" "$race_a_runner" "$race_b_runner"; do
+  wait "$runner" 2>/dev/null || true
+done
+mkdir -p "$repo/.git/agentsmith-runs/dead-scope"
+python3 - "$repo/.git/agentsmith-runs/dead-scope/controller.lock" <<'PY'
+import json, pathlib, sys
+pathlib.Path(sys.argv[1]).write_text(
+    json.dumps({'pid': 99999999, 'run_id': 'dead-scope', 'token': 'fixture'}) + '\n',
+    encoding='utf-8',
+)
+PY
+expect_concurrent_start "$repo" dead-owner-ignored 'demonstrably dead controller no longer reserves its scope' no
+(
+  cd "$repo" || exit 1
+  invoke "$repo" collision-slow start .harness/runs/successor.json >../successor-out 2>../successor-err
+) & successor_runner=$!
+if wait_for_active_run "$repo" successor; then ok 'stopped run no longer reserves its former scope'
+else
+  sed -n '1,8p' "$repo/../successor-err"
+  bad 'stopped run still blocked its former scope'
+fi
+
+(
+  cd "$repo" || exit 1
+  invoke "$repo" collision-slow resume live-primary >../resume-collision-out 2>../resume-collision-err
+) & resume_runner=$!
+resume_restarted=0
+for _ in {1..50}; do
+  if ! kill -0 "$resume_runner" 2>/dev/null; then break; fi
+  if python3 -c 'import json,sys; raise SystemExit(0 if json.load(open(sys.argv[1])).get("active_pid") else 1)' \
+      "$repo/.git/agentsmith-runs/live-primary/state.json" 2>/dev/null; then
+    resume_restarted=1
+    break
+  fi
+  sleep 0.05
+done
+if [ "$resume_restarted" -eq 1 ]; then
+  bad 'resume is rejected while another conflicting controller is live'
+  stop_started_run "$repo" live-primary
+  wait "$resume_runner" 2>/dev/null || true
+else
+  wait "$resume_runner"; resume_rc=$?
+  if [ "$resume_rc" -ne 0 ]; then ok 'resume is rejected while another conflicting controller is live'
+  else bad 'resume is rejected while another conflicting controller is live'; fi
+fi
+if grep -q 'successor' "$repo/../resume-collision-err" && grep -q 'src' "$repo/../resume-collision-err"; then
+  ok 'resume collision names the live conflicting run and prefix'
+else
+  sed -n '1,8p' "$repo/../resume-collision-err"
+  bad 'resume collision names the live conflicting run and prefix'
+fi
+stop_started_run "$repo" successor
+wait "$successor_runner" 2>/dev/null || true
 
 echo 'autonomous-run — operator stop and clean resume'
 repo="$(new_repo stopped)"; make_fake "$repo/../fake"; manifest "$repo" stopped

--- a/scripts/test-autonomous-state.py
+++ b/scripts/test-autonomous-state.py
@@ -23,6 +23,94 @@ SPEC.loader.exec_module(CONTROLLER)
 
 
 class AutonomousStateTests(unittest.TestCase):
+    def test_legacy_scope_defaults_to_no_coordinated_resources(self) -> None:
+        scope = {"allowed_paths": ["src/**"], "denied_paths": []}
+        self.assertEqual(CONTROLLER.scope_resources(scope), [])
+        self.assertNotIn("resources", scope)
+
+    def test_resource_keys_are_lowercase_unique_coordination_identifiers(self) -> None:
+        valid = ["port:3000", "db:local/test", "service:redis"]
+        self.assertEqual(CONTROLLER.scope_resources({"resources": valid}), valid)
+
+        for invalid in (
+            ["PORT:3000"],
+            ["port:Local"],
+            ["port"],
+            ["port:"],
+            [":3000"],
+            ["port:3000 extra"],
+        ):
+            with self.subTest(invalid=invalid):
+                with self.assertRaisesRegex(CONTROLLER.RunError, "scope.resources"):
+                    CONTROLLER.scope_resources({"resources": invalid})
+
+        with self.assertRaisesRegex(CONTROLLER.RunError, "unique"):
+            CONTROLLER.scope_resources({"resources": ["port:3000", "port:3000"]})
+
+    def test_fixed_prefix_stops_before_the_first_glob_segment(self) -> None:
+        cases = {
+            "src/**": "src",
+            "src/components/*.tsx": "src/components",
+            "docs/[ab]*/index.md": "docs",
+            "README.md": "README.md",
+            "**/*.md": ".",
+            "*": ".",
+        }
+        for pattern, expected in cases.items():
+            with self.subTest(pattern=pattern):
+                self.assertEqual(CONTROLLER.fixed_prefix(pattern), expected)
+
+    def test_scope_paths_reject_dot_segments_that_can_hide_overlap(self) -> None:
+        with self.assertRaisesRegex(CONTROLLER.RunError, "repository-relative"):
+            CONTROLLER.normalized_scope({"allowed_paths": ["src/./**"]})
+
+    def test_unlocked_state_cannot_exempt_a_self_declared_git_ref(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="agentsmith forged state ") as temporary:
+            common = Path(temporary)
+            run_dir = common / "agentsmith-runs" / "evil"
+            run_dir.mkdir(parents=True)
+            CONTROLLER.write_json(
+                run_dir / "state.json",
+                {"run_id": "evil", "branch": "agentsmith/evil"},
+            )
+
+            refs, logs, worktrees = CONTROLLER.registered_run_git_artifacts(
+                common, "refs/heads/agentsmith/active"
+            )
+
+            self.assertEqual(refs, set())
+            self.assertEqual(logs, set())
+            self.assertEqual(worktrees, set())
+
+    def test_prefix_overlap_is_segment_aware_and_bidirectional(self) -> None:
+        self.assertTrue(CONTROLLER.prefixes_overlap("src", "src/widgets"))
+        self.assertTrue(CONTROLLER.prefixes_overlap("src/widgets", "src"))
+        self.assertTrue(CONTROLLER.prefixes_overlap("src", "src"))
+        self.assertFalse(CONTROLLER.prefixes_overlap("src", "src2"))
+        self.assertFalse(CONTROLLER.prefixes_overlap("docs", "src"))
+
+    def test_wildcard_root_reserves_the_whole_repository(self) -> None:
+        broad = {"allowed_paths": ["**/*.md"]}
+        narrow = {"allowed_paths": ["src/**"]}
+        self.assertEqual(CONTROLLER.scope_collision(broad, narrow), ("path", "."))
+        self.assertEqual(CONTROLLER.scope_collision(narrow, broad), ("path", "."))
+
+    def test_scope_collision_names_shared_paths_or_resources(self) -> None:
+        parent = {"allowed_paths": ["src/**"], "resources": ["port:3000"]}
+        child = {"allowed_paths": ["src/widgets/**"], "resources": ["service:redis"]}
+        other_path_same_resource = {
+            "allowed_paths": ["docs/**"],
+            "resources": ["port:3000"],
+        }
+        disjoint = {"allowed_paths": ["tests/**"], "resources": ["db:local/test"]}
+
+        self.assertEqual(CONTROLLER.scope_collision(parent, child), ("path", "src"))
+        self.assertEqual(
+            CONTROLLER.scope_collision(parent, other_path_same_resource),
+            ("resource", "port:3000"),
+        )
+        self.assertIsNone(CONTROLLER.scope_collision(parent, disjoint))
+
     def test_atomic_replace_retries_a_transient_windows_sharing_denial(self) -> None:
         denial = PermissionError("destination is momentarily shared")
         denial.winerror = 5
@@ -92,6 +180,54 @@ class AutonomousStateTests(unittest.TestCase):
             recovered = CONTROLLER.acquire_lifecycle_lock(run_dir, "fixture")
             self.assertNotEqual(recovered, "stale")
             CONTROLLER.release_lifecycle_lock(run_dir, recovered)
+
+    def test_repository_coordination_lock_serializes_and_reclaims_stale_owner(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="agentsmith coordination ") as temporary:
+            root = Path(temporary)
+            first_entered = threading.Event()
+            second_attempted = threading.Event()
+            second_entered = threading.Event()
+            release_first = threading.Event()
+            observed_lock: list[Path] = []
+
+            def first() -> None:
+                with CONTROLLER.coordination_lock(root):
+                    files = list(root.iterdir())
+                    self.assertEqual(len(files), 1)
+                    observed_lock.append(files[0])
+                    first_entered.set()
+                    self.assertTrue(release_first.wait(2))
+
+            def second() -> None:
+                self.assertTrue(first_entered.wait(2))
+                second_attempted.set()
+                with CONTROLLER.coordination_lock(root):
+                    second_entered.set()
+
+            with ThreadPoolExecutor(max_workers=2) as pool:
+                first_future = pool.submit(first)
+                second_future = pool.submit(second)
+                self.assertTrue(first_entered.wait(2))
+                self.assertTrue(second_attempted.wait(2))
+                self.assertFalse(second_entered.wait(0.05))
+                release_first.set()
+                first_future.result()
+                second_future.result()
+
+            self.assertTrue(second_entered.is_set())
+            lock = observed_lock[0]
+            self.assertFalse(lock.exists())
+            stale_pid = next(
+                pid for pid in range(99_999_999, 99_999_900, -1)
+                if not CONTROLLER.process_is_live(pid)
+            )
+            lock.write_text(
+                json.dumps({"pid": stale_pid, "run_id": "coordination", "token": "stale"}) + "\n",
+                encoding="utf-8",
+            )
+            with CONTROLLER.coordination_lock(root):
+                self.assertTrue(lock.exists())
+            self.assertFalse(lock.exists())
 
     def test_stop_request_creation_is_atomic_and_idempotent(self) -> None:
         with tempfile.TemporaryDirectory(prefix="agentsmith stop ") as temporary:

--- a/scripts/test-verify-receipts.py
+++ b/scripts/test-verify-receipts.py
@@ -1,0 +1,476 @@
+#!/usr/bin/env python3
+"""Cross-platform behavioral tests for durable verification receipts."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import datetime as dt
+import hashlib
+import importlib.util
+import io
+import json
+import os
+from pathlib import Path
+import platform
+import re
+import shlex
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CORE = ROOT / "agentsmith.py"
+SHA256 = re.compile(r"[0-9a-f]{64}\Z")
+FINAL_STATUSES = {"passed", "failed", "error"}
+SPEC = importlib.util.spec_from_file_location("agentsmith_verify_receipts", CORE)
+assert SPEC and SPEC.loader
+AGENTSMITH = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(AGENTSMITH)
+
+
+def shell_command(*arguments: str) -> str:
+    """Quote one argv for the native shell used by agentsmith verify."""
+    return subprocess.list2cmdline(list(arguments)) if os.name == "nt" else shlex.join(arguments)
+
+
+class VerifyReceiptTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory(prefix="agentsmith verify receipt ü ")
+        self.root = Path(self.temporary.name) / "project with spaces ü"
+        (self.root / ".harness").mkdir(parents=True)
+        self.helper = self.root / "phase helper ü.py"
+        self.helper.write_text(
+            """from pathlib import Path
+import sys
+import time
+
+action = sys.argv[1]
+if action == "emit":
+    print(sys.argv[2], flush=True)
+elif action == "emit_pem":
+    print("-----BEGIN RSA PRIV" + "ATE KEY-----", flush=True)
+    print("c3VwZXItc2VjcmV0LWtleS1ib2R5", flush=True)
+    print("YW5vdGhlci1zZWNyZXQtbGluZQ==", flush=True)
+    print("-----END RSA PRIV" + "ATE KEY-----", flush=True)
+elif action == "emit_mismatched_pem":
+    print("-----BEGIN RSA PRIV" + "ATE KEY-----", flush=True)
+    print("cHJpdmF0ZS1ibG9jay1wcmVmaXg=", flush=True)
+    print("-----END EC PRIV" + "ATE KEY-----", flush=True)
+    print("bXVzdC1yZW1haW4taGlkZGVu", flush=True)
+    print("-----END RSA PRIV" + "ATE KEY-----", flush=True)
+elif action == "emit_prefixed_pem_end":
+    print("-----BEGIN RSA PRIV" + "ATE KEY-----", flush=True)
+    print("-----END RSA PRIV" + "ATE KEYCHAIN-----", flush=True)
+    print("Zmlyc3QtaGlkZGVuLWJvZHk=", flush=True)
+    print("XEND RSA PRIV" + "ATE KEYX", flush=True)
+    print("c2Vjb25kLWhpZGRlbi1ib2R5", flush=True)
+    print("X-----END RSA PRIV" + "ATE KEY-----X", flush=True)
+    print("ZGFzaGVkLWRlY29yYXRlZC1oaWRkZW4=", flush=True)
+    print("-----END RSA PRIV" + "ATE KEY EXTRA-----", flush=True)
+    print("dGhpcmQtaGlkZGVuLWJvZHk=", flush=True)
+    print("END RSA PRIV" + "ATE KEY EXTRA", flush=True)
+    print("Zm91cnRoLWhpZGRlbi1ib2R5", flush=True)
+    print("END RSA PRIV" + "ATE KEY: EXTRA", flush=True)
+    print("ZmlmdGgtaGlkZGVuLWJvZHk=", flush=True)
+    print("-----END RSA PRIV" + "ATE KEY-----", flush=True)
+elif action == "fail":
+    print(sys.argv[2], flush=True)
+    raise SystemExit(int(sys.argv[3]))
+elif action == "mark":
+    Path(sys.argv[2]).write_text(sys.argv[3], encoding="utf-8")
+elif action == "sleep":
+    print("phase waiting", flush=True)
+    time.sleep(float(sys.argv[2]))
+else:
+    raise SystemExit(99)
+""",
+            encoding="utf-8",
+        )
+        self.env = os.environ.copy()
+        self.env["PYTHONUTF8"] = "1"
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def phase(self, action: str, *arguments: str) -> str:
+        return shell_command(sys.executable, str(self.helper), action, *arguments)
+
+    def configure(self, *phases: tuple[str, str]) -> Path:
+        conf = self.root / ".harness" / "verify.conf"
+        conf.write_text(
+            "".join(f"{label} :: {command}\n" for label, command in phases),
+            encoding="utf-8",
+        )
+        return conf
+
+    def run_verify(self, *arguments: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(CORE), "verify", "--target", str(self.root), *arguments],
+            cwd=ROOT,
+            env=self.env,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            capture_output=True,
+            check=False,
+            timeout=30,
+        )
+
+    @staticmethod
+    def read_receipt(directory: Path) -> dict:
+        return json.loads((directory / "receipt.json").read_text(encoding="utf-8"))
+
+    @staticmethod
+    def artifact(directory: Path, stored_path: str) -> Path:
+        candidate = Path(stored_path)
+        return candidate if candidate.is_absolute() else directory / candidate
+
+    def assert_timestamp(self, value: object) -> None:
+        self.assertIsInstance(value, str)
+        dt.datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+
+    def assert_valid_receipt(self, directory: Path, receipt: dict, *, final: bool) -> None:
+        self.assertEqual(receipt["schema_version"], 1)
+        self.assertEqual(Path(receipt["target"]), self.root.resolve())
+        self.assert_timestamp(receipt["started_at"])
+        self.assert_timestamp(receipt["updated_at"])
+        if final:
+            self.assertIn(receipt["status"], FINAL_STATUSES)
+            self.assert_timestamp(receipt["completed_at"])
+        else:
+            self.assertEqual(receipt["status"], "running")
+            self.assertIsNone(receipt["completed_at"])
+
+        configuration = receipt["configuration"]
+        self.assertEqual(Path(configuration["path"]), (self.root / ".harness" / "verify.conf").resolve())
+        self.assertRegex(configuration["sha256"], SHA256)
+
+        git = receipt["git"]
+        self.assertIsInstance(git["available"], bool)
+        self.assertIn("head", git)
+        self.assertIn("branch", git)
+        self.assertIn("dirty", git)
+        observed_platform = receipt["platform"]
+        self.assertEqual(observed_platform["os"], platform.system())
+        self.assertEqual(observed_platform["python_version"], platform.python_version())
+
+        for index, phase in enumerate(receipt["phases"], 1):
+            self.assertEqual(phase["index"], index)
+            self.assertIn(phase["status"], {"pending", "running", "passed", "failed", "error"})
+            self.assertIsInstance(phase["redactions"], list)
+            if phase["status"] in FINAL_STATUSES:
+                self.assert_timestamp(phase["started_at"])
+                self.assert_timestamp(phase["completed_at"])
+                self.assertIsInstance(phase["duration_seconds"], (int, float))
+                self.assertGreaterEqual(phase["duration_seconds"], 0)
+                if phase["status"] in {"passed", "failed"}:
+                    self.assertIsInstance(phase["exit_code"], int)
+                self.assertEqual(set(phase["output_paths"]), set(phase["output_hashes"]))
+                for stream, stored_path in phase["output_paths"].items():
+                    path = self.artifact(directory, stored_path)
+                    self.assertTrue(path.is_file(), f"missing {stream} artifact: {path}")
+                    content = path.read_bytes()
+                    self.assertEqual(phase["output_hashes"][stream], hashlib.sha256(content).hexdigest())
+                    self.assertRegex(phase["output_hashes"][stream], SHA256)
+
+    def test_successful_multi_phase_run_records_metadata_and_stable_output_hashes(self) -> None:
+        conf = self.configure(
+            ("build ü", self.phase("emit", "first output ü")),
+            ("tests", self.phase("emit", "second output")),
+        )
+        first_directory = self.root / "receipt one ü"
+        first = self.run_verify("--record", first_directory.name)
+        self.assertEqual(first.returncode, 0, first.stdout + first.stderr)
+        receipt = self.read_receipt(first_directory)
+        self.assert_valid_receipt(first_directory, receipt, final=True)
+        self.assertEqual(receipt["status"], "passed")
+        self.assertIsNone(receipt["only"])
+        self.assertEqual(receipt["configuration"]["sha256"], hashlib.sha256(conf.read_bytes()).hexdigest())
+        self.assertEqual([phase["status"] for phase in receipt["phases"]], ["passed", "passed"])
+        self.assertIn("first output ü", first.stdout)
+        self.assertIn("second output", first.stdout)
+
+        second_directory = self.root / "receipt two ü"
+        second = self.run_verify("--record", second_directory.name)
+        self.assertEqual(second.returncode, 0, second.stdout + second.stderr)
+        second_receipt = self.read_receipt(second_directory)
+        self.assertEqual(
+            [phase["output_hashes"] for phase in receipt["phases"]],
+            [phase["output_hashes"] for phase in second_receipt["phases"]],
+        )
+        self.assertEqual(
+            [phase["output_paths"] for phase in receipt["phases"]],
+            [phase["output_paths"] for phase in second_receipt["phases"]],
+            "equivalent phases should use deterministic relative sidecar paths",
+        )
+        for phase in receipt["phases"]:
+            self.assertTrue(all(not Path(path).is_absolute() for path in phase["output_paths"].values()))
+
+    def test_failure_stops_later_phases_and_preserves_process_exit_code(self) -> None:
+        marker = self.root / "must not run.txt"
+        self.configure(
+            ("first", self.phase("emit", "before failure")),
+            ("failing", self.phase("fail", "expected failure", "7")),
+            ("later", self.phase("mark", str(marker), "ran")),
+        )
+        directory = self.root / "failed receipt"
+        result = self.run_verify("--record", directory.name)
+        self.assertEqual(result.returncode, 7, result.stdout + result.stderr)
+        self.assertFalse(marker.exists())
+        receipt = self.read_receipt(directory)
+        self.assert_valid_receipt(directory, receipt, final=True)
+        self.assertEqual(receipt["status"], "failed")
+        self.assertEqual([phase["status"] for phase in receipt["phases"]], ["passed", "failed", "pending"])
+        self.assertEqual(receipt["phases"][1]["exit_code"], 7)
+
+    def test_running_receipt_is_durable_between_phase_updates(self) -> None:
+        self.configure(
+            ("first", self.phase("emit", "finished first")),
+            ("waiting", self.phase("sleep", "30")),
+        )
+        directory = self.root / "partial receipt"
+        command = [
+            sys.executable,
+            str(CORE),
+            "verify",
+            "--target",
+            str(self.root),
+            "--record",
+            directory.name,
+        ]
+        process_options: dict[str, object] = {}
+        if os.name == "nt":
+            process_options["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+        else:
+            process_options["start_new_session"] = True
+        process = subprocess.Popen(
+            command,
+            cwd=ROOT,
+            env=self.env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            **process_options,
+        )
+        try:
+            deadline = time.monotonic() + 10
+            receipt: dict = {}
+            while time.monotonic() < deadline:
+                try:
+                    receipt = self.read_receipt(directory)
+                except (FileNotFoundError, json.JSONDecodeError):
+                    time.sleep(0.05)
+                    continue
+                statuses = [phase["status"] for phase in receipt.get("phases", [])]
+                if statuses == ["passed", "running"]:
+                    break
+                time.sleep(0.05)
+            else:
+                self.fail(f"receipt never reached durable partial state: {receipt}")
+            self.assert_valid_receipt(directory, receipt, final=False)
+        finally:
+            if process.poll() is None:
+                if os.name == "nt":
+                    subprocess.run(
+                        ["taskkill", "/PID", str(process.pid), "/T", "/F"],
+                        capture_output=True,
+                        check=False,
+                    )
+                else:
+                    os.killpg(process.pid, signal.SIGKILL)
+                process.wait(timeout=10)
+            if process.stdout is not None:
+                process.stdout.close()
+
+    def test_git_and_non_git_targets_record_truthful_repository_state(self) -> None:
+        self.configure(("check", self.phase("emit", "ok")))
+        non_git_directory = Path(self.temporary.name) / "non git receipt"
+        non_git = self.run_verify("--record", str(non_git_directory))
+        self.assertEqual(non_git.returncode, 0, non_git.stdout + non_git.stderr)
+        non_git_metadata = self.read_receipt(non_git_directory)["git"]
+        self.assertIsNone(non_git_metadata["head"])
+        self.assertIsNone(non_git_metadata["branch"])
+        self.assertIsNone(non_git_metadata["dirty"])
+
+        subprocess.run(["git", "-C", str(self.root), "init", "-q"], check=True)
+        subprocess.run(["git", "-C", str(self.root), "config", "user.name", "Receipt Test"], check=True)
+        subprocess.run(["git", "-C", str(self.root), "config", "user.email", "user@example.com"], check=True)
+        subprocess.run(["git", "-C", str(self.root), "add", ".harness/verify.conf", self.helper.name], check=True)
+        subprocess.run(["git", "-C", str(self.root), "commit", "-qm", "test: establish fixture"], check=True)
+
+        clean_directory = self.root / "clean git receipt"
+        clean_result = self.run_verify("--record", clean_directory.name)
+        self.assertEqual(clean_result.returncode, 0, clean_result.stdout + clean_result.stderr)
+        clean_metadata = self.read_receipt(clean_directory)["git"]
+        self.assertTrue(clean_metadata["available"])
+        self.assertRegex(clean_metadata["head"], r"[0-9a-f]{40}\Z")
+        self.assertTrue(clean_metadata["branch"])
+        self.assertFalse(clean_metadata["dirty"])
+
+        (self.root / "dirty.txt").write_text("dirty\n", encoding="utf-8")
+        git_directory = self.root / "git receipt"
+        git_result = self.run_verify("--record", git_directory.name)
+        self.assertEqual(git_result.returncode, 0, git_result.stdout + git_result.stderr)
+        git_metadata = self.read_receipt(git_directory)["git"]
+        self.assertTrue(git_metadata["available"])
+        self.assertRegex(git_metadata["head"], r"[0-9a-f]{40}\Z")
+        self.assertTrue(git_metadata["branch"])
+        self.assertTrue(git_metadata["dirty"])
+
+    def test_only_records_selected_filter_and_selected_phases(self) -> None:
+        marker = self.root / "excluded.txt"
+        self.configure(
+            ("unit ü", self.phase("emit", "selected")),
+            ("integration", self.phase("mark", str(marker), "ran")),
+        )
+        directory = self.root / "only receipt"
+        result = self.run_verify("--only", "unit", "--record", directory.name)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertFalse(marker.exists())
+        receipt = self.read_receipt(directory)
+        self.assertEqual(receipt["only"], "unit")
+        self.assertEqual([phase["label"] for phase in receipt["phases"]], ["unit ü"])
+
+    def test_existing_destination_is_refused_before_any_phase_runs(self) -> None:
+        marker = self.root / "ran.txt"
+        self.configure(("write marker", self.phase("mark", str(marker), "ran")))
+        directory = self.root / "existing receipt"
+        directory.mkdir()
+        sentinel = directory / "keep.txt"
+        sentinel.write_text("keep\n", encoding="utf-8")
+        result = self.run_verify("--record", directory.name)
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+        self.assertIn("exist", result.stderr.lower())
+        self.assertFalse(marker.exists())
+        self.assertEqual(sentinel.read_text(encoding="utf-8"), "keep\n")
+        self.assertFalse((directory / "receipt.json").exists())
+
+    def test_record_cannot_be_combined_with_list(self) -> None:
+        self.configure(("check", self.phase("emit", "must not run")))
+        directory = self.root / "listed receipt"
+        result = self.run_verify("--list", "--record", directory.name)
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+        self.assertIn("--list", result.stderr)
+        self.assertIn("--record", result.stderr)
+        self.assertFalse(directory.exists())
+
+    def test_capture_setup_error_finishes_an_honest_error_receipt(self) -> None:
+        self.configure(("check", self.phase("emit", "must not run")))
+        directory = self.root / "error receipt"
+        arguments = argparse.Namespace(
+            target=str(self.root), only=None, list=False, record=directory.name
+        )
+
+        def fail_capture(_command: str, _root: Path, stdout_path: Path, stderr_path: Path) -> None:
+            stdout_path.write_text("", encoding="utf-8")
+            stderr_path.write_text("", encoding="utf-8")
+            raise OSError("capture unavailable")
+
+        with (
+            mock.patch.object(AGENTSMITH, "recorded_verify_phase", side_effect=fail_capture),
+            contextlib.redirect_stdout(io.StringIO()),
+            contextlib.redirect_stderr(io.StringIO()),
+            self.assertRaisesRegex(AGENTSMITH.CliError, "recording failed"),
+        ):
+            AGENTSMITH.cmd_verify(arguments)
+        receipt = self.read_receipt(directory)
+        self.assert_valid_receipt(directory, receipt, final=True)
+        self.assertEqual(receipt["status"], "error")
+        self.assertEqual(receipt["phases"][0]["status"], "error")
+        self.assertIsNone(receipt["phases"][0]["exit_code"])
+
+    def test_secret_shaped_output_and_command_are_redacted_everywhere(self) -> None:
+        secret_value = "s" + "k-" + "A" * 32
+        self.configure((secret_value, self.phase("fail", secret_value, "9")))
+        directory = self.root / "redacted receipt"
+        result = self.run_verify("--record", directory.name)
+        self.assertEqual(result.returncode, 9, result.stdout + result.stderr)
+        receipt = self.read_receipt(directory)
+        serialized = json.dumps(receipt, ensure_ascii=False)
+        sidecars = "".join(
+            self.artifact(directory, path).read_text(encoding="utf-8")
+            for phase in receipt["phases"]
+            for path in phase["output_paths"].values()
+        )
+        exposed = result.stdout + result.stderr + serialized + sidecars
+        self.assertNotIn(secret_value, exposed)
+        self.assertIn("[REDACTED]", exposed)
+        self.assertIn("OpenAI-style key", receipt["phases"][0]["redactions"])
+
+    def test_multiline_pem_private_key_is_redacted_as_a_complete_block(self) -> None:
+        self.configure(("pem output", self.phase("emit_pem")))
+        directory = self.root / "pem receipt"
+        result = self.run_verify("--record", directory.name)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        receipt = self.read_receipt(directory)
+        serialized = json.dumps(receipt, ensure_ascii=False)
+        sidecars = "".join(
+            self.artifact(directory, path).read_text(encoding="utf-8")
+            for phase in receipt["phases"]
+            for path in phase["output_paths"].values()
+        )
+        exposed = result.stdout + result.stderr + serialized + sidecars
+        self.assertNotIn("c3VwZXItc2VjcmV0LWtleS1ib2R5", exposed)
+        self.assertNotIn("YW5vdGhlci1zZWNyZXQtbGluZQ==", exposed)
+        self.assertNotIn("END RSA PRIVATE KEY", exposed)
+        self.assertIn("[REDACTED]", exposed)
+        self.assertIn("PEM private key", receipt["phases"][0]["redactions"])
+
+    def test_mismatched_pem_end_marker_does_not_end_redaction(self) -> None:
+        self.configure(("mismatched pem output", self.phase("emit_mismatched_pem")))
+        directory = self.root / "mismatched pem receipt"
+        result = self.run_verify("--record", directory.name)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        receipt = self.read_receipt(directory)
+        serialized = json.dumps(receipt, ensure_ascii=False)
+        sidecars = "".join(
+            self.artifact(directory, path).read_text(encoding="utf-8")
+            for phase in receipt["phases"]
+            for path in phase["output_paths"].values()
+        )
+        exposed = result.stdout + result.stderr + serialized + sidecars
+        self.assertNotIn("cHJpdmF0ZS1ibG9jay1wcmVmaXg=", exposed)
+        self.assertNotIn("bXVzdC1yZW1haW4taGlkZGVu", exposed)
+        self.assertNotIn("END EC PRIVATE KEY", exposed)
+        self.assertNotIn("END RSA PRIVATE KEY", exposed)
+        self.assertIn("[REDACTED]", exposed)
+
+    def test_prefixed_pem_end_markers_do_not_end_redaction(self) -> None:
+        self.configure(("prefixed pem ends", self.phase("emit_prefixed_pem_end")))
+        directory = self.root / "prefixed pem receipt"
+        result = self.run_verify("--record", directory.name)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        receipt = self.read_receipt(directory)
+        serialized = json.dumps(receipt, ensure_ascii=False)
+        sidecars = "".join(
+            self.artifact(directory, path).read_text(encoding="utf-8")
+            for phase in receipt["phases"]
+            for path in phase["output_paths"].values()
+        )
+        exposed = result.stdout + result.stderr + serialized + sidecars
+        for hidden in (
+            "Zmlyc3QtaGlkZGVuLWJvZHk=",
+            "c2Vjb25kLWhpZGRlbi1ib2R5",
+            "ZGFzaGVkLWRlY29yYXRlZC1oaWRkZW4=",
+            "dGhpcmQtaGlkZGVuLWJvZHk=",
+            "Zm91cnRoLWhpZGRlbi1ib2R5",
+            "ZmlmdGgtaGlkZGVuLWJvZHk=",
+            "END RSA PRIVATE KEYCHAIN",
+            "XEND RSA PRIVATE KEYX",
+            "END RSA PRIVATE KEY EXTRA",
+            "END RSA PRIVATE KEY: EXTRA",
+        ):
+            self.assertNotIn(hidden, exposed)
+        self.assertIn("[REDACTED]", exposed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/autonomous-run/SKILL.md
+++ b/skills/autonomous-run/SKILL.md
@@ -34,8 +34,12 @@ python3 scripts/autonomous-run.py prepare --run-id <short-id> --spec docs/specs/
 ```
 
 This only creates a manifest. Review its exact allowed/denied paths, verifier, models, attempt cap,
-wall-clock limit, and budgets. Commit it before execution; the controller refuses an uncommitted
-contract.
+wall-clock limit, budgets, and optional `scope.resources` keys such as `port:3000` or
+`db:local/test`. Resource keys coordinate cooperating local runs; they do not replace operating-
+system port binding or database isolation. Commit the manifest before execution; the controller
+refuses an uncommitted contract. Concurrent worktrees share writable Git metadata needed for local
+commits, so this guard prevents accidental collisions between cooperating runs; it is not a
+security boundary for mutually untrusted makers.
 
 ## Start and supervise
 
@@ -51,6 +55,12 @@ deterministic verifier and a fresh checker. A rejection becomes the next maker's
 failed attempts, invalid state, denied scope, immutable-deadline or reported-budget exhaustion,
 Git metadata drift, or checker mutation escalates instead of widening authority. Verification
 fails closed unless macOS `sandbox-exec` or Linux `bubblewrap` is available.
+
+Before `start` creates local Git or state artifacts, and before `resume` restarts work, the
+controller serializes a repository-local collision scan. Ancestor/descendant fixed prefixes from
+`scope.allowed_paths` conflict; a glob with no fixed prefix reserves the repository; identical
+resource keys conflict. Live malformed state fails closed, while stopped or demonstrably dead
+controllers no longer reserve their scopes.
 
 Use `status <id>`, `stop <id>`, or `resume <id>`. Stop/resume retains the worktree and audit state.
 An accepted run ends at a local commit for human review: never push, open a PR, merge, deploy,

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -22,9 +22,16 @@ adapter such as `.claude/skills`. Use canonical `AGENTS.md` when an instruction 
    macOS/Linux and `.agentsmith\\agentsmith.cmd verify` on Windows). It runs every phase in
    `.harness/verify.conf` and stops at the first
    failure). `--list` shows the phases; `--only <tag>` iterates just one.
+   Add `--record <directory>` when deterministic command evidence needs a durable local receipt.
+   The destination must be new; relative paths resolve from the project target. Record mode
+   redacts secret-shaped console and sidecar output before either is emitted.
 2. On a failure: read the label + command it printed, explain in plain language what broke, and
    point at that phase's line in `.harness/verify.conf` to fix or refine.
 3. Report the actual pass/fail output — not a summary of intent.
+
+The v1 receipt covers deterministic commands only. Keep screenshots, videos, manual assertions,
+published results, and real runtime or visual checks as separately referenced artifacts. A green
+receipt does not satisfy an end-to-end gate that requires those observations.
 
 ## Fallback — no runner or no conf
 1. Say so plainly, and look at `.harness/verify.conf.example` for the intended phases.

--- a/templates/autonomous-run.json
+++ b/templates/autonomous-run.json
@@ -43,7 +43,8 @@
       "**/migrations/**",
       "**/terraform/**",
       "**/k8s/**"
-    ]
+    ],
+    "resources": []
   },
   "spec_path": "",
   "verify": {


### PR DESCRIPTION
Why

Verification evidence currently disappears with the terminal session, and concurrent local autonomous runs can collide through shared paths, resources, and Git metadata.

What changed

- add opt-in agentsmith verify --record receipts with atomic progress, Git/config provenance, SHA-256 sidecar hashes, and fail-closed secret redaction
- add cooperative path-prefix and resource-key collision checks for autonomous start/resume
- add cross-platform receipt coverage and autonomous state/integration coverage
- document limitations and retain the pinned independent source assessment and credits

Verification

- independent adversarial review: approved after PEM multiline, mismatched-label, decorated-marker, CRLF, EOF, and consecutive-block probes
- python3 agentsmith.py verify: all 20 phases passed
- receipt suite: 12/12
- autonomous state: 14/14
- autonomous integration: 87/87
- concrete verify --record run: passed and sidecar hashes revalidated

Release note

The separately authorized v0.3.0 release will be prepared only after this PR is reviewed, the Ubuntu/macOS/Windows matrix is green, and this PR is merged.