### PR TITLE
Release AgentSmith 0.3.0

### DIFF
--- a/agentsmith.py
+++ b/agentsmith.py
@@ -34,7 +34,7 @@ import urllib.error
 import urllib.request
 
 
-VERSION = "0.2.5"
+VERSION = "0.3.0"
 OFFICIAL_REMOTE = "https://github.com/PromptPartner/agentsmith.git"
 ROOT = Path(__file__).resolve().parent
 REGISTRY_PATH = ROOT / "config" / "agents.json"

--- a/docs/23-updating-existing-installations.md
+++ b/docs/23-updating-existing-installations.md
@@ -6,7 +6,11 @@ the existing installation, and keep planning separate from applying.
 
 ## Current release and legacy blockers
 
-The current stable release is `v0.2.5`.
+The current stable release is `v0.3.0`.
+
+`v0.3.0` adds opt-in durable verification receipts and cooperative collision protection for local
+autonomous runs. Both features are additive; existing verification commands and autonomous-run
+manifests without resource keys remain valid.
 
 **Do not apply `v0.2.1` to a pre-manifest, Claude-only installation when skills exist only under
 `~/.claude/skills` or its user-scope MCP configuration exists only in `~/.claude.json`.** In that legacy shape,
@@ -35,7 +39,7 @@ installation fingerprints. This ownership defect is fixed in `v0.2.4` and record
 `.agents/skills` source changes. Claude discovers the stale adapter, while strict Doctor can report
 it as healthy. This ownership defect is fixed in `v0.2.5` and recorded in
 [`feedback/0024-claude-skill-adapter-drift-treated-as-customization.md`](feedback/0024-claude-skill-adapter-drift-treated-as-customization.md).
-Use `v0.2.5` for the complete legacy global update chain: foreign skill contents are preserved and
+Use `v0.3.0` for the complete legacy global update chain: foreign skill contents are preserved and
 ignored, canonical customizations are retained and mirrored to Claude, and symlinks escaping an
 owned inventory root remain rejected.
 
@@ -63,7 +67,7 @@ installation that does not have one yet.
 ```bash
 AGENTSMITH_BOOTSTRAP_DIR="$(mktemp -d)"
 
-git clone --depth 1 --branch v0.2.5 \
+git clone --depth 1 --branch v0.3.0 \
   https://github.com/PromptPartner/agentsmith.git \
   "$AGENTSMITH_BOOTSTRAP_DIR"
 
@@ -71,7 +75,7 @@ git -C "$AGENTSMITH_BOOTSTRAP_DIR" rev-parse HEAD
 git -C "$AGENTSMITH_BOOTSTRAP_DIR" describe --tags --exact-match
 ```
 
-The final command must print `v0.2.5`. This proves the bootstrap is the immutable release tag rather
+The final command must print `v0.3.0`. This proves the bootstrap is the immutable release tag rather
 than an unreviewed branch checkout.
 
 ## Update one project installation
@@ -81,13 +85,13 @@ but does not modify the target.
 
 ```bash
 AGENTSMITH_TARGET="/absolute/path/to/project"
-AGENTSMITH_PLAN="/tmp/agentsmith-project-name-v0.2.5-plan.json"
+AGENTSMITH_PLAN="/tmp/agentsmith-project-name-v0.3.0-plan.json"
 
 git -C "$AGENTSMITH_TARGET" status --short
 
 python3 "$AGENTSMITH_BOOTSTRAP_DIR/agentsmith.py" update plan \
   --target "$AGENTSMITH_TARGET" \
-  --version v0.2.5 \
+  --version v0.3.0 \
   --save "$AGENTSMITH_PLAN"
 
 python3 -m json.tool "$AGENTSMITH_PLAN" | less
@@ -121,18 +125,18 @@ python3 "$AGENTSMITH_TARGET/.agentsmith/agentsmith.py" doctor \
 Global scope is separate from every project scope. Create and inspect its own plan:
 
 ```bash
-AGENTSMITH_PLAN="/tmp/agentsmith-global-v0.2.5-plan.json"
+AGENTSMITH_PLAN="/tmp/agentsmith-global-v0.3.0-plan.json"
 
 python3 "$AGENTSMITH_BOOTSTRAP_DIR/agentsmith.py" update plan \
   --global \
-  --version v0.2.5 \
+  --version v0.3.0 \
   --save "$AGENTSMITH_PLAN"
 
 python3 -m json.tool "$AGENTSMITH_PLAN" | less
 ```
 
 Global MCP is foreign by construction because AgentSmith supports MCP ownership only at project
-scope. `v0.2.5` therefore does not parse global MCP while reconstructing or validating capability
+scope. `v0.3.0` therefore does not parse global MCP while reconstructing or validating capability
 ownership. For valid user-scope client configuration, it preserves foreign MCP entries. A malformed
 client config can still block reconciliation of other AgentSmith-managed native settings, so repair
 invalid JSON or TOML before a non-assemble-only update. For a reconstructed legacy installation,


### PR DESCRIPTION
Why

PR #30 adds two backward-compatible capabilities that warrant a minor release: durable verification receipts and cooperative autonomous-run collision protection.

Release changes

- bump the runtime version from 0.2.5 to 0.3.0
- update the current-release runbook, bootstrap tag, plan filenames, and updater selectors
- preserve historical v0.2.5 defect references

Verification

- independent release review: approved with no blocking findings
- python3 agentsmith.py --version: agentsmith 0.3.0
- python3 agentsmith.py verify: all 20 phases passed after the version bump
- release diff: two files, clean diff check

Publication gate

Merge only after the Ubuntu/macOS/Windows matrix is green. After merge, create an annotated v0.3.0 tag on the merge commit, verify tag/version/commit agreement, and publish the GitHub release.