### PR TITLE
feat(integration): prevent validation from mutating durable state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 __pycache__/
 *.pyc
 .harness/handoffs/
+.harness/cache/
 # self-update remote (a user's private repo URL — keep it out of the tracked tree)
 .harness/remote
 # per-machine agent permissions, written by the tool as you work. The tracked
@@ -42,3 +43,4 @@ docs/feedback/[0-9]*.md
 !docs/feedback/0022-global-update-blocked-by-foreign-mcp.md
 !docs/feedback/0023-update-inventoried-foreign-skill-trees.md
 !docs/feedback/0024-claude-skill-adapter-drift-treated-as-customization.md
+!docs/feedback/0025-mcp-validation-mutated-durable-state.md

--- a/.harness/verify.conf
+++ b/.harness/verify.conf
@@ -11,7 +11,7 @@
 # CI runs the Python conformance/registry phases natively on all three operating systems and the
 # remaining POSIX guardrail phases on Ubuntu. This local file remains the superset release gate.
 
-python-core :: python3 -m py_compile agentsmith.py native_launcher.py evaluate.py config/statusline.py scripts/autonomous-run.py scripts/test-agent-conformance.py scripts/test-autonomous-state.py scripts/test-doctor.py scripts/test-evaluate.py scripts/test-secret-scan.py scripts/test-statusline.py scripts/test-tracker-consent.py scripts/test-update.py scripts/test-verify-receipts.py compatibility/test_registry.py
+python-core :: python3 -m py_compile agentsmith.py native_launcher.py evaluate.py config/statusline.py scripts/autonomous-run.py scripts/test-agent-conformance.py scripts/test-autonomous-state.py scripts/test-doctor.py scripts/test-durable-checkpoints.py scripts/test-evaluate.py scripts/test-integration-validation.py scripts/test-secret-scan.py scripts/test-statusline.py scripts/test-tracker-consent.py scripts/test-update.py scripts/test-verify-receipts.py compatibility/test_registry.py
 agent-conformance :: python3 scripts/test-agent-conformance.py --strict
 update :: python3 scripts/test-update.py
 registry :: python3 compatibility/test_registry.py
@@ -24,6 +24,8 @@ tracker-consent :: python3 scripts/test-tracker-consent.py
 operator-identity :: bash scripts/test-operator-identity.sh
 secret-scan :: python3 scripts/test-secret-scan.py
 verify-receipts :: python3 scripts/test-verify-receipts.py
+integration-validation :: python3 scripts/test-integration-validation.py
+durable-checkpoints :: python3 scripts/test-durable-checkpoints.py
 leak-gate  :: bash scripts/test-leak-gate.sh
 wayfinder-spec :: bash scripts/test-wayfinder-spec.sh
 ui-design-hook :: bash scripts/test-ui-design-reminder.sh

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -172,7 +172,8 @@ Set `HARNESS_ORG_DIR` to an explicit directory for fleet packaging or a non-priv
 ```bash
 agentsmith verify --list
 agentsmith verify
-agentsmith verify --record .harness/receipts/my-check
+agentsmith verify --record .harness/receipts/my-check --tree-class operator-worktree
+agentsmith validate-integration --checkpoint .planning/integration-checkpoint.json
 agentsmith handoff ITEM-123
 agentsmith new-research "topic"
 agentsmith new-feedback "symptom"
@@ -195,9 +196,11 @@ normalized schema-v2 records. Review every failure and secret-scan the records b
 
 Project verification phases live in `.harness/verify.conf` and run with the native OS shell.
 Replace the failing `unwired` placeholder with real build, lint, test, render, or evaluation
-commands before calling the project verified. `verify --record <directory>` resolves a relative
-directory from the project target, refuses to overwrite it, and stores an atomic command receipt
-plus redacted per-phase output. Receipts remain local unless you deliberately move them.
+commands before calling the project verified. `verify --record <directory> --tree-class <class>`
+resolves a relative directory from the project target, refuses to overwrite it, and stores an
+atomic command receipt plus redacted per-phase output. `clean-clone` additionally rejects dirty Git
+state. Receipts remain local unless you deliberately move them. `validate-integration` performs
+static JSON checks only; it does not install or launch the declared integration.
 
 ## 7. Evidence and migration
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,8 @@ Claude-only `--org-policy` manages the OS policy directory with backup/restore o
 ```bash
 agentsmith verify --list
 agentsmith verify
-agentsmith verify --record .harness/receipts/my-check
+agentsmith verify --record .harness/receipts/my-check --tree-class operator-worktree
+agentsmith validate-integration --checkpoint .planning/integration-checkpoint.json
 agentsmith handoff ITEM-123
 agentsmith new-research "topic"
 agentsmith new-feedback "observed failure"
@@ -172,9 +173,11 @@ printf '%s\n' "text to inspect" | agentsmith secret-scan -
 
 An installed project carries the Python runtime and command shims under `.agentsmith/`, so hooks
 and skills resolve the same CLI on macOS, Linux, and Windows. Verification phases are
-project-owned and run with the native OS shell. `--record` adds a local, durable `receipt.json`
-and redacted stdout/stderr sidecars; it refuses an existing destination instead of overwriting
-earlier evidence.
+project-owned and run with the native OS shell. `--record` plus an explicit `--tree-class` adds a
+local, durable `receipt.json` and redacted stdout/stderr sidecars; `clean-clone` refuses dirty Git
+state, and every mode refuses an existing destination. `validate-integration` reads the structured
+checkpoint described by `.harness/templates/integration-checkpoint.md`; it never installs or starts
+the configured package.
 
 The default secret scan examines only added lines in the staged Git diff, which is the pre-commit
 contract. `--all` scans the tracked working tree; file arguments and `-` select explicit files or

--- a/agentsmith.py
+++ b/agentsmith.py
@@ -775,6 +775,350 @@ def mcp_source(names: Iterable[str]) -> dict[str, Any]:
     return selected
 
 
+EXACT_PACKAGE_SPEC = re.compile(
+    r"^(?:@[A-Za-z0-9._-]+/[A-Za-z0-9._-]+|[A-Za-z0-9._-]+)@"
+    r"(?P<version>(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)"
+    r"(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)$"
+)
+
+
+def executable_package_spec(configuration: Any) -> str | None:
+    """Return an npx package operand from structured configuration without running it."""
+    if not isinstance(configuration, dict):
+        return None
+    command = configuration.get("command")
+    args = configuration.get("args")
+    if not isinstance(command, str) or not isinstance(args, list):
+        return None
+    executable = Path(command).name.casefold().removesuffix(".cmd").removesuffix(".exe")
+    if executable != "npx":
+        return None
+    for value in args:
+        if isinstance(value, str) and value and not value.startswith("-"):
+            return value
+    return None
+
+
+def executable_package_version(configuration: Any) -> str:
+    package = executable_package_spec(configuration)
+    match = EXACT_PACKAGE_SPEC.fullmatch(package or "")
+    return match.group("version") if match else ""
+
+
+def integration_issue(issues: list[dict[str, str]], index: int, code: str, message: str) -> None:
+    issues.append({"integration": f"integration-{index}", "code": code, "message": message})
+
+
+def integration_flag(configuration: dict[str, Any], argument: str, environment: str) -> bool:
+    args = configuration.get("args") if isinstance(configuration.get("args"), list) else []
+    env = configuration.get("env") if isinstance(configuration.get("env"), dict) else {}
+    value = env.get(environment)
+    return any(
+        isinstance(item, str) and (item == argument or item.startswith(argument + "="))
+        for item in args
+    ) or (isinstance(value, str) and value.casefold() in {"1", "true", "yes"})
+
+
+def validate_integration_checkpoint(document: Any) -> dict[str, Any]:
+    """Validate declared checkpoint facts without installing or launching an integration."""
+    issues: list[dict[str, str]] = []
+    limit = "Static declarations only; no authority, side effects, invocation, response minimization, or cleanup was inferred."
+    if not isinstance(document, dict) or document.get("schema_version") != 1:
+        return {
+            "schema_version": 1,
+            "complete": False,
+            "integrations_checked": 0,
+            "issues": [{
+                "integration": "document",
+                "code": "unsupported-checkpoint-schema",
+                "message": "checkpoint must be a schema_version 1 object",
+            }],
+            "limits": limit,
+        }
+    integrations = document.get("integrations")
+    if not isinstance(integrations, list) or not integrations:
+        integrations = []
+        issues.append({
+            "integration": "document",
+            "code": "integrations-missing",
+            "message": "checkpoint must contain at least one integration",
+        })
+
+    for index, integration in enumerate(integrations, 1):
+        if not isinstance(integration, dict):
+            integration_issue(issues, index, "integration-malformed", "integration entry must be an object")
+            continue
+        configuration = integration.get("configuration")
+        configuration = configuration if isinstance(configuration, dict) else {}
+        args = configuration.get("args") if isinstance(configuration.get("args"), list) else []
+        env = configuration.get("env") if isinstance(configuration.get("env"), dict) else {}
+        diagnostics = configuration.get("diagnostics")
+        diagnostics = diagnostics if isinstance(diagnostics, dict) else {}
+
+        package = executable_package_spec(configuration)
+        pinned_version = executable_package_version(configuration)
+        if package is not None and not pinned_version:
+            integration_issue(
+                issues, index, "executable-package-unpinned",
+                "pin the executable package to an exact semantic version in durable configuration",
+            )
+        package_record = integration.get("package")
+        discovered = package_record.get("discovered_version") if isinstance(package_record, dict) else None
+        if pinned_version and (not isinstance(discovered, str) or not discovered):
+            integration_issue(
+                issues, index, "package-discovery-unrecorded",
+                "record the discovered upstream version separately from the durable package pin",
+            )
+        elif pinned_version and discovered != pinned_version:
+            integration_issue(
+                issues, index, "package-pin-differs-from-discovery",
+                "the durable package pin must match the recorded discovered version",
+            )
+
+        consumers = integration.get("consumers")
+        if not isinstance(consumers, list) or not consumers or any(
+            not isinstance(item, dict)
+            or not isinstance(item.get("name"), str) or not item["name"].strip()
+            or not isinstance(item.get("credential_class"), str) or not item["credential_class"].strip()
+            for item in consumers
+        ):
+            integration_issue(
+                issues, index, "consumers-or-credentials-missing",
+                "enumerate every named consumer and its credential class",
+            )
+        for field in ("capabilities", "authentication_mode", "data_scope", "owner"):
+            value = integration.get(field)
+            if value is None or value == "" or value == []:
+                integration_issue(issues, index, f"{field.replace('_', '-')}-missing", f"record {field.replace('_', ' ')}")
+        authority = integration.get("authority")
+        authority = authority if isinstance(authority, dict) else {}
+        if any(not authority.get(field) for field in ("read", "write", "credential_privilege")):
+            integration_issue(
+                issues, index, "authority-declaration-incomplete",
+                "record read authority, write authority, and credential privilege separately",
+            )
+
+        native_cli = integration.get("native_cli")
+        native_cli = native_cli if isinstance(native_cli, dict) else {}
+        if native_cli.get("available") is True and native_cli.get("adequate") is True and integration.get("mcp_install_planned") is True:
+            integration_issue(
+                issues, index, "native-cli-already-adequate",
+                "use the adequate native CLI instead of adding another MCP installation",
+            )
+
+        name = integration.get("name")
+        playwright = (
+            isinstance(name, str) and "playwright" in name.casefold()
+        ) or any(isinstance(value, str) and "playwright" in value.casefold() for value in args)
+        resources = integration.get("resources")
+        resources = resources if isinstance(resources, dict) else {}
+        profile = resources.get("profile")
+        profile = profile if isinstance(profile, dict) else {}
+        browser_cache = resources.get("browser_cache")
+        browser_cache = browser_cache if isinstance(browser_cache, dict) else {}
+        profile_configured = integration_flag(configuration, "--isolated", "PLAYWRIGHT_MCP_ISOLATED")
+        if not profile_configured:
+            profile_configured = any(
+                isinstance(value, str) and (value == "--user-data-dir" or value.startswith("--user-data-dir="))
+                for value in args
+            )
+        cache_path = env.get("PLAYWRIGHT_BROWSERS_PATH")
+        shared_cache_preserved = (
+            browser_cache.get("mode") == "shared"
+            and (
+                env.get("PLAYWRIGHT_SKIP_BROWSER_GC") == "1"
+                or browser_cache.get("preservation") in {"trusted-snapshot", "skip-browser-gc"}
+            )
+        )
+        if playwright and (profile.get("mode") != "isolated" or not profile_configured):
+            integration_issue(
+                issues, index, "playwright-profile-not-isolated",
+                "configure an isolated Playwright profile before launch",
+            )
+        if playwright and not (
+            browser_cache.get("mode") == "isolated" and isinstance(cache_path, str) and bool(cache_path.strip())
+        ) and not shared_cache_preserved:
+            integration_issue(
+                issues, index, "playwright-cache-unprotected",
+                "configure an isolated browser cache or declare shared-cache preservation",
+            )
+
+        no_sandbox = integration_flag(configuration, "--no-sandbox", "PLAYWRIGHT_MCP_NO_SANDBOX")
+        sandbox = integration.get("sandbox_exception")
+        sandbox = sandbox if isinstance(sandbox, dict) else {}
+        if no_sandbox:
+            reason = sandbox.get("runtime_reason")
+            if sandbox.get("enabled") is not True or not isinstance(reason, str) or not reason.strip():
+                integration_issue(
+                    issues, index, "sandbox-exception-unjustified",
+                    "--no-sandbox requires an explicit runtime reason",
+                )
+            compensated = (
+                sandbox.get("compensating_isolation") is True
+                and profile.get("mode") == "isolated"
+                and browser_cache.get("mode") == "isolated"
+            )
+            if not compensated:
+                integration_issue(
+                    issues, index, "sandbox-exception-uncompensated",
+                    "--no-sandbox requires compensating isolated profile and browser cache",
+                )
+
+        if diagnostics.get("emit_full_argv") is not False:
+            integration_issue(
+                issues, index, "full-argv-output-forbidden",
+                "diagnostics must suppress complete process argument vectors",
+            )
+        if diagnostics.get("emit_full_environment") is not False:
+            integration_issue(
+                issues, index, "full-environment-output-forbidden",
+                "diagnostics must suppress complete environment blocks",
+            )
+
+        validation = integration.get("validation")
+        validation = validation if isinstance(validation, dict) else {}
+        if not isinstance(validation.get("client_auto_start_observed"), bool):
+            integration_issue(
+                issues, index, "auto-start-state-unrecorded",
+                "record client auto-start separately from capability listing and invocation",
+            )
+        for field, code, message in (
+            ("configured", "configuration-not-confirmed", "record configured state explicitly"),
+            ("authenticated", "authentication-not-confirmed", "record authenticated state explicitly"),
+            ("read_tested", "read-not-tested", "a real read remains untested"),
+            ("capability_listing_completed", "capabilities-not-listed", "capability listing remains incomplete"),
+            ("harmless_tool_invocation_observed", "harmless-call-not-observed", "observe the declared harmless tool invocation"),
+            ("tool_schema_inspected", "tool-schema-not-inspected", "inspect the tool schema before invocation"),
+        ):
+            if validation.get(field) is not True:
+                integration_issue(issues, index, code, message)
+        harmless_call = validation.get("declared_harmless_call")
+        if not isinstance(harmless_call, str) or not harmless_call.strip():
+            integration_issue(issues, index, "harmless-call-undeclared", "name the harmless validation call before invoking it")
+        bounded_side_effects = validation.get("bounded_side_effects")
+        if not isinstance(bounded_side_effects, list):
+            integration_issue(
+                issues, index, "bounded-side-effects-undeclared",
+                "declare the harmless call's bounded side effects before invocation",
+            )
+        if validation.get("least_privilege_accepted") is not True:
+            integration_issue(
+                issues, index, "least-privilege-unaccepted",
+                "successful access remains incomplete until least privilege or excess privilege is explicitly accepted",
+            )
+        if validation.get("response_status") == 403 and validation.get("scope_widening_recommended") is True:
+            integration_issue(
+                issues, index, "scope-widening-after-403",
+                "a 403 does not justify broader credential scopes; resolve service or plan capability separately",
+            )
+        minimum = validation.get("minimum_response_fields")
+        received = validation.get("received_response_fields")
+        retained = validation.get("retained_response_fields")
+        if not all(isinstance(value, list) and all(isinstance(item, str) for item in value) for value in (minimum, received, retained)):
+            integration_issue(
+                issues, index, "response-field-declaration-incomplete",
+                "record minimum, received, and retained response field names",
+            )
+        else:
+            minimum_set, received_set, retained_set = set(minimum), set(received), set(retained)
+            if not minimum_set <= received_set or not minimum_set <= retained_set:
+                integration_issue(
+                    issues, index, "minimum-response-fields-missing",
+                    "received and retained evidence must contain the declared minimum fields",
+                )
+            if not retained_set <= minimum_set:
+                integration_issue(
+                    issues, index, "response-fields-over-retained",
+                    "suppress response fields beyond the declared minimum from retained evidence",
+                )
+
+        protected = resources.get("protected_artifacts")
+        protected = protected if isinstance(protected, list) else []
+        for artifact in protected:
+            if isinstance(artifact, dict) and artifact.get("before_sha256") != artifact.get("after_sha256"):
+                integration_issue(
+                    issues, index, "protected-artifact-mutated",
+                    "a protected artifact changed during the validation window",
+                )
+                break
+        shared_store = resources.get("shared_store")
+        shared_store = shared_store if isinstance(shared_store, dict) else {}
+        if not isinstance(shared_store.get("observation_window"), str) or not shared_store["observation_window"].strip():
+            integration_issue(
+                issues, index, "shared-store-window-missing",
+                "define the shared-store observation window before validation",
+            )
+        drift = shared_store.get("observed_drift")
+        if isinstance(drift, list) and drift and shared_store.get("causality") == "ambiguous":
+            integration_issue(
+                issues, index, "ambiguous-shared-store-causality",
+                "stop: shared-store drift has ambiguous causality while other writers may be active",
+            )
+
+        operation = integration.get("operation")
+        operation = operation if isinstance(operation, dict) else {}
+        if operation.get("can_reprime") is True and operation.get("write_capable") is not True:
+            integration_issue(
+                issues, index, "write-capable-operation-misclassified",
+                "automatic re-priming makes this operation potentially write-capable",
+            )
+
+        lifecycle = integration.get("lifecycle")
+        lifecycle = lifecycle if isinstance(lifecycle, dict) else {}
+        expected_children = lifecycle.get("expected_children")
+        if not isinstance(expected_children, list) or not expected_children:
+            integration_issue(
+                issues, index, "expected-child-identities-missing",
+                "record expected child-process identities before launch",
+            )
+        launched = {pid for pid in lifecycle.get("launched_pids", []) if isinstance(pid, int)}
+        alive = {pid for pid in lifecycle.get("alive_pids_after_cleanup", []) if isinstance(pid, int)}
+        if integration.get("kind") == "mcp" and configuration.get("command") and not launched:
+            integration_issue(
+                issues, index, "launched-pids-missing",
+                "record exact server and browser PIDs launched by validation",
+            )
+        if launched & alive:
+            integration_issue(
+                issues, index, "launched-process-survived",
+                "cleanup is incomplete because an exact PID launched by validation is still alive",
+            )
+
+    return {
+        "schema_version": 1,
+        "complete": not issues,
+        "integrations_checked": len(integrations),
+        "issues": issues,
+        "limits": limit,
+    }
+
+
+def cmd_validate_integration(args: argparse.Namespace) -> int:
+    path = Path(args.checkpoint).expanduser().resolve()
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise CliError(f"Cannot read integration checkpoint {path}: {exc.strerror or 'read failed'}") from exc
+    except json.JSONDecodeError as exc:
+        raise CliError(
+            f"Integration checkpoint is not valid JSON at line {exc.lineno}, column {exc.colno}"
+        ) from exc
+    report = validate_integration_checkpoint(document)
+    if args.debug:
+        print(
+            f"debug: schema={report['schema_version']} integrations={report['integrations_checked']} "
+            "configuration-values=withheld"
+        )
+    for issue in report["issues"]:
+        print(f"FAIL {issue['integration']} {issue['code']}: {issue['message']}")
+    print(report["limits"])
+    if report["complete"]:
+        ok(f"integration checkpoint complete for {report['integrations_checked']} integration(s)")
+        return 0
+    warn(f"integration checkpoint incomplete ({len(report['issues'])} issue(s))")
+    return 1
+
+
 def toml_value(value: Any) -> str:
     if isinstance(value, str):
         return json.dumps(value, ensure_ascii=False)
@@ -4285,12 +4629,17 @@ def recorded_verify_phase(command: str, root: Path, stdout_path: Path,
 
 def cmd_verify(args: argparse.Namespace) -> int:
     root = Path(args.target or os.getcwd()).resolve()
+    tree_class = getattr(args, "tree_class", None)
     conf = root / ".harness" / "verify.conf"
     if not conf.exists():
         raise CliError(f"No verification config at {conf}")
     phases = [(label, cmd) for label, cmd in parse_verify_conf(conf) if not args.only or args.only in label]
     if args.record and args.list:
         raise CliError("--record cannot be combined with --list")
+    if args.record and not tree_class:
+        raise CliError("--record requires an explicit tree class (--tree-class)")
+    if tree_class and not args.record:
+        raise CliError("--tree-class is meaningful only with --record")
     if args.list:
         for index, (label, command) in enumerate(phases, 1):
             print(f"{index}. {label} :: {command}")
@@ -4304,6 +4653,10 @@ def cmd_verify(args: argparse.Namespace) -> int:
             raise CliError(f"Refusing to overwrite existing verification receipt destination {record_dir}")
         configuration_sha256 = file_sha256(conf)
         git_metadata = verification_git_metadata(root)
+        if tree_class == "clean-clone" and (
+            git_metadata["available"] is not True or git_metadata["dirty"] is not False
+        ):
+            raise CliError("clean-clone evidence requires a clean Git worktree")
         try:
             record_dir.parent.mkdir(parents=True, exist_ok=True)
             record_dir.mkdir()
@@ -4341,6 +4694,7 @@ def cmd_verify(args: argparse.Namespace) -> int:
             "updated_at": started_at,
             "completed_at": None,
             "target": str(root),
+            "tree_class": tree_class,
             "only": safe_only if args.only is not None else None,
             "configuration": {"path": str(conf.resolve()), "sha256": configuration_sha256},
             "git": git_metadata,
@@ -4431,7 +4785,7 @@ def cmd_scaffold(kind: str, args: argparse.Namespace) -> int:
             result = subprocess.run(["git", "-C", str(root), *git_args], capture_output=True, text=True)
             return result.stdout.strip() if result.returncode == 0 and result.stdout.strip() else fallback
         branch = git_value("rev-parse", "--abbrev-ref", "HEAD")
-        head = git_value("rev-parse", "--short", "HEAD")
+        head = git_value("rev-parse", "HEAD")
         status = git_value("status", "--porcelain", fallback="")
         dirty = len(status.splitlines()) if status else 0
         source = textwrap.dedent(f"""\
@@ -4439,6 +4793,20 @@ def cmd_scaffold(kind: str, args: argparse.Namespace) -> int:
 
             **Branch:** {branch}   **HEAD:** {head}   **Uncommitted files:** {dirty}
             {"> ⚠ Tree is dirty — commit or stash BEFORE handing off (core/50 step 1)." if dirty else ""}
+
+            ## Recovery checkpoint
+
+            - **Exact objective:** {item}
+            - **Repository / worktree:** {root}
+            - **Protected-state hashes:**
+            - **Branch / commit:** {branch} / {head}
+            - **External identifiers:**
+            - **Completed verification:**
+            - **Active external operation:**
+            - **Next read-only recovery command:**
+            - **Remaining authorized writes:**
+            - **Stop conditions:**
+            - **Skipped validation:**
 
             ## What shipped this session
 
@@ -4783,6 +5151,17 @@ def parser() -> argparse.ArgumentParser:
     verify.add_argument("--only")
     verify.add_argument("--list", action="store_true")
     verify.add_argument("--record", metavar="DIRECTORY")
+    verify.add_argument(
+        "--tree-class",
+        choices=("clean-clone", "disposable-fixture", "linked-worktree", "operator-worktree"),
+        help="required with --record; declares which tree produced the evidence",
+    )
+    integration = sub.add_parser(
+        "validate-integration",
+        help="validate a structured integration checkpoint without installing or launching it",
+    )
+    integration.add_argument("--checkpoint", required=True)
+    integration.add_argument("--debug", action="store_true", help="print only redacted structural diagnostics")
     for name in ("handoff", "new-feedback", "new-research"):
         scaffold = sub.add_parser(name)
         scaffold.add_argument("name", nargs="?")
@@ -4812,7 +5191,7 @@ def parser() -> argparse.ArgumentParser:
 def normalize_legacy_argv(argv: list[str]) -> list[str]:
     if not argv:
         return ["install", "--wizard"]
-    commands = {"install", "update", "agents", "doctor", "compatibility", "verify", "handoff", "new-feedback", "new-research", "secret-scan", "hook", "evaluate"}
+    commands = {"install", "update", "agents", "doctor", "compatibility", "verify", "validate-integration", "handoff", "new-feedback", "new-research", "secret-scan", "hook", "evaluate"}
     if argv[0] in commands or argv[0] in {"-h", "--help", "--version"}:
         return argv
     if "--doctor" in argv:
@@ -4837,7 +5216,7 @@ def apply_wizard_answers(args: argparse.Namespace, input_fn: Any = input) -> Non
 def run(argv: list[str] | None = None) -> int:
     require_python()
     args = parser().parse_args(normalize_legacy_argv(list(argv if argv is not None else sys.argv[1:])))
-    if args.command != "update":
+    if args.command not in {"update", "validate-integration"}:
         maybe_report_automatic_update()
     if args.command == "install":
         if args.wizard:
@@ -4867,6 +5246,8 @@ def run(argv: list[str] | None = None) -> int:
         return cmd_compatibility(args)
     if args.command == "verify":
         return cmd_verify(args)
+    if args.command == "validate-integration":
+        return cmd_validate_integration(args)
     if args.command in {"handoff", "new-feedback", "new-research"}:
         if args.command != "handoff" and not args.name:
             raise CliError(f"{args.command} requires a topic/symptom")

--- a/config/mcp.example.json
+++ b/config/mcp.example.json
@@ -1,21 +1,31 @@
 {
   "_comment": "MCP servers extend the agent with extra tools (browsers, diagramming, SaaS APIs). These are DYNAMIC context — add only the ones a project actually needs (R10: keep the surface small). Copy the relevant block into your project's .mcp.json (project scope) or ~/.claude/settings.json under mcpServers (global). Pick by profile — see config/plugins.md. None of these are required to run the harness.",
+  "_package_resolution": {
+    "source": "npm registry",
+    "checked_at": "2026-09-04",
+    "exact_versions": {
+      "@playwright/mcp": "0.0.80",
+      "@upstash/context7-mcp": "4.0.5",
+      "mcp-excalidraw-server": "2.0.0"
+    }
+  },
   "mcpServers": {
     "playwright": {
       "_use": "Browser automation — drive a real browser to verify UI changes (software-dev, document render-checks).",
       "command": "npx",
-      "args": ["@playwright/mcp", "--headless"]
+      "args": ["-y", "@playwright/mcp@0.0.80", "--headless", "--isolated"],
+      "env": { "PLAYWRIGHT_BROWSERS_PATH": ".harness/cache/playwright" }
     },
     "excalidraw": {
       "_use": "Clean diagrams (creative-design). Pairs with the excalidraw-diagram skill.",
       "command": "npx",
-      "args": ["-y", "mcp-excalidraw-server"],
+      "args": ["-y", "mcp-excalidraw-server@2.0.0"],
       "env": { "EXPRESS_SERVER_URL": "http://localhost:3000" }
     },
     "context7": {
       "_use": "Fetch current library/framework/API docs on demand (all profiles). Often available as a hosted MCP — prefer that if your client already has it.",
       "command": "npx",
-      "args": ["-y", "@upstash/context7-mcp"]
+      "args": ["-y", "@upstash/context7-mcp@4.0.5"]
     }
   },
   "_other_useful_servers_by_profile": {

--- a/config/settings.json
+++ b/config/settings.json
@@ -25,7 +25,7 @@
   "mcpServers": {
     "excalidraw": {
       "command": "npx",
-      "args": ["-y", "mcp-excalidraw-server"],
+      "args": ["-y", "mcp-excalidraw-server@2.0.0"],
       "env": { "EXPRESS_SERVER_URL": "http://localhost:3000" }
     }
   },

--- a/docs/12-whats-built-in.md
+++ b/docs/12-whats-built-in.md
@@ -44,7 +44,8 @@ emulate hooks or MCP to make matrix cells green.
 
 | Command | Purpose |
 |---|---|
-| `agentsmith verify [--record <directory>]` | Run `.harness/verify.conf` phases with the native OS shell; optionally retain a local redacted command receipt. |
+| `agentsmith verify [--record <directory> --tree-class <class>]` | Run `.harness/verify.conf`; optionally retain a redacted receipt naming the tested tree class. |
+| `agentsmith validate-integration --checkpoint <file>` | Validate a structured integration checkpoint without installing or launching packages. |
 | `agentsmith handoff` | Scaffold durable session memory with branch/HEAD/dirty facts. |
 | `agentsmith new-research` | Create a durable research note that is archived, never silently deleted. |
 | `agentsmith new-feedback` | Create the five-stage post-incident record. |

--- a/docs/15-safety-model.md
+++ b/docs/15-safety-model.md
@@ -79,6 +79,20 @@ connected MCP server, not just the one the harness happens to know about. Readin
 writing is always asked. (The tracker case, and why the default is *propose, don't post*, is in
 [`14-project-tracker-guide.md`](14-project-tracker-guide.md).)
 
+Projects can grant standing authority more narrowly through an explicit operator instruction; the
+tool's presence alone is never the grant. Name the exact system and permitted actions, require
+read-only diagnosis first, and keep the normal stops for missing credentials, surprising external
+state, destructive recovery, production or customer data, and scope expansion. For example:
+
+> Standing authority: after read-only queue and service checks, diagnose and restart dedicated CI
+> runner `project-ci-1` when it is unhealthy or not consuming this repository's jobs. Do not use
+> destructive recovery, touch production or customer data, or extend this grant to another runner.
+> Stop for missing credentials or surprising external state.
+
+Keep such a grant in the project's operator-owned contract or give it explicitly for the session.
+Do not add it to AgentSmith's universal core, and do not edit a generated runtime adapter as its
+source.
+
 ## Unattended work has a hard denylist
 
 When work runs without a human in the path (a loop), the blast radius is bounded by category:

--- a/docs/feedback/0025-mcp-validation-mutated-durable-state.md
+++ b/docs/feedback/0025-mcp-validation-mutated-durable-state.md
@@ -1,0 +1,127 @@
+# Feedback 0025: MCP validation mutated durable state
+
+> A harness post-incident. The point is to make this class of mistake less likely next time.
+> Never delete this record; archive it under `_archive/` if it becomes obsolete.
+
+- **Date:** 2026-09-04
+- **Status:** applied
+- **Cost:** A Claude-to-Codex migration touched an operator browser profile and shared browser/index
+  caches before the validation path was isolated; missing before-state evidence made restoration unsafe.
+
+## 1. Evidence / symptom
+
+The migration supplied these observations:
+
+- A non-isolated Playwright MCP touched an existing persistent profile. There was no trustworthy
+  before-snapshot, so restoration could have destroyed legitimate operator state.
+- Installing Playwright 1.62.1 added a browser revision and garbage-collected an older shared-cache
+  revision because the cache was neither isolated nor protected by `PLAYWRIGHT_SKIP_BROWSER_GC`.
+- An unpinned `npx -y @vendor/package` launcher could resolve a different release later.
+- Root Chromium needed `--no-sandbox`; it ran, but with weaker isolation.
+- The MCP client auto-started configured servers without listing capabilities or invoking tools.
+  Process existence therefore proved neither discovery nor a real call.
+- A returned call did not prove server/browser cleanup. Exact launched process identities were
+  required because broad name matching included unrelated processes.
+- Generic MCP inventory exposed credential-bearing configuration for an unrelated integration.
+  Inventory itself was therefore secret-bearing.
+- OAuth availability in one client did not prove authorization in an isolated client. Granted
+  scopes did not prove least privilege.
+- An identity lookup returned more personal metadata than validation required.
+- A successful GitHub read used an admin-capable credential; successful access and acceptance of
+  excess privilege were distinct facts.
+- A service-plan HTTP 403 did not show that the token needed broader scopes.
+- A native CLI already supplied some required capabilities, making another MCP unnecessary.
+- An independent synchronizer changed a shared Chroma/SQLite store during validation. Causality
+  could not safely be assigned to the request, although retained corpus artifacts stayed byte-identical.
+- A retrieval-named operation could rewrite its corpus during automatic re-priming; read intent did
+  not make it read-only.
+- One integration label hid distinct consumers and credential classes: Pages, Worker/D1, DNS,
+  DNS-01, R2, deployment, and runtime secrets.
+
+The incident supported none of these shortcuts: configured ⇒ authenticated; authenticated ⇒ least
+privilege; started ⇒ tested; returned ⇒ cleaned up; read-named ⇒ read-only; changed store ⇒ request
+caused it; one integration name ⇒ one authority boundary; returned field ⇒ appropriate evidence.
+
+Later closeout supplied four related observations:
+
+- Repeated process/session crashes were recoverable only because Git state, PR/run IDs, plans, and
+  protected-file hashes were durable.
+- A verifier baseline derived from a dirty operator file passed locally but failed in a clean checkout.
+- Truncated search output was treated as complete and caused a false missing-document defect.
+- One AAP runner had narrow standing repair authority, and its watchdog reported local liveness while
+  repository jobs remained queued.
+
+## 2. Failure mechanism
+
+The old migration checklist covered scope, authentication, ownership, harmless validation, and
+external-write consent. It did not make persistent local state, response minimization, privilege
+acceptance, background writers, exact child lifecycle, evidence tree provenance, or durable
+pre-gate recovery first-class fields.
+
+## 3. Bounded edit
+
+Add one conditional integration checkpoint template and one static JSON validator. Pin AgentSmith's
+own executable MCP examples. The validator reads declarations only: it never installs, launches, or
+infers semantic evidence. Extend the existing handoff artifact for pre-wait/gate recovery, record
+verification tree class, and put the search-completeness check in the dynamic feedback skill.
+
+## 4. Named surface
+
+- Integration decision record: `templates/plan.md` → `templates/integration-checkpoint.md`.
+- Static guard and command: `agentsmith.py`; safe shipped examples: `config/mcp.example.json` and
+  `config/settings.json`.
+- Fixture guard: `tests/fixtures/integration-validation/` and
+  `scripts/test-integration-validation.py`.
+- Recovery: `templates/handoff-memory.md`, `skills/handoff/SKILL.md`, `scripts/handoff.sh`, and the
+  native scaffold in `agentsmith.py`; checked by `scripts/test-durable-checkpoints.py`.
+- Clean/local separation: verification receipt `tree_class` in `agentsmith.py`, documented by
+  `skills/verify/SKILL.md`, checked by `scripts/test-verify-receipts.py`.
+- False absence: `skills/new-feedback/SKILL.md`, checked after native dual-adapter regeneration by
+  `scripts/test-durable-checkpoints.py`.
+- Project-specific standing authority: the bounded pattern in `docs/15-safety-model.md`, checked by
+  `scripts/test-durable-checkpoints.py`; explicit operator instructions already outrank defaults.
+
+The AAP runner permission and repair remain project-specific; the pattern does not grant universal
+infrastructure authority. The reusable watchdog lesson already lives in `profiles/devops-setup.md`:
+externally observed function, not local process existence, is the evidence. Adding either to
+universal core would be duplicated always-loaded prose.
+
+### Lesson-to-guard map
+
+| Accepted lesson | Canonical source | Regression evidence |
+|---|---|---|
+| Discovery is separate from an exact executable pin | `templates/integration-checkpoint.md`; `agentsmith.py` | fixture cases `unpinned-package`, `exact-package-pin` |
+| Playwright profile/cache isolation and bounded sandbox exceptions | `templates/integration-checkpoint.md`; `agentsmith.py` | `playwright-profile-missing`, `playwright-cache-missing`, both `no-sandbox-*` cases, `shared-cache-preserved` |
+| Static validation must not mutate profiles/caches, install, launch, or disclose credentials | `agentsmith.py` | `test_cli_never_changes_existing_profile_or_browser_revisions`, `test_validator_does_not_install_or_launch_any_integration`, `test_credentials_never_appear_in_normal_error_or_debug_output` |
+| Auto-start, listing, declared invocation, authentication, reads, and privilege acceptance are separate facts | `templates/integration-checkpoint.md`; `agentsmith.py` | `auto-start-is-not-invocation`, `capability-list-is-not-invocation`, `declared-call-not-observed`, `admin-read-not-accepted` |
+| A plan-tier 403 is not evidence for wider scopes; an adequate native CLI avoids another MCP | `templates/integration-checkpoint.md`; `agentsmith.py` | both `plan-tier-403-*` cases and `adequate-native-cli` |
+| Retained evidence contains only declared minimum response fields | `templates/integration-checkpoint.md`; `agentsmith.py` | both `identity-response-*` cases |
+| Protected artifacts, background writers, drift causality, and automatic re-priming are explicit | `templates/integration-checkpoint.md`; `agentsmith.py` | `shared-store-ambiguous-causality`, `retrieval-can-reprime`, and the profile/cache byte snapshot test |
+| Cleanup follows exact launched PIDs and ignores unrelated processes | `templates/integration-checkpoint.md`; `agentsmith.py` | `launched-pid-survives`, `unrelated-process-survives` |
+| Long gates have a serialized recovery checkpoint | `templates/handoff-memory.md`; `skills/handoff/SKILL.md`; both handoff scaffold implementations | `test_handoff_scaffold_serializes_recovery_checkpoint_fields` |
+| Clean-checkout validity and operator-local preservation are different evidence | `agentsmith.py`; `skills/verify/SKILL.md` | `test_record_requires_explicit_tree_class_and_clean_class_rejects_dirty_git` |
+| Search absence needs complete evidence before creating a defect | `skills/new-feedback/SKILL.md` | `test_search_absence_gate_is_dynamic_and_generated_adapters_remain_outputs` |
+| Standing operational authority stays project-scoped and guarded | `docs/15-safety-model.md` | `test_narrow_project_authority_has_a_bounded_pattern_not_a_universal_grant` |
+| External function, not a local process, proves service health | existing `profiles/devops-setup.md` | `test_existing_devops_gate_checks_external_function_not_process_existence` |
+
+The integration tests are fixture-driven through `tests/fixtures/integration-validation/cases.json`.
+Disposable native assembly checks both Claude and Codex adapters while keeping the conditional
+checkpoint out of always-loaded instructions. Existing conformance/update tests remain the guards
+for foreign-file preservation and byte-exact install/update rollback.
+
+## 5. Non-regression validation
+
+Applied after all required gates passed on 2026-09-04:
+
+- `python3 agentsmith.py verify --target .` passed all 22 canonical phases.
+- Integration validation passed all six test methods and the 21-case fixture matrix without
+  installing or launching an MCP package.
+- Durable-checkpoint and verification-receipt suites passed 4 and 13 tests respectively.
+- Disposable native assembly regenerated equivalent Claude and Codex managed adapters, installed
+  the dynamic checkpoint/skill only at their intended surfaces, and added no project hook.
+- Byte snapshots proved the existing browser profile, both cached browser revisions, and
+  operator-local files unchanged. Agent conformance also preserved foreign project content.
+- The 41-test updater suite proved plan/apply/rollback, including byte-exact restoration and
+  foreign-content preservation from disposable installations.
+- `python3 agentsmith.py secret-scan --all --target .`, the 35-case leak gate, and
+  `git diff --cached --check` passed on the fully staged change.

--- a/scripts/handoff.sh
+++ b/scripts/handoff.sh
@@ -10,7 +10,7 @@ mkdir -p "$DIR"
 STAMP="$(date +%Y%m%d-%H%M 2>/dev/null || echo session)"
 FILE="$DIR/handoff-$STAMP.md"
 BRANCH="$(git -C "$ROOT_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo 'n/a')"
-HEAD="$(git -C "$ROOT_DIR" rev-parse --short HEAD 2>/dev/null || echo 'n/a')"
+HEAD="$(git -C "$ROOT_DIR" rev-parse HEAD 2>/dev/null || echo 'n/a')"
 DIRTY="$(git -C "$ROOT_DIR" status --porcelain 2>/dev/null | wc -l | tr -d ' ')"
 
 cat > "$FILE" <<EOF
@@ -18,6 +18,20 @@ cat > "$FILE" <<EOF
 
 **Branch:** $BRANCH   **HEAD:** $HEAD   **Uncommitted files:** $DIRTY
 $( [ "$DIRTY" != "0" ] && echo '> ⚠ Tree is dirty — commit or stash BEFORE handing off (core/50 step 1).' )
+
+## Recovery checkpoint
+
+- **Exact objective:** $ITEM
+- **Repository / worktree:** $ROOT_DIR
+- **Protected-state hashes:**
+- **Branch / commit:** $BRANCH / $HEAD
+- **External identifiers:**
+- **Completed verification:**
+- **Active external operation:**
+- **Next read-only recovery command:**
+- **Remaining authorized writes:**
+- **Stop conditions:**
+- **Skipped validation:**
 
 ## What shipped this session
 

--- a/scripts/test-durable-checkpoints.py
+++ b/scripts/test-durable-checkpoints.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Regression checks for durable recovery and dynamic investigation guidance."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CORE = ROOT / "agentsmith.py"
+RECOVERY_FIELDS = (
+    "Exact objective",
+    "Repository / worktree",
+    "Protected-state hashes",
+    "Branch / commit",
+    "External identifiers",
+    "Completed verification",
+    "Active external operation",
+    "Next read-only recovery command",
+    "Remaining authorized writes",
+    "Stop conditions",
+    "Skipped validation",
+)
+
+
+class DurableCheckpointTests(unittest.TestCase):
+    def test_handoff_scaffold_serializes_recovery_checkpoint_fields(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="agentsmith durable checkpoint ") as temporary:
+            target = Path(temporary) / "project"
+            target.mkdir()
+            subprocess.run(["git", "-C", str(target), "init", "-q"], check=True)
+            subprocess.run(["git", "-C", str(target), "config", "user.name", "Checkpoint Test"], check=True)
+            subprocess.run(["git", "-C", str(target), "config", "user.email", "test@example.com"], check=True)
+            (target / "tracked.txt").write_text("tracked\n", encoding="utf-8")
+            subprocess.run(["git", "-C", str(target), "add", "."], check=True)
+            subprocess.run(["git", "-C", str(target), "commit", "-qm", "test: fixture"], check=True)
+            result = subprocess.run(
+                [sys.executable, str(CORE), "handoff", "MIGRATION-1", "--target", str(target)],
+                cwd=ROOT, text=True, capture_output=True, check=False,
+            )
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            handoffs = list((target / ".harness" / "handoffs").glob("handoff-*.md"))
+            self.assertEqual(len(handoffs), 1)
+            text = handoffs[0].read_text(encoding="utf-8")
+            self.assertIn(str(target.resolve()), text)
+            for field in RECOVERY_FIELDS:
+                self.assertIn(field, text)
+
+    def test_search_absence_gate_is_dynamic_and_generated_adapters_remain_outputs(self) -> None:
+        skill = (ROOT / "skills" / "new-feedback" / "SKILL.md").read_text(encoding="utf-8")
+        self.assertIn("untruncated", skill)
+        self.assertIn("count-based", skill)
+        self.assertNotIn("search returned no visible match", (ROOT / "core" / "40-subagents-and-tools.md").read_text(encoding="utf-8").casefold())
+
+        with tempfile.TemporaryDirectory(prefix="agentsmith generated checkpoint ") as temporary:
+            target = Path(temporary) / "project"
+            target.mkdir()
+            environment = os.environ.copy()
+            environment.update({
+                "HOME": str(Path(temporary) / "home"),
+                "USERPROFILE": str(Path(temporary) / "home"),
+                "CODEX_HOME": str(Path(temporary) / "codex"),
+            })
+            result = subprocess.run(
+                [
+                    sys.executable, str(CORE), "install", "--agent", "native", "--profile", "software-dev",
+                    "--assemble-only", "--with-skills", "--target", str(target),
+                ],
+                cwd=ROOT, env=environment, text=True, capture_output=True, check=False,
+            )
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertEqual((target / "AGENTS.md").read_bytes(), (target / "CLAUDE.md").read_bytes())
+            self.assertEqual(
+                (target / ".agents" / "skills" / "new-feedback" / "SKILL.md").read_bytes(),
+                (target / ".claude" / "skills" / "new-feedback" / "SKILL.md").read_bytes(),
+            )
+            self.assertTrue((target / ".harness" / "templates" / "integration-checkpoint.md").is_file())
+            instructions = (target / "AGENTS.md").read_text(encoding="utf-8")
+            self.assertNotIn("MCP/integration validation checkpoint", instructions)
+            self.assertFalse((target / ".git" / "hooks").exists())
+
+    def test_narrow_project_authority_has_a_bounded_pattern_not_a_universal_grant(self) -> None:
+        safety = (ROOT / "docs" / "15-safety-model.md").read_text(encoding="utf-8")
+        core = "\n".join(path.read_text(encoding="utf-8") for path in (ROOT / "core").glob("*.md"))
+        for guard in (
+            "exact system and permitted actions",
+            "read-only diagnosis first",
+            "missing credentials",
+            "surprising external state",
+            "destructive recovery",
+            "production or customer data",
+            "scope expansion",
+            "another runner",
+        ):
+            self.assertIn(guard, safety)
+        self.assertIn("explicit operator instruction", safety)
+        self.assertNotIn("project-ci-1", core)
+
+    def test_existing_devops_gate_checks_external_function_not_process_existence(self) -> None:
+        profile = (ROOT / "profiles" / "devops-setup.md").read_text(encoding="utf-8")
+        self.assertIn("reachable from outside the box", profile)
+        self.assertIn('not when `docker ps` shows "running"', profile)
+        self.assertIn("curl the real URL", profile)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/test-integration-validation.py
+++ b/scripts/test-integration-validation.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Fixture-driven regression tests for the integration validation checkpoint."""
+
+from __future__ import annotations
+
+import copy
+import contextlib
+import hashlib
+import importlib.util
+import io
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CORE = ROOT / "agentsmith.py"
+FIXTURES = ROOT / "tests" / "fixtures" / "integration-validation"
+SPEC = importlib.util.spec_from_file_location("agentsmith_integration_validation", CORE)
+assert SPEC and SPEC.loader
+AGENTSMITH = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(AGENTSMITH)
+
+
+def merge(base: object, patch: object) -> object:
+    """Recursively merge fixture patches; one-item integration lists patch by index."""
+    if isinstance(base, dict) and isinstance(patch, dict):
+        result = copy.deepcopy(base)
+        for key, value in patch.items():
+            result[key] = merge(result[key], value) if key in result else copy.deepcopy(value)
+        return result
+    if isinstance(base, list) and isinstance(patch, list) and len(base) == len(patch) == 1:
+        return [merge(base[0], patch[0])]
+    return copy.deepcopy(patch)
+
+
+def snapshot(path: Path) -> dict[str, str]:
+    return {
+        item.relative_to(path).as_posix(): hashlib.sha256(item.read_bytes()).hexdigest()
+        for item in path.rglob("*") if item.is_file()
+    }
+
+
+class IntegrationValidationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.fixture = json.loads((FIXTURES / "cases.json").read_text(encoding="utf-8"))
+
+    def document(self, name: str) -> tuple[dict, dict]:
+        case = next(item for item in self.fixture["cases"] if item["name"] == name)
+        return merge(self.fixture["base"], case.get("patch", {})), case
+
+    def test_fixture_matrix(self) -> None:
+        for case in self.fixture["cases"]:
+            with self.subTest(case=case["name"]):
+                document = merge(self.fixture["base"], case.get("patch", {}))
+                report = AGENTSMITH.validate_integration_checkpoint(document)
+                codes = {issue["code"] for issue in report["issues"]}
+                self.assertTrue(set(case.get("expected_codes", [])) <= codes, (case["name"], codes))
+                self.assertTrue(set(case.get("forbidden_codes", [])).isdisjoint(codes), (case["name"], codes))
+                if not case.get("expected_codes"):
+                    self.assertTrue(report["complete"], (case["name"], codes))
+
+    def test_cli_never_changes_existing_profile_or_browser_revisions(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="agentsmith integration bytes ") as temporary:
+            temporary_path = Path(temporary)
+            protected = temporary_path / "protected"
+            protected.mkdir()
+            for source in (FIXTURES / "existing-profile", FIXTURES / "browser-cache"):
+                destination = protected / source.name
+                import shutil
+                shutil.copytree(source, destination)
+            before = snapshot(protected)
+            document, _ = self.document("shared-cache-preserved")
+            checkpoint = temporary_path / "checkpoint.json"
+            checkpoint.write_text(json.dumps(document), encoding="utf-8")
+            result = subprocess.run(
+                [sys.executable, str(CORE), "validate-integration", "--checkpoint", str(checkpoint)],
+                cwd=ROOT, text=True, capture_output=True, check=False,
+            )
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertEqual(before, snapshot(protected))
+            revisions = [path.name for path in (protected / "browser-cache").iterdir()]
+            self.assertEqual(sorted(revisions), ["chromium-100", "chromium-200"])
+
+    def test_credentials_never_appear_in_normal_error_or_debug_output(self) -> None:
+        document, _ = self.document("unpinned-package")
+        token = "".join(("g", "hp_", "A" * 36))
+        api_key = "".join(("s", "k-", "B" * 32))
+        integration = document["integrations"][0]
+        integration["configuration"]["args"].append(f"--token={token}")
+        integration["configuration"]["env"] = {"API_TOKEN": api_key}
+        with tempfile.TemporaryDirectory(prefix="agentsmith integration secrets ") as temporary:
+            checkpoint = Path(temporary) / "checkpoint.json"
+            checkpoint.write_text(json.dumps(document), encoding="utf-8")
+            for extra in ([], ["--debug"]):
+                result = subprocess.run(
+                    [sys.executable, str(CORE), "validate-integration", "--checkpoint", str(checkpoint), *extra],
+                    cwd=ROOT, text=True, capture_output=True, check=False,
+                )
+                output = result.stdout + result.stderr
+                self.assertNotEqual(result.returncode, 0)
+                self.assertNotIn(token, output)
+                self.assertNotIn(api_key, output)
+                self.assertNotIn("--token=", output)
+                self.assertNotIn("API_TOKEN", output)
+
+            malformed = Path(temporary) / "malformed.json"
+            malformed.write_text('{"env":{"API_TOKEN":"' + api_key + '"}', encoding="utf-8")
+            result = subprocess.run(
+                [sys.executable, str(CORE), "validate-integration", "--checkpoint", str(malformed), "--debug"],
+                cwd=ROOT, text=True, capture_output=True, check=False,
+            )
+            self.assertNotIn(api_key, result.stdout + result.stderr)
+
+    def test_validator_does_not_install_or_launch_any_integration(self) -> None:
+        document, _ = self.document("exact-package-pin")
+        with mock.patch.object(AGENTSMITH.subprocess, "run", side_effect=AssertionError("process launched")):
+            report = AGENTSMITH.validate_integration_checkpoint(document)
+        self.assertTrue(report["complete"])
+
+    def test_cli_validation_skips_automatic_update_state_and_network(self) -> None:
+        document, _ = self.document("exact-package-pin")
+        with tempfile.TemporaryDirectory(prefix="agentsmith integration no update ") as temporary:
+            checkpoint = Path(temporary) / "checkpoint.json"
+            checkpoint.write_text(json.dumps(document), encoding="utf-8")
+            with mock.patch.object(AGENTSMITH, "maybe_report_automatic_update") as update:
+                with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+                    result = AGENTSMITH.run(["validate-integration", "--checkpoint", str(checkpoint)])
+            self.assertEqual(result, 0)
+            update.assert_not_called()
+
+    def test_shipped_mcp_defaults_pass_the_same_static_checks(self) -> None:
+        defaults = json.loads((ROOT / "config" / "mcp.example.json").read_text(encoding="utf-8"))["mcpServers"]
+        for name, configuration in defaults.items():
+            with self.subTest(name=name):
+                document, _ = self.document("exact-package-pin")
+                integration = document["integrations"][0]
+                integration["id"] = name
+                integration["name"] = name
+                integration["configuration"] = {
+                    **copy.deepcopy(configuration),
+                    "diagnostics": {"emit_full_argv": False, "emit_full_environment": False},
+                }
+                integration["package"]["discovered_version"] = AGENTSMITH.executable_package_version(configuration)
+                if name != "playwright":
+                    integration["resources"]["profile"] = {"mode": "not-applicable"}
+                    integration["resources"]["browser_cache"] = {"mode": "not-applicable"}
+                report = AGENTSMITH.validate_integration_checkpoint(document)
+                self.assertTrue(report["complete"], (name, report["issues"]))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/test-verify-receipts.py
+++ b/scripts/test-verify-receipts.py
@@ -110,8 +110,11 @@ else:
         return conf
 
     def run_verify(self, *arguments: str) -> subprocess.CompletedProcess[str]:
+        resolved_arguments = list(arguments)
+        if "--record" in resolved_arguments and "--tree-class" not in resolved_arguments:
+            resolved_arguments.extend(("--tree-class", "operator-worktree"))
         return subprocess.run(
-            [sys.executable, str(CORE), "verify", "--target", str(self.root), *arguments],
+            [sys.executable, str(CORE), "verify", "--target", str(self.root), *resolved_arguments],
             cwd=ROOT,
             env=self.env,
             text=True,
@@ -138,6 +141,10 @@ else:
     def assert_valid_receipt(self, directory: Path, receipt: dict, *, final: bool) -> None:
         self.assertEqual(receipt["schema_version"], 1)
         self.assertEqual(Path(receipt["target"]), self.root.resolve())
+        self.assertIn(
+            receipt["tree_class"],
+            {"clean-clone", "disposable-fixture", "linked-worktree", "operator-worktree"},
+        )
         self.assert_timestamp(receipt["started_at"])
         self.assert_timestamp(receipt["updated_at"])
         if final:
@@ -243,6 +250,8 @@ else:
             str(self.root),
             "--record",
             directory.name,
+            "--tree-class",
+            "operator-worktree",
         ]
         process_options: dict[str, object] = {}
         if os.name == "nt":
@@ -325,6 +334,37 @@ else:
         self.assertTrue(git_metadata["branch"])
         self.assertTrue(git_metadata["dirty"])
 
+    def test_record_requires_explicit_tree_class_and_clean_class_rejects_dirty_git(self) -> None:
+        self.configure(("check", self.phase("emit", "ok")))
+        missing = subprocess.run(
+            [sys.executable, str(CORE), "verify", "--target", str(self.root), "--record", "missing-class"],
+            cwd=ROOT, env=self.env, text=True, capture_output=True, check=False,
+        )
+        self.assertEqual(missing.returncode, 2)
+        self.assertIn("tree class", missing.stderr.lower())
+
+        subprocess.run(["git", "-C", str(self.root), "init", "-q"], check=True)
+        subprocess.run(["git", "-C", str(self.root), "config", "user.name", "Receipt Test"], check=True)
+        subprocess.run(["git", "-C", str(self.root), "config", "user.email", "user@example.com"], check=True)
+        subprocess.run(["git", "-C", str(self.root), "add", "."], check=True)
+        subprocess.run(["git", "-C", str(self.root), "commit", "-qm", "test: clean baseline"], check=True)
+        local = self.root / "operator-local.txt"
+        local.write_text("private operator bytes\n", encoding="utf-8")
+        before = local.read_bytes()
+
+        rejected = self.run_verify("--record", "false-clean", "--tree-class", "clean-clone")
+        self.assertEqual(rejected.returncode, 2)
+        self.assertIn("clean-clone", rejected.stderr)
+        self.assertEqual(before, local.read_bytes())
+        self.assertFalse((self.root / "false-clean").exists())
+
+        accepted = self.run_verify("--record", "operator", "--tree-class", "operator-worktree")
+        self.assertEqual(accepted.returncode, 0, accepted.stdout + accepted.stderr)
+        receipt = self.read_receipt(self.root / "operator")
+        self.assertEqual(receipt["tree_class"], "operator-worktree")
+        self.assertTrue(receipt["git"]["dirty"])
+        self.assertEqual(before, local.read_bytes())
+
     def test_only_records_selected_filter_and_selected_phases(self) -> None:
         marker = self.root / "excluded.txt"
         self.configure(
@@ -366,7 +406,8 @@ else:
         self.configure(("check", self.phase("emit", "must not run")))
         directory = self.root / "error receipt"
         arguments = argparse.Namespace(
-            target=str(self.root), only=None, list=False, record=directory.name
+            target=str(self.root), only=None, list=False, record=directory.name,
+            tree_class="operator-worktree",
         )
 
         def fail_capture(_command: str, _root: Path, stdout_path: Path, stderr_path: Path) -> None:

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: handoff
-description: Wrap up a work session for a clean restart — fires on "handoff", "wrap up", "let's stop here", when context is filling, or when a phase closed. Part of the Agentsmith harness; writes a durable handoff note plus a paste-ready kickoff block so a fresh session loses nothing.
+description: Checkpoint work for recovery — fires on "handoff", "wrap up", context pressure, a closed phase, or before a long external wait or irreversible gate. Part of the Agentsmith harness; writes durable state plus a paste-ready kickoff block so a fresh session loses nothing.
 compatibility: Requires filesystem access and git; the fast path requires the cross-platform Agentsmith CLI.
 ---
 
@@ -10,7 +10,8 @@ A fresh session has **zero** memory of this one; the handoff note is the only br
 whenever work winds down — even if no one asked (core/50).
 
 ## When this fires
-"handoff" / "wrap up" / "let's stop here" / "I'm running low on context" / a phase or task just closed.
+"handoff" / "wrap up" / "let's stop here" / context pressure / a closed phase / before a long
+external wait, merge, release, deployment, or other irreversible external gate.
 
 ## Runtime neutrality
 This workflow is identical in every client. Never infer the active agent from this skill's install
@@ -29,6 +30,9 @@ portable.
 1. **Safe state FIRST** (core/50 step 1): commit or stash so nothing half-edited is lost. Never
    hand off a dirty tree silently.
 2. Write `.harness/handoffs/handoff-<stamp>.md` with these sections:
+   - **Recovery checkpoint** — exact objective; repository/worktree; protected-state hashes;
+     branch/commit and external identifiers; completed/skipped verification; active operation;
+     next read-only recovery command; remaining authorized writes; stop conditions.
    - **What shipped this session** — with commit SHAs / PR links.
    - **What is still pending.**
    - **Deviations / decisions made** (so they're not re-litigated).

--- a/skills/new-feedback/SKILL.md
+++ b/skills/new-feedback/SKILL.md
@@ -14,6 +14,10 @@ You were corrected on something a rule could have prevented; you iterated more t
 have; a human stepped in; you re-derived a decision a past session already made. After fixing the
 immediate thing, capture the lesson.
 
+## Absence gate
+Before filing or implementing a missing-item defect, confirm absence with an exact, count-based, or
+untruncated result. Truncated, paginated, filtered, or summarized search output is incomplete evidence.
+
 ## Fast path — if the Agentsmith CLI is available
 Run `agentsmith new-feedback "short symptom"` — use `.agentsmith/agentsmith` on macOS/Linux or
 `.agentsmith\\agentsmith.cmd` on Windows when the command is not on PATH. It computes the next number and writes

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -22,7 +22,9 @@ adapter such as `.claude/skills`. Use canonical `AGENTS.md` when an instruction 
    macOS/Linux and `.agentsmith\\agentsmith.cmd verify` on Windows). It runs every phase in
    `.harness/verify.conf` and stops at the first
    failure). `--list` shows the phases; `--only <tag>` iterates just one.
-   Add `--record <directory>` when deterministic command evidence needs a durable local receipt.
+   Add `--record <directory> --tree-class <clean-clone|disposable-fixture|linked-worktree|operator-worktree>`
+   when deterministic command evidence needs a durable local receipt. The explicit class keeps a
+   dirty operator tree from masquerading as clean-checkout evidence; `clean-clone` refuses a dirty tree.
    The destination must be new; relative paths resolve from the project target. Record mode
    redacts secret-shaped console and sidecar output before either is emitted.
 2. On a failure: read the label + command it printed, explain in plain language what broke, and

--- a/templates/handoff-memory.md
+++ b/templates/handoff-memory.md
@@ -6,6 +6,21 @@
 **Branch / version:** <branch + HEAD SHA, or saved-version name>
 **State of the tree:** <clean / what's committed vs stashed — never leave it mid-edit>
 
+## Recovery checkpoint
+Complete this before a long external wait or an irreversible external gate; use `n/a` explicitly.
+
+- **Exact objective:**
+- **Repository / worktree:**
+- **Protected-state hashes:**
+- **Branch / commit:**
+- **External identifiers:** <PR, CI run, tag, deployment, release>
+- **Completed verification:**
+- **Active external operation:**
+- **Next read-only recovery command:**
+- **Remaining authorized writes:**
+- **Stop conditions:**
+- **Skipped validation:**
+
 ## What shipped
 -
 

--- a/templates/integration-checkpoint.md
+++ b/templates/integration-checkpoint.md
@@ -1,0 +1,119 @@
+# MCP / integration validation checkpoint
+
+Use this only when adding, restoring, or validating an external integration. Complete the record
+before first launch. Inventory is secret-bearing: parse structured configuration, retain credential
+references rather than values, and suppress complete argument vectors and environment blocks.
+
+## 1. Need and durable configuration
+
+- Required capability and why the existing native CLI is insufficient:
+- Upstream version discovery source/date:
+- Exact executable package pin in durable configuration:
+- Integration owner:
+- Named consumers and credential class for each:
+- Authentication mode and data scope:
+- Read authority, possible writes, and credential privilege:
+
+Stop when an adequate native CLI already supplies the capability. A package discovered as current
+is not durably pinned until the exact version is in configuration.
+
+## 2. Declared validation
+
+- Tool schema inspected:
+- Harmless call named before invocation:
+- Minimum retained response fields:
+- Bounded local/remote side effects:
+- Operation can automatically re-prime or otherwise write:
+
+Use the least revealing call that proves authorization; avoid identity endpoints when a narrower
+call works. A service-plan 403 does not justify broader credential scopes. Record these states
+separately: configured, authenticated, client auto-start observed, capability listing completed,
+declared call observed, read-tested, and least privilege (or excess privilege) accepted.
+
+## 3. Durable-state boundary
+
+- Persistent profiles and caches:
+- Mutable backing stores and existing background writers:
+- Protected artifact hashes before/after:
+- Shared-store observation window, acceptable drift, observed drift, and causality:
+- Expected server/browser child identities and exact launched PIDs:
+
+Prefer an isolated Playwright profile and browser cache. A shared browser cache needs
+`PLAYWRIGHT_SKIP_BROWSER_GC=1` or a trustworthy pre-snapshot. Classify automatic re-priming as
+write-capable. Stop on ambiguous shared-store causality; retain legitimate background workers and
+do not attribute their writes to this validation.
+
+`--no-sandbox` requires a runtime-specific reason plus an isolated profile and browser cache.
+Close the client/server, then prove every exact PID launched here exited; ignore unrelated names.
+
+## 4. Structured record and static gate
+
+Store a JSON record shaped like this, substituting credential references for live values:
+
+```json
+{
+  "schema_version": 1,
+  "integrations": [{
+    "id": "example",
+    "name": "service-name",
+    "kind": "mcp",
+    "capabilities": ["declared-capability"],
+    "authentication_mode": "oauth|token|none",
+    "data_scope": ["bounded dataset"],
+    "owner": "team-or-person",
+    "consumers": [{"name": "named-consumer", "credential_class": "credential-class"}],
+    "authority": {"read": "authorized", "write": "none|authorized|possible", "credential_privilege": "minimal|admin|other"},
+    "package": {"discovered_version": "1.2.3"},
+    "configuration": {
+      "command": "npx",
+      "args": ["-y", "@vendor/server@1.2.3"],
+      "env": {},
+      "diagnostics": {"emit_full_argv": false, "emit_full_environment": false}
+    },
+    "native_cli": {"available": false, "adequate": false},
+    "mcp_install_planned": true,
+    "validation": {
+      "configured": true,
+      "authenticated": true,
+      "read_tested": true,
+      "least_privilege_accepted": true,
+      "client_auto_start_observed": false,
+      "capability_listing_completed": true,
+      "declared_harmless_call": "tool_name",
+      "bounded_side_effects": [],
+      "harmless_tool_invocation_observed": true,
+      "tool_schema_inspected": true,
+      "minimum_response_fields": ["id"],
+      "received_response_fields": ["id"],
+      "retained_response_fields": ["id"],
+      "response_status": 200,
+      "scope_widening_recommended": false
+    },
+    "resources": {
+      "profile": {"mode": "isolated|not-applicable"},
+      "browser_cache": {"mode": "isolated|shared|not-applicable", "preservation": "skip-browser-gc|trusted-snapshot"},
+      "protected_artifacts": [{"path": "path", "before_sha256": "sha256", "after_sha256": "sha256"}],
+      "shared_store": {
+        "observation_window": "start/end",
+        "background_writers": [],
+        "acceptable_drift": [],
+        "observed_drift": [],
+        "causality": "none|validation|independent|ambiguous"
+      }
+    },
+    "operation": {"name": "read", "can_reprime": false, "write_capable": false},
+    "sandbox_exception": {"enabled": false, "runtime_reason": "", "compensating_isolation": false},
+    "lifecycle": {"expected_children": ["server"], "launched_pids": [], "alive_pids_after_cleanup": [], "unrelated_pids": []}
+  }]
+}
+```
+
+Run:
+
+```text
+agentsmith validate-integration --checkpoint <record.json>
+```
+
+This command only reads JSON and checks explicit fields. It never installs or launches packages,
+and it never infers authority, harmlessness, real invocation, response minimization, least
+privilege, causal attribution, or cleanup. Those observations must be supplied as evidence.

--- a/templates/plan.md
+++ b/templates/plan.md
@@ -27,5 +27,8 @@ files/assets/areas to change. Reuse what already exists — reference it by path
 How we'll prove this works end-to-end (the verify command/phases, the real run, the
 click-through, the reconciliation) — see the active profile's quality gates.
 
+External integration or MCP work → complete `.harness/templates/integration-checkpoint.md`
+before the first launch; its static validator never installs or starts the integration.
+
 ## Done means
 The concrete, checkable definition of done for this unit of work.

--- a/tests/fixtures/integration-validation/browser-cache/chromium-100/INSTALLATION_COMPLETE
+++ b/tests/fixtures/integration-validation/browser-cache/chromium-100/INSTALLATION_COMPLETE
@@ -1,0 +1,1 @@
+revision 100

--- a/tests/fixtures/integration-validation/browser-cache/chromium-200/INSTALLATION_COMPLETE
+++ b/tests/fixtures/integration-validation/browser-cache/chromium-200/INSTALLATION_COMPLETE
@@ -1,0 +1,1 @@
+revision 200

--- a/tests/fixtures/integration-validation/cases.json
+++ b/tests/fixtures/integration-validation/cases.json
@@ -1,0 +1,186 @@
+{
+  "schema_version": 1,
+  "base": {
+    "schema_version": 1,
+    "integrations": [
+      {
+        "id": "browser-check",
+        "name": "playwright",
+        "kind": "mcp",
+        "capabilities": ["tools/list", "browser_snapshot"],
+        "authentication_mode": "none",
+        "data_scope": ["local disposable fixture"],
+        "owner": "test-team",
+        "consumers": [
+          {"name": "ui-verification", "credential_class": "none"}
+        ],
+        "authority": {
+          "read": "authorized",
+          "write": "none",
+          "credential_privilege": "minimal"
+        },
+        "package": {"discovered_version": "0.0.80"},
+        "configuration": {
+          "command": "npx",
+          "args": ["-y", "@playwright/mcp@0.0.80", "--headless", "--isolated"],
+          "env": {"PLAYWRIGHT_BROWSERS_PATH": ".harness/cache/playwright"},
+          "diagnostics": {"emit_full_argv": false, "emit_full_environment": false}
+        },
+        "native_cli": {"available": false, "adequate": false},
+        "mcp_install_planned": true,
+        "validation": {
+          "configured": true,
+          "authenticated": true,
+          "read_tested": true,
+          "least_privilege_accepted": true,
+          "client_auto_start_observed": true,
+          "capability_listing_completed": true,
+          "declared_harmless_call": "browser_snapshot",
+          "bounded_side_effects": ["temporary in-memory browser context"],
+          "harmless_tool_invocation_observed": true,
+          "tool_schema_inspected": true,
+          "minimum_response_fields": ["title", "url"],
+          "received_response_fields": ["title", "url"],
+          "retained_response_fields": ["title", "url"],
+          "response_status": 200,
+          "scope_widening_recommended": false
+        },
+        "resources": {
+          "profile": {"mode": "isolated"},
+          "browser_cache": {"mode": "isolated"},
+          "protected_artifacts": [
+            {
+              "path": "existing-profile/sentinel.bin",
+              "before_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              "after_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            }
+          ],
+          "shared_store": {
+            "observation_window": "2026-09-04T12:00:00Z/2026-09-04T12:01:00Z",
+            "background_writers": [],
+            "acceptable_drift": [],
+            "observed_drift": [],
+            "causality": "none"
+          }
+        },
+        "operation": {"name": "snapshot", "can_reprime": false, "write_capable": false},
+        "sandbox_exception": {"enabled": false, "runtime_reason": "", "compensating_isolation": false},
+        "lifecycle": {
+          "expected_children": ["npx", "node", "chromium"],
+          "launched_pids": [101, 102],
+          "alive_pids_after_cleanup": [],
+          "unrelated_pids": [999]
+        }
+      }
+    ]
+  },
+  "cases": [
+    {
+      "name": "unpinned-package",
+      "patch": {"integrations": [{"configuration": {"args": ["-y", "@vendor/server"]}, "package": {"discovered_version": "1.2.3"}}]},
+      "expected_codes": ["executable-package-unpinned"]
+    },
+    {
+      "name": "exact-package-pin",
+      "patch": {"integrations": [{"name": "vendor", "configuration": {"args": ["-y", "@vendor/server@1.2.3"]}, "package": {"discovered_version": "1.2.3"}}]},
+      "expected_codes": []
+    },
+    {
+      "name": "playwright-profile-missing",
+      "patch": {"integrations": [{"configuration": {"args": ["-y", "@playwright/mcp@0.0.80", "--headless"]}, "resources": {"profile": {"mode": "shared"}}}]},
+      "expected_codes": ["playwright-profile-not-isolated"]
+    },
+    {
+      "name": "playwright-cache-missing",
+      "patch": {"integrations": [{"configuration": {"env": null}, "resources": {"browser_cache": {"mode": "shared"}}}]},
+      "expected_codes": ["playwright-cache-unprotected"]
+    },
+    {
+      "name": "no-sandbox-unjustified",
+      "patch": {"integrations": [{"configuration": {"args": ["-y", "@playwright/mcp@0.0.80", "--headless", "--isolated", "--no-sandbox"]}, "sandbox_exception": {"enabled": true, "runtime_reason": "", "compensating_isolation": true}}]},
+      "expected_codes": ["sandbox-exception-unjustified"]
+    },
+    {
+      "name": "no-sandbox-without-compensation",
+      "patch": {"integrations": [{"configuration": {"args": ["-y", "@playwright/mcp@0.0.80", "--headless", "--no-sandbox"]}, "resources": {"profile": {"mode": "shared"}}, "sandbox_exception": {"enabled": true, "runtime_reason": "root runtime requires Chromium sandbox exception", "compensating_isolation": false}}]},
+      "expected_codes": ["playwright-profile-not-isolated", "sandbox-exception-uncompensated"]
+    },
+    {
+      "name": "shared-cache-preserved",
+      "patch": {"integrations": [{"configuration": {"env": {"PLAYWRIGHT_SKIP_BROWSER_GC": "1"}}, "resources": {"browser_cache": {"mode": "shared", "preservation": "skip-browser-gc"}}}]},
+      "expected_codes": []
+    },
+    {
+      "name": "auto-start-is-not-invocation",
+      "patch": {"integrations": [{"validation": {"client_auto_start_observed": true, "capability_listing_completed": false, "harmless_tool_invocation_observed": false}}]},
+      "expected_codes": ["capabilities-not-listed", "harmless-call-not-observed"]
+    },
+    {
+      "name": "capability-list-is-not-invocation",
+      "patch": {"integrations": [{"validation": {"client_auto_start_observed": true, "capability_listing_completed": true, "harmless_tool_invocation_observed": false}}]},
+      "expected_codes": ["harmless-call-not-observed"]
+    },
+    {
+      "name": "declared-call-not-observed",
+      "patch": {"integrations": [{"validation": {"harmless_tool_invocation_observed": false}}]},
+      "expected_codes": ["harmless-call-not-observed"]
+    },
+    {
+      "name": "admin-read-not-accepted",
+      "patch": {"integrations": [{"authority": {"credential_privilege": "admin"}, "validation": {"least_privilege_accepted": false}}]},
+      "expected_codes": ["least-privilege-unaccepted"]
+    },
+    {
+      "name": "plan-tier-403-no-scope-widening",
+      "patch": {"integrations": [{"validation": {"read_tested": false, "response_status": 403, "scope_widening_recommended": false}}]},
+      "expected_codes": ["read-not-tested"],
+      "forbidden_codes": ["scope-widening-after-403"]
+    },
+    {
+      "name": "plan-tier-403-with-scope-widening",
+      "patch": {"integrations": [{"validation": {"read_tested": false, "response_status": 403, "scope_widening_recommended": true}}]},
+      "expected_codes": ["read-not-tested", "scope-widening-after-403"]
+    },
+    {
+      "name": "adequate-native-cli",
+      "patch": {"integrations": [{"native_cli": {"available": true, "adequate": true}, "mcp_install_planned": true}]},
+      "expected_codes": ["native-cli-already-adequate"]
+    },
+    {
+      "name": "identity-response-minimized",
+      "patch": {"integrations": [{"validation": {"minimum_response_fields": ["login"], "received_response_fields": ["login", "email", "name", "avatar_url"], "retained_response_fields": ["login"]}}]},
+      "expected_codes": []
+    },
+    {
+      "name": "identity-response-over-retained",
+      "patch": {"integrations": [{"validation": {"minimum_response_fields": ["login"], "received_response_fields": ["login", "email"], "retained_response_fields": ["login", "email"]}}]},
+      "expected_codes": ["response-fields-over-retained"]
+    },
+    {
+      "name": "shared-store-ambiguous-causality",
+      "patch": {"integrations": [{"resources": {"shared_store": {"background_writers": ["sync-worker"], "acceptable_drift": [], "observed_drift": ["index.sqlite"], "causality": "ambiguous"}}}]},
+      "expected_codes": ["ambiguous-shared-store-causality"],
+      "forbidden_codes": ["protected-artifact-mutated"]
+    },
+    {
+      "name": "retrieval-can-reprime",
+      "patch": {"integrations": [{"operation": {"name": "retrieve", "can_reprime": true, "write_capable": false}}]},
+      "expected_codes": ["write-capable-operation-misclassified"]
+    },
+    {
+      "name": "launched-pid-survives",
+      "patch": {"integrations": [{"lifecycle": {"alive_pids_after_cleanup": [102, 999]}}]},
+      "expected_codes": ["launched-process-survived"]
+    },
+    {
+      "name": "unrelated-process-survives",
+      "patch": {"integrations": [{"lifecycle": {"alive_pids_after_cleanup": [999]}}]},
+      "expected_codes": []
+    },
+    {
+      "name": "unsafe-diagnostics",
+      "patch": {"integrations": [{"configuration": {"diagnostics": {"emit_full_argv": true, "emit_full_environment": true}}}]},
+      "expected_codes": ["full-argv-output-forbidden", "full-environment-output-forbidden"]
+    }
+  ]
+}

--- a/tests/fixtures/integration-validation/existing-profile/sentinel.txt
+++ b/tests/fixtures/integration-validation/existing-profile/sentinel.txt
@@ -1,0 +1,1 @@
+operator profile bytes must remain unchanged


### PR DESCRIPTION
## Why

A nominally harmless MCP validation mutated an operator browser profile and shared caches. Static configuration also encouraged false conclusions about authentication, invocation, least privilege, response minimization, causal attribution, and child-process cleanup.

## What changed

- add one conditional integration checkpoint and a read-only structured validator
- pin shipped executable MCP examples and isolate Playwright profile/cache state
- add fixture-driven coverage for the 20 migration failure modes
- distinguish verification tree provenance and reject dirty `clean-clone` receipts
- extend the existing handoff artifact for pre-gate crash recovery
- keep search-completeness guidance dynamic and project-specific authority bounded

The validator never installs or launches MCP packages. Generated runtime adapters remain outputs, and no project hooks were added.

## Verification

- `python3 agentsmith.py verify --target .` — all 22 phases passed
- `python3 agentsmith.py secret-scan --all --target .` — clean
- `bash scripts/test-leak-gate.sh` — 35 passed
- `git diff --cached --check` — clean before commit
- disposable native generation produced equivalent Claude/Codex adapters
- updater suite: 41 passed, including byte-exact rollback and foreign-content preservation

Feedback: `docs/feedback/0025-mcp-validation-mutated-durable-state.md`
