### PR TITLE
chore(release): publish integration safeguards as 0.3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ docs/feedback/[0-9]*.md
 !docs/feedback/0023-update-inventoried-foreign-skill-trees.md
 !docs/feedback/0024-claude-skill-adapter-drift-treated-as-customization.md
 !docs/feedback/0025-mcp-validation-mutated-durable-state.md
+!docs/feedback/0026-windows-atomic-state-read-sharing-denial.md

--- a/agentsmith.py
+++ b/agentsmith.py
@@ -34,7 +34,7 @@ import urllib.error
 import urllib.request
 
 
-VERSION = "0.3.0"
+VERSION = "0.3.1"
 OFFICIAL_REMOTE = "https://github.com/PromptPartner/agentsmith.git"
 ROOT = Path(__file__).resolve().parent
 REGISTRY_PATH = ROOT / "config" / "agents.json"

--- a/docs/23-updating-existing-installations.md
+++ b/docs/23-updating-existing-installations.md
@@ -6,7 +6,11 @@ the existing installation, and keep planning separate from applying.
 
 ## Current release and legacy blockers
 
-The current stable release is `v0.3.0`.
+The current stable release is `v0.3.1`.
+
+`v0.3.1` adds a conditional MCP/integration validation checkpoint, a static non-launching
+configuration validator, explicit verification-tree provenance, and durable pre-gate recovery
+fields. Its integration validator does not install or launch MCP packages.
 
 `v0.3.0` adds opt-in durable verification receipts and cooperative collision protection for local
 autonomous runs. Both features are additive; existing verification commands and autonomous-run
@@ -39,7 +43,7 @@ installation fingerprints. This ownership defect is fixed in `v0.2.4` and record
 `.agents/skills` source changes. Claude discovers the stale adapter, while strict Doctor can report
 it as healthy. This ownership defect is fixed in `v0.2.5` and recorded in
 [`feedback/0024-claude-skill-adapter-drift-treated-as-customization.md`](feedback/0024-claude-skill-adapter-drift-treated-as-customization.md).
-Use `v0.3.0` for the complete legacy global update chain: foreign skill contents are preserved and
+Use `v0.3.1` for the complete legacy global update chain: foreign skill contents are preserved and
 ignored, canonical customizations are retained and mirrored to Claude, and symlinks escaping an
 owned inventory root remain rejected.
 
@@ -67,7 +71,7 @@ installation that does not have one yet.
 ```bash
 AGENTSMITH_BOOTSTRAP_DIR="$(mktemp -d)"
 
-git clone --depth 1 --branch v0.3.0 \
+git clone --depth 1 --branch v0.3.1 \
   https://github.com/PromptPartner/agentsmith.git \
   "$AGENTSMITH_BOOTSTRAP_DIR"
 
@@ -75,7 +79,7 @@ git -C "$AGENTSMITH_BOOTSTRAP_DIR" rev-parse HEAD
 git -C "$AGENTSMITH_BOOTSTRAP_DIR" describe --tags --exact-match
 ```
 
-The final command must print `v0.3.0`. This proves the bootstrap is the immutable release tag rather
+The final command must print `v0.3.1`. This proves the bootstrap is the immutable release tag rather
 than an unreviewed branch checkout.
 
 ## Update one project installation
@@ -85,13 +89,13 @@ but does not modify the target.
 
 ```bash
 AGENTSMITH_TARGET="/absolute/path/to/project"
-AGENTSMITH_PLAN="/tmp/agentsmith-project-name-v0.3.0-plan.json"
+AGENTSMITH_PLAN="/tmp/agentsmith-project-name-v0.3.1-plan.json"
 
 git -C "$AGENTSMITH_TARGET" status --short
 
 python3 "$AGENTSMITH_BOOTSTRAP_DIR/agentsmith.py" update plan \
   --target "$AGENTSMITH_TARGET" \
-  --version v0.3.0 \
+  --version v0.3.1 \
   --save "$AGENTSMITH_PLAN"
 
 python3 -m json.tool "$AGENTSMITH_PLAN" | less
@@ -125,19 +129,19 @@ python3 "$AGENTSMITH_TARGET/.agentsmith/agentsmith.py" doctor \
 Global scope is separate from every project scope. Create and inspect its own plan:
 
 ```bash
-AGENTSMITH_PLAN="/tmp/agentsmith-global-v0.3.0-plan.json"
+AGENTSMITH_PLAN="/tmp/agentsmith-global-v0.3.1-plan.json"
 
 python3 "$AGENTSMITH_BOOTSTRAP_DIR/agentsmith.py" update plan \
   --global \
-  --version v0.3.0 \
+  --version v0.3.1 \
   --save "$AGENTSMITH_PLAN"
 
 python3 -m json.tool "$AGENTSMITH_PLAN" | less
 ```
 
 Global MCP is foreign by construction because AgentSmith supports MCP ownership only at project
-scope. `v0.3.0` therefore does not parse global MCP while reconstructing or validating capability
-ownership. For valid user-scope client configuration, it preserves foreign MCP entries. A malformed
+scope. Current releases therefore do not parse global MCP while reconstructing or validating
+capability ownership. For valid user-scope client configuration, it preserves foreign MCP entries. A malformed
 client config can still block reconciliation of other AgentSmith-managed native settings, so repair
 invalid JSON or TOML before a non-assemble-only update. For a reconstructed legacy installation,
 confirm the plan records `capabilities.mcp` as an empty list, proposes no MCP-file changes, and

--- a/docs/23-updating-existing-installations.md
+++ b/docs/23-updating-existing-installations.md
@@ -10,7 +10,8 @@ The current stable release is `v0.3.1`.
 
 `v0.3.1` adds a conditional MCP/integration validation checkpoint, a static non-launching
 configuration validator, explicit verification-tree provenance, and durable pre-gate recovery
-fields. Its integration validator does not install or launch MCP packages.
+fields. Its integration validator does not install or launch MCP packages. It also retries bounded
+Windows sharing denials when reading atomically replaced autonomous-run state.
 
 `v0.3.0` adds opt-in durable verification receipts and cooperative collision protection for local
 autonomous runs. Both features are additive; existing verification commands and autonomous-run

--- a/docs/feedback/0025-mcp-validation-mutated-durable-state.md
+++ b/docs/feedback/0025-mcp-validation-mutated-durable-state.md
@@ -5,6 +5,7 @@
 
 - **Date:** 2026-09-04
 - **Status:** applied
+- **Fixed release:** `v0.3.1`
 - **Cost:** A Claude-to-Codex migration touched an operator browser profile and shared browser/index
   caches before the validation path was isolated; missing before-state evidence made restoration unsafe.
 

--- a/docs/feedback/0026-windows-atomic-state-read-sharing-denial.md
+++ b/docs/feedback/0026-windows-atomic-state-read-sharing-denial.md
@@ -1,0 +1,38 @@
+# Feedback 0026: Windows atomic state read hit a sharing denial
+
+> A harness post-incident. The point is to make this class of mistake less likely next time.
+> Never delete this record; archive it under `_archive/` if it becomes obsolete.
+
+- **Date:** 2026-09-04
+- **Status:** applied
+- **Fixed release:** `v0.3.1`
+- **Cost:** One Windows release-gate run failed after an observer could not open autonomous state
+  during concurrent atomic replacements; an identical run passed, making the guard flaky.
+
+## 1. Evidence / symptom
+
+GitHub Actions run `33877605556`, job `101038218183`, failed
+`test_concurrent_atomic_writers_never_expose_invalid_json` with
+`PermissionError(13, 'Permission denied')`. The observer failed while reading the destination; it
+did not observe malformed JSON. The identical push-triggered Windows job passed.
+
+## 2. Failure mechanism
+
+Atomic replacement already retried transient Windows sharing errors, but `load_json()` performed a
+single read. Windows can briefly deny the reader access while another process replaces the file,
+so valid atomic state could be reported as unreadable.
+
+## 3. Bounded edit
+
+Retry only Windows sharing violations 5 and 32 for at most one second when reading JSON. Preserve
+immediate failure for every other operating-system error and for invalid JSON.
+
+## 4. Named surface
+
+`scripts/autonomous-run.py` JSON read boundary and `scripts/test-autonomous-state.py`.
+
+## 5. Non-regression validation
+
+The focused suite first failed because the synthetic sharing denial became `RunError`. It then
+passed 15 tests after the bounded retry. The concurrent observer now exercises the production
+reader, and the release remains gated by Windows CI plus the complete canonical verifier.

--- a/scripts/autonomous-run.py
+++ b/scripts/autonomous-run.py
@@ -95,12 +95,25 @@ def repo_root(path: Path) -> Path:
 
 def load_json(path: Path) -> dict[str, Any]:
     try:
-        value = json.loads(path.read_text())
+        value = json.loads(read_text(path))
     except (OSError, json.JSONDecodeError) as exc:
         raise RunError(f"cannot read JSON {path}: {exc}") from exc
     if not isinstance(value, dict):
         raise RunError(f"{path} must contain a JSON object")
     return value
+
+
+def read_text(path: Path) -> str:
+    """Read a file while tolerating bounded Windows sharing races."""
+    for attempt in range(100):
+        try:
+            return path.read_text(encoding="utf-8")
+        except PermissionError as exc:
+            transient_windows_error = os.name == "nt" and getattr(exc, "winerror", None) in {5, 32}
+            if not transient_windows_error or attempt == 99:
+                raise
+            time.sleep(0.01)
+    raise AssertionError("unreachable")
 
 
 def write_json(path: Path, value: dict[str, Any]) -> None:

--- a/scripts/test-autonomous-state.py
+++ b/scripts/test-autonomous-state.py
@@ -123,6 +123,19 @@ class AutonomousStateTests(unittest.TestCase):
         self.assertEqual(replace.call_count, 2)
         pause.assert_called_once_with(0.01)
 
+    def test_json_read_retries_a_transient_windows_sharing_denial(self) -> None:
+        path = Path("state.json")
+        denial = PermissionError("destination is momentarily shared")
+        denial.winerror = 32
+        with (
+            mock.patch.object(CONTROLLER.os, "name", "nt"),
+            mock.patch.object(Path, "read_text", side_effect=[denial, '{"ready": true}']) as read,
+            mock.patch.object(CONTROLLER.time, "sleep") as pause,
+        ):
+            self.assertEqual(CONTROLLER.load_json(path), {"ready": True})
+        self.assertEqual(read.call_count, 2)
+        pause.assert_called_once_with(0.01)
+
     def test_process_liveness_recognizes_current_and_missing_processes(self) -> None:
         self.assertTrue(CONTROLLER.process_is_live(os.getpid()))
         stale_pid = next(
@@ -141,7 +154,7 @@ class AutonomousStateTests(unittest.TestCase):
             def observe() -> None:
                 while not finished.is_set():
                     try:
-                        value = json.loads(path.read_text(encoding="utf-8"))
+                        value = CONTROLLER.load_json(path)
                         if not isinstance(value.get("writer"), int):
                             raise AssertionError("state record lost its writer field")
                     except BaseException as exc:  # captured and asserted on the main test thread


### PR DESCRIPTION
## Release

Publishes AgentSmith 0.3.1 from merged integration commit 82ce797.

- declares runtime version 0.3.1
- updates the stable-update runbook to immutable tag v0.3.1
- records v0.3.1 as the fixed release for feedback 0025
- fixes a Windows atomic-state read sharing race exposed by release CI and records feedback 0026

## Verification

- `python3 agentsmith.py verify --target .` — all 22 phases passed after the Windows fix
- focused state suite — red before the bounded read retry, 15 passed after
- tracked-tree and staged-diff secret scans — clean
- `git diff --cached --check` — clean
- `python3 agentsmith.py --version` — `agentsmith 0.3.1`

After merge, tag the immutable merge commit and publish matching GitHub release notes. No generated adapter or hook source changes are included.
